### PR TITLE
fix: reject unsupported fps parameter for Gemini (Veo)

### DIFF
--- a/.agents/memory/daily/2026-04-18/events/2026-04-18T21-56-37Z--2355287-davecthomas--thread_0407f408-a895-496a-9531-9bcfa6c94600--turn_7ef0d1ee04.md
+++ b/.agents/memory/daily/2026-04-18/events/2026-04-18T21-56-37Z--2355287-davecthomas--thread_0407f408-a895-496a-9531-9bcfa6c94600--turn_7ef0d1ee04.md
@@ -1,0 +1,52 @@
+---
+agentmemory_version: "0.4.4"
+timestamp: "2026-04-18T21:56:37Z"
+author: "2355287-davecthomas"
+branch: "fix/gemini-fps-leaky-abstraction"
+thread_id: "0407f408-a895-496a-9531-9bcfa6c94600"
+turn_id: "7ef0d1ee04"
+workstream_id: "thread-0407f408-a895-496a-9531-9bcfa6c94600"
+workstream_scope: "thread"
+episode_id: "episode-thread-0407f408-a895-496a-9531-9bcfa6c94600"
+episode_scope: "thread"
+checkpoint_goal: "Close a leaky abstraction in the Google Gemini (Veo) video client where callers could pass an 'fps' parameter that Veo does not support, so the mismatch is surfaced at the provider-properties boundary instead of silently propagating into the remote config."
+checkpoint_surface: "src/ai_api_unified/videos/ai_google_gemini_videos.py \u2014 specifically AIGoogleGeminiVideoProperties Pydantic model validation and the generate_videos config-kwargs forwarding path in AIGoogleGeminiVideos."
+checkpoint_outcome: "Added an upfront ValueError in AIGoogleGeminiVideoProperties._validate_google_video_properties when fps is non-None, removed the fps forwarding branch in the generate_videos config builder, and updated tests to drop the now-invalid fps=24 assertion and add a dedicated rejection test."
+decision_candidate: false
+enriched: true
+ai_generated: true
+ai_model: "claude-unknown"
+ai_tool: "claude"
+ai_surface: "claude-code"
+ai_executor: "local-agent"
+related_adrs:
+files_touched:
+  - "src/ai_api_unified/videos/ai_google_gemini_videos.py"
+  - "tests/test_google_gemini_videos.py"
+design_docs_touched:
+verification:
+  - "git diff:  2 files changed, 17 insertions(+), 4 deletions(-); if self.fps is not None:; raise ValueError(; \"Google Gemini (Veo) does not support the 'fps' parameter. \""
+source_pending_shards:
+  - ".agents/memory/pending/2026-04-18/2026-04-18T21-56-37Z--2355287-davecthomas--thread_0407f408-a895-496a-9531-9bcfa6c94600--turn_7ef0d1ee04.md"
+---
+
+## Why
+
+- Veo does not accept fps; the previous code forwarded it into the generate_videos config, which either triggered a remote rejection or was silently dropped — a leaky abstraction that hid a provider capability gap from the caller. Validating at the Properties layer gives callers a clear, actionable error at the right boundary and keeps provider-specific capability handling owned by the provider code, consistent with ADR-0008's stance on explicit video-engine selection and provider-owned defaults.
+
+## What changed
+
+- AIGoogleGeminiVideoProperties._validate_google_video_properties now raises ValueError with a message naming the unsupported 'fps' parameter when it is set. The config_kwargs builder in AIGoogleGeminiVideos no longer forwards fps into the generate_videos config; the previous forwarding block is replaced with a comment explaining that validation upstream prevents this case. Tests removed fps=24 from the 'forwards supported generate_videos config fields' scenario (which is no longer a valid property set) and added test_google_video_properties_reject_fps to pin down the rejection behavior via pytest.raises.
+
+## Evidence
+
+- src/ai_api_unified/videos/ai_google_gemini_videos.py: new ValueError branch in the model_validator; removed fps forwarding in config_kwargs assembly.
+- tests/test_google_gemini_videos.py: new test_google_video_properties_reject_fps using pytest.raises(ValueError, match="does not support the 'fps' parameter"); existing forward-fields test updated to stop asserting fps.
+- Branch fix/gemini-fps-leaky-abstraction names the intent.
+- Aligns with ADR-0008 (explicit VIDEO_ENGINE selection with provider-owned model defaults) and ADR-0006 (sync-friendly public video API wrapping provider async job models).
+
+## Next
+
+- Audit the other video providers for analogous silently-accepted-but-unsupported parameters and apply the same fail-fast validation pattern.
+- Decide whether AIBaseVideoProperties should grow an explicit per-provider 'unsupported fields' declaration mechanism, or whether per-provider model_validators remain the right surface.
+- Land this fix through the normal PR flow so the new rejection test gates future regressions.

--- a/.agents/memory/daily/2026-04-18/summary.md
+++ b/.agents/memory/daily/2026-04-18/summary.md
@@ -1,0 +1,41 @@
+# 2026-04-18 summary
+
+## Snapshot
+
+- Captured 1 memory event.
+- Main work: AIGoogleGeminiVideoProperties._validate_google_video_properties now raises ValueError with a message naming the unsupported 'fps' parameter when it is set. The config_kwargs builder in AIGoogleGeminiVideos no longer forwards fps into the generate_videos config; the previous forwarding block is replaced with a comment explaining that validation upstream prevents this case. Tests removed fps=24 from the 'forwards supported generate_videos config fields' scenario (which is no longer a valid property set) and added test_google_video_properties_reject_fps to pin down the rejection behavior via pytest.raises.
+- Top decision: None.
+- Blockers: None.
+
+| Metric | Value |
+|---|---|
+| Memory events captured | 1 |
+| Repo files changed | 1 |
+| Decision candidates | 0 |
+| Active blockers | 0 |
+
+## Major work completed
+
+- AIGoogleGeminiVideoProperties._validate_google_video_properties now raises ValueError with a message naming the unsupported 'fps' parameter when it is set. The config_kwargs builder in AIGoogleGeminiVideos no longer forwards fps into the generate_videos config; the previous forwarding block is replaced with a comment explaining that validation upstream prevents this case. Tests removed fps=24 from the 'forwards supported generate_videos config fields' scenario (which is no longer a valid property set) and added test_google_video_properties_reject_fps to pin down the rejection behavior via pytest.raises.
+
+## Why this mattered
+
+- Veo does not accept fps; the previous code forwarded it into the generate_videos config, which either triggered a remote rejection or was silently dropped — a leaky abstraction that hid a provider capability gap from the caller. Validating at the Properties layer gives callers a clear, actionable error at the right boundary and keeps provider-specific capability handling owned by the provider code, consistent with ADR-0008's stance on explicit video-engine selection and provider-owned defaults.
+
+## Active blockers
+
+- None
+
+## Decision candidates
+
+- None
+
+## Next likely steps
+
+- Audit the other video providers for analogous silently-accepted-but-unsupported parameters and apply the same fail-fast validation pattern.
+- Decide whether AIBaseVideoProperties should grow an explicit per-provider 'unsupported fields' declaration mechanism, or whether per-provider model_validators remain the right surface.
+- Land this fix through the normal PR flow so the new rejection test gates future regressions.
+
+## Relevant event shards
+
+- [2026-04-18 21:56:37 UTC by 2355287-davecthomas](events/2026-04-18T21-56-37Z--2355287-davecthomas--thread_0407f408-a895-496a-9531-9bcfa6c94600--turn_7ef0d1ee04.md)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@
 [project]
 name = "ai_api_unified"
 
-version = "2.5.1" # keep in sync with src/ai_api_unified/__version__.py
+version = "2.5.2" # keep in sync with src/ai_api_unified/__version__.py
 description = "Unified access layer for AI completions (LLM), embedding (semantic), image, video, and voice services"
 authors = [{ name = "Dave Thomas", email = "davidcthomas@gmail.com" }]
 license = "MIT"

--- a/src/ai_api_unified/__version__.py
+++ b/src/ai_api_unified/__version__.py
@@ -9,4 +9,4 @@ from __future__ import annotations
 
 __all__: list[str] = ["__version__"]
 
-__version__: str = "2.5.1"
+__version__: str = "2.5.2"

--- a/src/ai_api_unified/videos/ai_google_gemini_videos.py
+++ b/src/ai_api_unified/videos/ai_google_gemini_videos.py
@@ -51,6 +51,11 @@ class AIGoogleGeminiVideoProperties(AIBaseVideoProperties):
 
     @model_validator(mode="after")
     def _validate_google_video_properties(self) -> "AIGoogleGeminiVideoProperties":
+        if self.fps is not None:
+            raise ValueError(
+                "Google Gemini (Veo) does not support the 'fps' parameter. "
+                "Remove fps from your video properties for this provider."
+            )
         if (
             self.aspect_ratio is not None
             and self.aspect_ratio not in self._ALLOWED_ASPECT_RATIOS
@@ -363,8 +368,8 @@ class AIGoogleGeminiVideos(AIGoogleBase, AIBaseVideos):
             config_kwargs["duration_seconds"] = google_properties.duration_seconds
         if google_properties.seed is not None:
             config_kwargs["seed"] = google_properties.seed
-        if google_properties.fps is not None:
-            config_kwargs["fps"] = google_properties.fps
+        # fps is intentionally NOT forwarded — Veo rejects it.
+        # Validation in AIGoogleGeminiVideoProperties catches this upfront.
         if google_properties.generate_audio is not None:
             config_kwargs["generate_audio"] = google_properties.generate_audio
         if google_properties.person_generation is not None:

--- a/src/ai_api_unified/videos/ai_google_gemini_videos.py
+++ b/src/ai_api_unified/videos/ai_google_gemini_videos.py
@@ -368,8 +368,6 @@ class AIGoogleGeminiVideos(AIGoogleBase, AIBaseVideos):
             config_kwargs["duration_seconds"] = google_properties.duration_seconds
         if google_properties.seed is not None:
             config_kwargs["seed"] = google_properties.seed
-        # fps is intentionally NOT forwarded — Veo rejects it.
-        # Validation in AIGoogleGeminiVideoProperties catches this upfront.
         if google_properties.generate_audio is not None:
             config_kwargs["generate_audio"] = google_properties.generate_audio
         if google_properties.person_generation is not None:

--- a/tests/test_google_gemini_videos.py
+++ b/tests/test_google_gemini_videos.py
@@ -176,7 +176,6 @@ def test_google_video_submit_forwards_supported_generate_videos_config_fields() 
     provider: _InspectableGoogleGeminiVideos = _InspectableGoogleGeminiVideos(operation)
     properties: AIGoogleGeminiVideoProperties = AIGoogleGeminiVideoProperties(
         seed=123,
-        fps=24,
         generate_audio=True,
         person_generation="allow_adult",
         output_dir=Path("/tmp/google-videos"),
@@ -187,9 +186,18 @@ def test_google_video_submit_forwards_supported_generate_videos_config_fields() 
     captured_call: dict[str, Any] = provider.client.models.calls[0]
     config: Any = captured_call["config"]
     assert config.seed == 123
-    assert config.fps == 24
     assert config.generate_audio is True
     assert config.person_generation == "allow_adult"
+
+
+def test_google_video_properties_reject_fps() -> None:
+    """Gemini (Veo) does not support fps — it should be rejected at validation time."""
+
+    with pytest.raises(ValueError, match="does not support the 'fps' parameter"):
+        AIGoogleGeminiVideoProperties(
+            fps=24,
+            output_dir=Path("/tmp/google-videos"),
+        )
 
 
 def test_google_video_submit_rejects_source_video_when_api_key_auth_is_selected(


### PR DESCRIPTION
## Summary

- **Bug:** `AIBaseVideoProperties.fps` was blindly forwarded into the Veo SDK call, which rejects fps outright — producing a cryptic non-retryable error deep in the SDK
- **Fix:** Upfront validation in `AIGoogleGeminiVideoProperties` now raises a clear `ValueError` at property construction time, before any API call reaches the provider
- **Scope:** Gemini adapter only — other providers that support fps are unaffected
- **Version bump:** 2.5.1 → 2.5.2

## Changes

| File | What changed |
|---|---|
| `src/ai_api_unified/videos/ai_google_gemini_videos.py` | Added fps rejection in validator; removed blind fps forwarding from config builder |
| `tests/test_google_gemini_videos.py` | Updated forwarding test to exclude fps; added `test_google_video_properties_reject_fps` |
| `pyproject.toml` | Version 2.5.1 → 2.5.2 |
| `src/ai_api_unified/__version__.py` | Version 2.5.1 → 2.5.2 |

## Reproducer (before fix)

```python
from ai_api_unified.videos.ai_google_gemini_videos import AIGoogleGeminiVideoProperties
props = AIGoogleGeminiVideoProperties(fps=3, duration_seconds=8)
# → cryptic SDK error: "fps parameter is not supported in Gemini API"
```

## After fix

```python
# → ValueError: Google Gemini (Veo) does not support the 'fps' parameter.
#   Remove fps from your video properties for this provider.
```

## Test plan

- [x] `poetry run pytest tests/test_google_gemini_videos.py` — 10/10 pass
- [ ] Verify storyboard video path works end-to-end without fps against Veo

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- pr-review-prep:start -->
## PR Composition

Based on changed lines (added + deleted) vs. base branch `main`.

| Change Type | Lines Changed | Percentage |
|---|---:|---:|
| Core logic changes | 7 | 30% |
| Tests | 12 | 52% |
| Other | 4 | 18% |
| Total | 23 | 100% |
<!-- pr-review-prep:end -->

<!-- pr-content-attribution:start -->
## Content Attribution Summary

Based on changed lines across counted PR commits.

| Attribution Type | Commits | Lines Changed | Percentage |
|---|---:|---:|---:|
| AI-attributed | 2 | 27 | 100% |
| Human-attributed | 0 | 0 | 0% |
| Bot-attributed | 0 | 0 | 0% |
| Total | 2 | 27 | 100% |
<!-- pr-content-attribution:end -->