### PR TITLE
Align CC last-4 default expectations across test and docs

### DIFF
--- a/docs/middleware-extensibility-pattern-pii-poc.md
+++ b/docs/middleware-extensibility-pattern-pii-poc.md
@@ -321,7 +321,7 @@ middleware:
           enabled: true
           confidence_threshold: 0.80
           context_terms: ['cc', 'card', 'credit card', 'debit', 'visa', 'mastercard', 'master card', 'amex', 'american express', 'discover', 'last 4', 'ending in']
-          negative_context_terms: ['ssn', 'social security', 'expires', 'expiration', 'expiry', 'exp']
+          negative_context_terms: ['ssn', 'social security']
 
         dob:
           enabled: true

--- a/tests/test_custom_recognizer_registration.py
+++ b/tests/test_custom_recognizer_registration.py
@@ -8,6 +8,9 @@ pytest.importorskip("presidio_analyzer")
 
 from presidio_analyzer import AnalyzerEngine, RecognizerResult
 
+from ai_api_unified.middleware.middleware_config import (
+    LIST_STR_DEFAULT_CC_LAST4_NEGATIVE_CONTEXT_TERMS,
+)
 from ai_api_unified.middleware.impl._presidio_redactor import (
     PROFILE_SMALL,
     PiiRedactor,
@@ -972,8 +975,8 @@ def test_pii_redactor_applies_default_recognizer_settings_for_missing_block() ->
         redactor.dict_redaction_recognizers_settings[RECOGNIZER_RULE_KEY_DOB]
     )
     assert "cc" in dict_cc_rule_settings["context_terms"]
-    assert dict_cc_rule_settings["negative_context_terms"] == list(
-        TUPLE_STR_CC_NEGATIVE_CONTEXT_TERMS
+    assert dict_cc_rule_settings["negative_context_terms"] == (
+        LIST_STR_DEFAULT_CC_LAST4_NEGATIVE_CONTEXT_TERMS
     )
     assert "dob" in dict_dob_rule_settings["context_terms"]
     assert dict_dob_rule_settings["negative_context_terms"] == list(


### PR DESCRIPTION
Closes #7

## Summary
- align the direct `PiiRedactor(...)` default-settings test with the shared middleware-config default source
- update the middleware extensibility doc example so `cc_last4.negative_context_terms` matches the shipped defaults
- confirm the mocked-only pytest selection passes after installing the optional extras

## Testing
- `poetry run pytest -m "not nonmock" -q`

<!-- pr-review-prep:start -->
## Review Prep Summary

Composition percentages are based on added and deleted textual lines relative to `main`.

| Change Type | Lines Changed | Percentage |
|---|---:|---:|
| Core logic changes | 0 | 0% |
| Documentation | 2 | 22% |
| Tests | 7 | 78% |
| Other | 0 | 0% |
| Total | 9 | 100% |
<!-- pr-review-prep:end -->

<!-- pr-content-attribution:start -->
## Content Attribution Summary

Based on changed lines across counted PR commits in this PR.

| Attribution Type | Commits | Lines Changed | Percentage |
|---|---:|---:|---:|
| AI-attributed | 1 | 9 | 100% |
| Human-attributed | 0 | 0 | 0% |
| Bot-attributed | 0 | 0 | 0% |
| Total | 1 | 9 | 100% |

Attribution percentages are based on changed lines across counted PR commits.
<!-- pr-content-attribution:end -->
