### PR TITLE
Fix PyPI-safe PII packaging for spaCy model extras

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,9 +105,9 @@ poetry install --all-extras --with dev
 | `video_frames`                   | Optional frame extraction helpers backed by ImageIO + Pillow           |
 | `azure_tts`                      | Azure Cognitive Services TTS                                           |
 | `elevenlabs`                     | ElevenLabs TTS and STT                                                 |
-| `middleware-pii-redaction`       | Presidio + `usaddress` without packaged spaCy model wheels             |
-| `middleware-pii-redaction-small` | Presidio + `usaddress` + packaged `en_core_web_sm`                     |
-| `middleware-pii-redaction-large` | Presidio + `usaddress` + packaged `en_core_web_lg`                     |
+| `middleware-pii-redaction`       | Presidio + spaCy + `usaddress`; install the required spaCy model separately |
+| `middleware-pii-redaction-small` | Compatibility alias for PII redaction deps; pair with separate `en_core_web_sm` install |
+| `middleware-pii-redaction-large` | Compatibility alias for PII redaction deps; pair with separate `en_core_web_lg` install |
 | `similarity_score`               | NumPy-based similarity helpers                                         |
 | `dev`                            | Optional dev dependencies from `[project.optional-dependencies]`       |
 
@@ -489,6 +489,9 @@ Notes:
 
 - `strict_mode: true` enables fail-closed behavior
 - `balanced`, `high_accuracy`, and `low_memory` detection profiles are supported
+- install a matching spaCy model separately, for example `poetry run python -m spacy download en_core_web_sm` for `balanced` or `poetry run python -m spacy download en_core_web_lg` for `high_accuracy`
+- `middleware-pii-redaction-small` and `middleware-pii-redaction-large` are compatibility aliases for the same Python dependency set; the spaCy model is still installed as a separate build/runtime asset
+- for no-egress images and Lambda-style deployments, install the spaCy model wheel into the build artifact instead of relying on runtime downloads
 - recognizer customization is configured in YAML, not hard-coded in provider implementations
 
 See [`docs/pii_redaction_design.md`](docs/pii_redaction_design.md) for the fuller contract and deployment tradeoffs.
@@ -590,7 +593,9 @@ The script:
 - checks for uncommitted changes
 - confirms the version
 - removes old build artifacts
-- runs `poetry publish --build`
+- builds the wheel and sdist locally
+- fails before upload if built metadata contains direct URL requirements that PyPI rejects
+- runs `poetry publish` only after metadata validation passes
 
 After publishing, tag and push the release:
 

--- a/docs/conditional-dependencies-best-practices.md
+++ b/docs/conditional-dependencies-best-practices.md
@@ -195,10 +195,11 @@ To meet the requirement that each provider must be explicitly enabled:
   - `google_gemini`
   - `azure_tts`
   - `elevenlabs`
-- Keep middleware extras independent:
+- Keep middleware extras user-facing and clearly documented:
   - `middleware-pii-redaction`
   - `middleware-pii-redaction-small`
   - `middleware-pii-redaction-large`
+- Alias variants are acceptable when packaging constraints require separate runtime asset installation, as long as the install behavior is documented explicitly.
 - Optionally add a convenience umbrella extra for local integration testing, while keeping provider-specific extras as the main path.
 
 ## Required `README.md` Changes

--- a/docs/pii_redaction_design.md
+++ b/docs/pii_redaction_design.md
@@ -459,14 +459,17 @@ flowchart LR
         ExtraSmall["Install: [middleware-pii-redaction-small]"]
         ExtraLarge["Install: [middleware-pii-redaction-large]"]
         ExtraStandard["Install: [middleware-pii-redaction]"]
-        SmallWheel["en_core_web_sm wheel is resolved at install and packaged in artifact"]
-        LargeWheel["en_core_web_lg wheel is resolved at install and packaged in artifact"]
-        ManualLarge["Optional custom build step: package en_core_web_lg into artifact"]
+        BaseDeps["Presidio + spaCy + usaddress Python deps installed"]
+        SmallWheel["Separate build step: install en_core_web_sm into artifact"]
+        LargeWheel["Separate build step: install en_core_web_lg into artifact"]
 
-        ExtraSmall --> SmallWheel
-        ExtraLarge --> LargeWheel
+        ExtraSmall --> BaseDeps
+        ExtraLarge --> BaseDeps
+        ExtraStandard --> BaseDeps
+        BaseDeps --> SmallWheel
+        BaseDeps --> LargeWheel
         LargeWheel --> ModelLg
-        ManualLarge --> ModelLg
+        SmallWheel --> ModelSm
     end
 
     subgraph Runtime["Runtime Startup"]
@@ -569,23 +572,21 @@ Address redaction uses a hybrid strategy designed for US address formats.
   Inside `_presidio_redactor.py`, `detection_profile` is mapped to an internal runtime profile before Presidio engine construction. If `low_memory` is selected, an empty NLP configuration is used, forcing the regex-only execution path.
 
   **Install-time packaging behavior (critical for restricted networking):**
-  - `middleware-pii-redaction-small` includes a direct wheel reference for `en_core_web_sm` in `pyproject.toml`.
-  - Installing `middleware-pii-redaction-small` during image/build creation packages the small spaCy model into the deployment artifact.
-  - `middleware-pii-redaction-large` includes a direct wheel reference for `en_core_web_lg` in `pyproject.toml`.
-  - Installing `middleware-pii-redaction-large` during image/build creation packages the large spaCy model into the deployment artifact.
-  - `middleware-pii-redaction` installs Presidio and `usaddress` but does not package spaCy model wheels.
-  - If `high_accuracy` is selected and `en_core_web_lg` is not prepackaged, teams typically add a runtime download/bootstrap step, which requires outbound network access and can fail in no-egress environments.
-  - For no-egress Lambda and similarly restricted environments, the stable path is `middleware-pii-redaction-small` with `detection_profile: balanced` or `low_memory`; `middleware-pii-redaction-large` is available when large-model accuracy is required and deployment size constraints permit it.
+  - `middleware-pii-redaction` installs the Python dependencies required for Presidio-backed redaction, including spaCy itself.
+  - `middleware-pii-redaction-small` and `middleware-pii-redaction-large` are compatibility aliases to that same Python dependency set so existing install commands continue to work.
+  - Published PyPI metadata cannot contain direct URL requirements for the spaCy model wheels, so `en_core_web_sm` and `en_core_web_lg` must be installed as separate build or bootstrap steps.
+  - For connected developer environments, the common path is `python -m spacy download en_core_web_sm` for `balanced` or `python -m spacy download en_core_web_lg` for `high_accuracy`.
+  - For no-egress Lambda and similarly restricted environments, install the matching spaCy wheel into the image or deployment artifact during the build.
+  - If a non-`low_memory` profile is selected and the corresponding model is missing, redaction will require a separate runtime/bootstrap step and may fail in no-egress environments.
 
   **No-egress deployment matrix:**
 
-  | Install extra                    | Selected `detection_profile` | Runtime internet needed for model                      | Result in no-egress environment                 |
-  | -------------------------------- | ---------------------- | ------------------------------------------------------ | ----------------------------------------------- |
-  | `middleware-pii-redaction-small` | `balanced`     | No                                                     | Works with packaged small model                 |
-  | `middleware-pii-redaction-large` | `high_accuracy`    | No                                                     | Works with packaged large model                 |
-  | `middleware-pii-redaction`       | `balanced`     | Yes, unless `en_core_web_sm` is prepackaged separately | Fails if model is missing and cannot be fetched |
-  | `middleware-pii-redaction`       | `high_accuracy`    | Yes, unless `en_core_web_lg` is prepackaged separately | Fails if model is missing and cannot be fetched |
-  | either extra                     | `low_memory`          | No                                                     | Works without spaCy model                       |
+  | Install extra                                          | Selected `detection_profile` | Runtime internet needed for model                   | Result in no-egress environment                 |
+  | ------------------------------------------------------ | ---------------------------- | --------------------------------------------------- | ----------------------------------------------- |
+  | `middleware-pii-redaction` or `-small`, plus `en_core_web_sm` installed separately | `balanced`                    | No                                                  | Works with preinstalled small model             |
+  | `middleware-pii-redaction` or `-large`, plus `en_core_web_lg` installed separately | `high_accuracy`               | No                                                  | Works with preinstalled large model             |
+  | any PII extra without the required spaCy model         | `balanced` or `high_accuracy` | Yes, unless the matching model is prepackaged       | Fails if model is missing and cannot be fetched |
+  | any PII extra                                          | `low_memory`                 | No                                                  | Works without spaCy model                       |
 
 - **Caching & Performance (`@functools.cache`):**
   - Loading the Presidio `AnalyzerEngine` and underlying NLP models (e.g., spaCy `en_core_web_lg`) is an incredibly expensive operation, taking approximately **2 to 5 seconds** and consuming **500MB+ of RAM**.

--- a/poetry.lock
+++ b/poetry.lock
@@ -967,38 +967,6 @@ websockets = ">=11.0"
 pyaudio = ["pyaudio (>=0.2.14)"]
 
 [[package]]
-name = "en_core_web_lg"
-version = "3.8.0"
-description = "English pipeline optimized for CPU. Components: tok2vec, tagger, parser, senter, ner, attribute_ruler, lemmatizer."
-optional = true
-python-versions = "*"
-groups = ["main"]
-markers = "extra == \"middleware-pii-redaction-large\""
-files = [
-    {file = "en_core_web_lg-3.8.0-py3-none-any.whl", hash = "sha256:293e9547a655b25499198ab15a525b05b9407a75f10255e405e8c3854329ab63"},
-]
-
-[package.source]
-type = "url"
-url = "https://github.com/explosion/spacy-models/releases/download/en_core_web_lg-3.8.0/en_core_web_lg-3.8.0-py3-none-any.whl"
-
-[[package]]
-name = "en_core_web_sm"
-version = "3.8.0"
-description = "English pipeline optimized for CPU. Components: tok2vec, tagger, parser, senter, ner, attribute_ruler, lemmatizer."
-optional = true
-python-versions = "*"
-groups = ["main"]
-markers = "extra == \"middleware-pii-redaction-small\""
-files = [
-    {file = "en_core_web_sm-3.8.0-py3-none-any.whl", hash = "sha256:1932429db727d4bff3deed6b34cfc05df17794f4a52eeb26cf8928f7c1a0fb85"},
-]
-
-[package.source]
-type = "url"
-url = "https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.8.0/en_core_web_sm-3.8.0-py3-none-any.whl"
-
-[[package]]
 name = "filelock"
 version = "3.25.2"
 description = "A platform independent file lock."
@@ -4199,9 +4167,9 @@ bedrock = ["boto3"]
 dev = ["black", "pytest", "ruff"]
 elevenlabs = ["elevenlabs"]
 google-gemini = ["google-cloud-speech", "google-cloud-texttospeech", "google-genai", "googleapis-common-protos", "protobuf"]
-middleware-pii-redaction = ["presidio-analyzer", "presidio-anonymizer", "usaddress"]
-middleware-pii-redaction-large = ["en_core_web_lg", "presidio-analyzer", "presidio-anonymizer", "usaddress"]
-middleware-pii-redaction-small = ["en_core_web_sm", "presidio-analyzer", "presidio-anonymizer", "usaddress"]
+middleware-pii-redaction = ["presidio-analyzer", "presidio-anonymizer", "spacy", "usaddress"]
+middleware-pii-redaction-large = ["presidio-analyzer", "presidio-anonymizer", "spacy", "usaddress"]
+middleware-pii-redaction-small = ["presidio-analyzer", "presidio-anonymizer", "spacy", "usaddress"]
 openai = ["openai"]
 similarity-score = ["numpy"]
 video-frames = ["Pillow", "imageio", "imageio-ffmpeg"]
@@ -4209,4 +4177,4 @@ video-frames = ["Pillow", "imageio", "imageio-ffmpeg"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<3.14"
-content-hash = "cf9ad6c41e6a3c599921a324e3306b245fa8faad7f8cff4b349ff01bbe01a8f8"
+content-hash = "1be11c7697c9fb9f1d1f7d71530b66fbfcdb1aa92668393b129a24d6373d8216"

--- a/publish.sh
+++ b/publish.sh
@@ -8,7 +8,8 @@
 # 1. The git working directory is clean.
 # 2. The user is reminded of the current version and prompts for confirmation.
 # 3. Old build artifacts are removed.
-# 4. The package is built and published securely using Poetry.
+# 4. The package is built locally and validated for publish-safe metadata.
+# 5. The prevalidated package is published securely using Poetry.
 # ==============================================================================
 
 # Exit immediately if a command exits with a non-zero status
@@ -45,10 +46,16 @@ echo ""
 echo "🧹 Cleaning up previous builds..."
 rm -rf dist/ build/ *.egg-info/
 
-echo "🚀 Building and publishing the package via Poetry..."
+echo "🚀 Building the package via Poetry..."
+poetry build
+
+echo "🔎 Validating built package metadata..."
+PYTHONPATH=src poetry run python -m ai_api_unified.util.package_metadata_validation dist
+
+echo "🚀 Publishing the validated package via Poetry..."
 # This requires the PyPI token to be configured beforehand:
 # poetry config pypi-token.pypi <your-pypi-token>
-poetry publish --build
+poetry publish
 
 echo "✅ Successfully published version ${CURRENT_VERSION}!"
 echo ""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,8 @@
 # Packaging
 #   poetry build                 # Build the package (wheel + sdist)
 # Publishing 
-#   poetry publish --build 
+#   ./publish.sh                 # Clean, build, validate metadata, and publish
+#   poetry publish               # Publish prebuilt artifacts after validation
 # Environment
 #   poetry shell                 # Spawn a shell within the virtualenv
 #   poetry run <cmd>             # Run any command inside the Poetry virtualenv

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@
 [project]
 name = "ai_api_unified"
 
-version = "2.5.0" # keep in sync with src/ai_api_unified/__version__.py
+version = "2.5.1" # keep in sync with src/ai_api_unified/__version__.py
 description = "Unified access layer for AI completions (LLM), embedding (semantic), image, video, and voice services"
 authors = [{ name = "Dave Thomas", email = "davidcthomas@gmail.com" }]
 license = "MIT"
@@ -92,19 +92,21 @@ google_gemini = [
 middleware-pii-redaction = [
   "presidio-analyzer>=2.2.35",
   "presidio-anonymizer>=2.2.35",
+  "spacy>=3.4.4,!=3.7.0,<4.0.0",
   "usaddress>=0.5.16,<0.6.0",
 ]
+# Compatibility aliases retained so existing install commands keep working.
 middleware-pii-redaction-small = [
   "presidio-analyzer>=2.2.35",
   "presidio-anonymizer>=2.2.35",
+  "spacy>=3.4.4,!=3.7.0,<4.0.0",
   "usaddress>=0.5.16,<0.6.0",
-  "en-core-web-sm @ https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.8.0/en_core_web_sm-3.8.0-py3-none-any.whl",
 ]
 middleware-pii-redaction-large = [
   "presidio-analyzer>=2.2.35",
   "presidio-anonymizer>=2.2.35",
+  "spacy>=3.4.4,!=3.7.0,<4.0.0",
   "usaddress>=0.5.16,<0.6.0",
-  "en-core-web-lg @ https://github.com/explosion/spacy-models/releases/download/en_core_web_lg-3.8.0/en_core_web_lg-3.8.0-py3-none-any.whl",
 ]
 similarity_score = ["numpy==2.2.6"]
 video_frames = [

--- a/src/ai_api_unified/__version__.py
+++ b/src/ai_api_unified/__version__.py
@@ -9,4 +9,4 @@ from __future__ import annotations
 
 __all__: list[str] = ["__version__"]
 
-__version__: str = "2.5.0"
+__version__: str = "2.5.1"

--- a/src/ai_api_unified/util/package_metadata_validation.py
+++ b/src/ai_api_unified/util/package_metadata_validation.py
@@ -1,0 +1,233 @@
+"""
+Validation helpers for built package metadata.
+
+PyPI rejects uploaded package metadata that contains direct URL dependencies in
+``Requires-Dist`` fields. The helpers in this module inspect built wheel and
+sdist artifacts before publish so maintainers fail locally instead of during the
+upload request.
+"""
+
+from __future__ import annotations
+
+from email.parser import Parser
+from pathlib import Path
+import sys
+import tarfile
+import zipfile
+
+DIST_DIR_DEFAULT: str = "dist"
+METADATA_FILENAME_WHEEL_SUFFIX: str = ".dist-info/METADATA"
+METADATA_FILENAME_SDIST_SUFFIX: str = "/PKG-INFO"
+SUPPORTED_SDIST_SUFFIX: str = ".tar.gz"
+SUPPORTED_WHEEL_SUFFIX: str = ".whl"
+REQUIRES_DIST_HEADER: str = "Requires-Dist"
+
+
+def _is_supported_distribution_path(path_distribution: Path) -> bool:
+    """
+    Returns whether a path points to a supported built distribution artifact.
+
+    Args:
+        path_distribution: Candidate filesystem path.
+
+    Returns:
+        True when the path is a wheel or gzip-compressed sdist.
+    """
+    return path_distribution.name.endswith(
+        (SUPPORTED_WHEEL_SUFFIX, SUPPORTED_SDIST_SUFFIX)
+    )
+
+
+def collect_distribution_paths(
+    list_path_targets: list[str] | None = None,
+) -> list[Path]:
+    """
+    Expands input targets into concrete built distribution paths.
+
+    Args:
+        list_path_targets: File or directory paths supplied by the caller.
+
+    Returns:
+        Sorted list of supported distribution artifact paths.
+
+    Raises:
+        ValueError: When no supported distributions are found.
+    """
+    list_path_inputs: list[Path] = [
+        Path(str_path_target)
+        for str_path_target in (
+            list_path_targets if list_path_targets is not None else [DIST_DIR_DEFAULT]
+        )
+    ]
+    list_path_distributions: list[Path] = []
+    for path_input in list_path_inputs:
+        if path_input.is_dir():
+            list_path_distributions.extend(
+                sorted(
+                    (
+                        path_candidate
+                        for path_candidate in path_input.iterdir()
+                        if _is_supported_distribution_path(path_candidate)
+                    ),
+                    key=lambda path_candidate: path_candidate.name,
+                )
+            )
+            continue
+        if _is_supported_distribution_path(path_input):
+            list_path_distributions.append(path_input)
+
+    if not list_path_distributions:
+        raise ValueError("No built distributions found to validate.")
+
+    return list_path_distributions
+
+
+def _read_metadata_text_from_wheel(path_distribution: Path) -> str:
+    """
+    Reads the METADATA payload from a wheel artifact.
+
+    Args:
+        path_distribution: Path to a wheel file.
+
+    Returns:
+        Decoded METADATA text.
+
+    Raises:
+        ValueError: When the wheel does not contain a METADATA payload.
+    """
+    with zipfile.ZipFile(path_distribution) as zip_distribution:
+        for str_member_name in zip_distribution.namelist():
+            if str_member_name.endswith(METADATA_FILENAME_WHEEL_SUFFIX):
+                return zip_distribution.read(str_member_name).decode("utf-8")
+    raise ValueError(f"Wheel is missing METADATA: {path_distribution}")
+
+
+def _read_metadata_text_from_sdist(path_distribution: Path) -> str:
+    """
+    Reads the PKG-INFO payload from a gzip-compressed source distribution.
+
+    Args:
+        path_distribution: Path to a ``.tar.gz`` source distribution.
+
+    Returns:
+        Decoded PKG-INFO text.
+
+    Raises:
+        ValueError: When the source distribution does not contain PKG-INFO.
+    """
+    with tarfile.open(path_distribution, "r:gz") as tar_distribution:
+        for tar_member in tar_distribution.getmembers():
+            if tar_member.name.endswith(METADATA_FILENAME_SDIST_SUFFIX):
+                binary_file_metadata = tar_distribution.extractfile(tar_member)
+                if binary_file_metadata is None:
+                    break
+                return binary_file_metadata.read().decode("utf-8")
+    raise ValueError(f"Source distribution is missing PKG-INFO: {path_distribution}")
+
+
+def read_distribution_metadata_text(path_distribution: Path) -> str:
+    """
+    Reads package metadata text from a supported distribution artifact.
+
+    Args:
+        path_distribution: Path to a wheel or source distribution.
+
+    Returns:
+        Decoded metadata text for the artifact.
+
+    Raises:
+        ValueError: When the artifact type is unsupported.
+    """
+    if path_distribution.name.endswith(SUPPORTED_WHEEL_SUFFIX):
+        return _read_metadata_text_from_wheel(path_distribution)
+    if path_distribution.name.endswith(SUPPORTED_SDIST_SUFFIX):
+        return _read_metadata_text_from_sdist(path_distribution)
+    raise ValueError(f"Unsupported distribution artifact: {path_distribution}")
+
+
+def requirement_has_direct_url(str_requirement: str) -> bool:
+    """
+    Returns whether a ``Requires-Dist`` entry uses direct URL syntax.
+
+    Args:
+        str_requirement: Parsed requirement string from package metadata.
+
+    Returns:
+        True when the requirement contains a direct URL reference.
+    """
+    return " @ " in str_requirement and "://" in str_requirement
+
+
+def find_direct_url_requirements(
+    list_path_distributions: list[Path],
+) -> dict[Path, list[str]]:
+    """
+    Finds invalid direct URL requirements in built distribution metadata.
+
+    Args:
+        list_path_distributions: Built wheel and/or sdist paths to inspect.
+
+    Returns:
+        Mapping of artifact path to the direct URL requirements found there.
+    """
+    dict_path_to_invalid_requirements: dict[Path, list[str]] = {}
+    metadata_parser: Parser = Parser()
+    for path_distribution in list_path_distributions:
+        str_metadata_text: str = read_distribution_metadata_text(path_distribution)
+        metadata_message = metadata_parser.parsestr(str_metadata_text)
+        list_str_invalid_requirements: list[str] = [
+            str_requirement
+            for str_requirement in metadata_message.get_all(REQUIRES_DIST_HEADER, [])
+            if requirement_has_direct_url(str_requirement)
+        ]
+        if list_str_invalid_requirements:
+            dict_path_to_invalid_requirements[path_distribution] = (
+                list_str_invalid_requirements
+            )
+
+    return dict_path_to_invalid_requirements
+
+
+def main(list_str_args: list[str] | None = None) -> int:
+    """
+    CLI entrypoint for distribution metadata validation.
+
+    Args:
+        list_str_args: Optional CLI-style filesystem path arguments.
+
+    Returns:
+        Process exit code. Zero indicates success.
+    """
+    try:
+        list_path_distributions: list[Path] = collect_distribution_paths(list_str_args)
+        dict_path_to_invalid_requirements: dict[Path, list[str]] = (
+            find_direct_url_requirements(list_path_distributions)
+        )
+    except ValueError as exception:
+        print(str(exception), file=sys.stderr)
+        return 1
+
+    if dict_path_to_invalid_requirements:
+        print(
+            "Publish metadata validation failed. Direct URL requirements are not "
+            "allowed in PyPI upload metadata:",
+            file=sys.stderr,
+        )
+        for (
+            path_distribution,
+            list_str_invalid_requirements,
+        ) in dict_path_to_invalid_requirements.items():
+            print(f"  {path_distribution.name}", file=sys.stderr)
+            for str_requirement in list_str_invalid_requirements:
+                print(f"    - {str_requirement}", file=sys.stderr)
+        return 1
+
+    print(
+        f"Validated {len(list_path_distributions)} distribution artifact(s); "
+        "no direct URL requirements found."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/tests/test_package_metadata_validation.py
+++ b/tests/test_package_metadata_validation.py
@@ -1,0 +1,168 @@
+"""Tests for built package metadata validation helpers."""
+
+from __future__ import annotations
+
+import io
+from pathlib import Path
+import tarfile
+import zipfile
+
+from ai_api_unified.util.package_metadata_validation import (
+    collect_distribution_paths,
+    find_direct_url_requirements,
+    main,
+)
+
+DIRECT_URL_REQUIREMENT: str = (
+    "en-core-web-sm @ "
+    "https://github.com/explosion/spacy-models/releases/download/"
+    "en_core_web_sm-3.8.0/en_core_web_sm-3.8.0-py3-none-any.whl ; "
+    'extra == "middleware-pii-redaction-small"'
+)
+
+
+def _build_metadata_text(list_str_requirements: list[str]) -> str:
+    """
+    Builds minimal package metadata text for a synthetic distribution artifact.
+
+    Args:
+        list_str_requirements: ``Requires-Dist`` values to encode.
+
+    Returns:
+        Metadata text suitable for METADATA or PKG-INFO payloads.
+    """
+    list_str_lines: list[str] = [
+        "Metadata-Version: 2.3",
+        "Name: ai_api_unified",
+        "Version: 2.5.1",
+    ]
+    list_str_lines.extend(
+        f"Requires-Dist: {str_requirement}" for str_requirement in list_str_requirements
+    )
+    return "\n".join(list_str_lines) + "\n"
+
+
+def _write_wheel(path_distribution: Path, str_metadata_text: str) -> None:
+    """
+    Writes a synthetic wheel containing package metadata.
+
+    Args:
+        path_distribution: Output wheel path.
+        str_metadata_text: Metadata payload to embed.
+
+    Returns:
+        None
+    """
+    with zipfile.ZipFile(path_distribution, "w") as zip_distribution:
+        zip_distribution.writestr(
+            "ai_api_unified-2.5.1.dist-info/METADATA",
+            str_metadata_text,
+        )
+
+
+def _write_sdist(path_distribution: Path, str_metadata_text: str) -> None:
+    """
+    Writes a synthetic source distribution containing PKG-INFO metadata.
+
+    Args:
+        path_distribution: Output source distribution path.
+        str_metadata_text: Metadata payload to embed.
+
+    Returns:
+        None
+    """
+    bytes_metadata: bytes = str_metadata_text.encode("utf-8")
+    tar_info: tarfile.TarInfo = tarfile.TarInfo("ai_api_unified-2.5.1/PKG-INFO")
+    tar_info.size = len(bytes_metadata)
+    with tarfile.open(path_distribution, "w:gz") as tar_distribution:
+        tar_distribution.addfile(tar_info, io.BytesIO(bytes_metadata))
+
+
+def test_collect_distribution_paths_expands_dist_directory(tmp_path: Path) -> None:
+    """
+    Verifies supported wheel and sdist artifacts are discovered from a directory.
+
+    Args:
+        tmp_path: Temporary pytest directory fixture.
+
+    Returns:
+        None
+    """
+    path_wheel: Path = tmp_path / "ai_api_unified-2.5.1-py3-none-any.whl"
+    path_sdist: Path = tmp_path / "ai_api_unified-2.5.1.tar.gz"
+    path_notes: Path = tmp_path / "notes.txt"
+
+    _write_wheel(path_wheel, _build_metadata_text([]))
+    _write_sdist(path_sdist, _build_metadata_text([]))
+    path_notes.write_text("ignore me", encoding="utf-8")
+
+    list_path_distributions: list[Path] = collect_distribution_paths([str(tmp_path)])
+
+    assert path_sdist in list_path_distributions
+    assert path_wheel in list_path_distributions
+    assert path_notes not in list_path_distributions
+
+
+def test_find_direct_url_requirements_flags_invalid_wheel_and_sdist(
+    tmp_path: Path,
+) -> None:
+    """
+    Verifies direct URL requirements are detected in both wheel and sdist metadata.
+
+    Args:
+        tmp_path: Temporary pytest directory fixture.
+
+    Returns:
+        None
+    """
+    str_metadata_text: str = _build_metadata_text(
+        [
+            "presidio-analyzer>=2.2.35",
+            DIRECT_URL_REQUIREMENT,
+        ]
+    )
+    path_wheel: Path = tmp_path / "ai_api_unified-2.5.1-py3-none-any.whl"
+    path_sdist: Path = tmp_path / "ai_api_unified-2.5.1.tar.gz"
+
+    _write_wheel(path_wheel, str_metadata_text)
+    _write_sdist(path_sdist, str_metadata_text)
+
+    dict_path_to_invalid_requirements: dict[Path, list[str]] = (
+        find_direct_url_requirements([path_wheel, path_sdist])
+    )
+
+    assert dict_path_to_invalid_requirements[path_wheel] == [DIRECT_URL_REQUIREMENT]
+    assert dict_path_to_invalid_requirements[path_sdist] == [DIRECT_URL_REQUIREMENT]
+
+
+def test_main_returns_success_for_publish_safe_metadata(
+    tmp_path: Path,
+    capsys,
+) -> None:
+    """
+    Verifies the CLI entrypoint accepts metadata without direct URL requirements.
+
+    Args:
+        tmp_path: Temporary pytest directory fixture.
+        capsys: Pytest stdout/stderr capture fixture.
+
+    Returns:
+        None
+    """
+    path_wheel: Path = tmp_path / "ai_api_unified-2.5.1-py3-none-any.whl"
+    _write_wheel(
+        path_wheel,
+        _build_metadata_text(
+            [
+                "presidio-analyzer>=2.2.35",
+                "spacy<4.0.0,>=3.4.4,!=3.7.0 ; extra == 'middleware-pii-redaction'",
+            ]
+        ),
+    )
+
+    int_exit_code: int = main([str(tmp_path)])
+    captured_output = capsys.readouterr()
+
+    assert int_exit_code == 0
+    assert "no direct URL requirements found" in captured_output.out
+    assert captured_output.err == ""


### PR DESCRIPTION
Closes #9

## Summary
- remove direct-URL spaCy model wheel requirements from the published PII extras so PyPI accepts the package metadata
- keep spaCy-based PII redaction available by retaining the PII extras, making spaCy explicit, and documenting separate model installation for connected and no-egress environments
- add a built-distribution metadata validator and wire `publish.sh` to fail before upload when artifacts contain disallowed direct URL requirements
- bump the package version to `2.5.1`

## Testing
- `poetry lock`
- `poetry check`
- `poetry run black src/ai_api_unified/util/package_metadata_validation.py tests/test_package_metadata_validation.py`
- `poetry run pytest tests/test_package_metadata_validation.py -q`
- `poetry build`
- `PYTHONPATH=src poetry run python -m ai_api_unified.util.package_metadata_validation dist/ai_api_unified-2.5.1.tar.gz dist/ai_api_unified-2.5.1-py3-none-any.whl`
- `poetry run pytest -m "not nonmock" -q`

<!-- pr-review-prep:start -->
## Review Prep Summary

Composition percentages are based on added and deleted textual lines relative to `main`.

| Change Type | Lines Changed | Percentage |
|---|---:|---:|
| Core logic changes | 235 | 45% |
| Documentation | 56 | 11% |
| Tests | 168 | 32% |
| Other | 61 | 12% |
| Total | 520 | 100% |
<!-- pr-review-prep:end -->

<!-- pr-content-attribution:start -->
## Content Attribution Summary

Based on changed lines across counted PR commits in this PR.

| Attribution Type | Commits | Lines Changed | Percentage |
|---|---:|---:|---:|
| AI-attributed | 1 | 520 | 100% |
| Human-attributed | 0 | 0 | 0% |
| Bot-attributed | 0 | 0 | 0% |
| Total | 1 | 520 | 100% |
<!-- pr-content-attribution:end -->
