### PR TITLE
Ignore agentmemory state files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,7 @@ settings.json
 .agents/memory/pending/
 .agents/memory/logs/
 # Do not edit this block manually; rerun ./install.sh and reopen an agent session if needed.
+
+# Do not edit this block manually; rerun the installer from your agentmemory checkout and reopen an agent session if needed.
+.agents/memory/state/
+.agents/memory/.auto_bootstrap_running


### PR DESCRIPTION
## Summary
- ignore generated agentmemory state files that should not be committed from this repo
- keep the installer-managed warning near the agentmemory ignore block

## Testing
- not run; `.gitignore`-only change

<!-- pr-review-prep:start -->
## Review Prep Summary

Composition percentages are based on added and deleted textual lines relative to `main`.

| Change Type | Lines Changed | Percentage |
|---|---:|---:|
| Core logic changes | 0 | 0% |
| Documentation | 0 | 0% |
| Tests | 0 | 0% |
| Other | 4 | 100% |
| Total | 4 | 100% |
<!-- pr-review-prep:end -->

<!-- pr-content-attribution:start -->
## Content Attribution Summary

Based on changed lines across counted PR commits in this PR.

| Attribution Type | Commits | Lines Changed | Percentage |
|---|---:|---:|---:|
| AI-attributed | 0 | 0 | 0% |
| Human-attributed | 1 | 4 | 100% |
| Bot-attributed | 0 | 0 | 0% |
| Total | 1 | 4 | 100% |
<!-- pr-content-attribution:end -->
