### PR TITLE
chore: sync .gitignore with agentmemory SessionStart output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,5 @@ settings.json
 # Do not edit this block manually; rerun the installer from your agentmemory checkout and reopen an agent session if needed.
 .agents/memory/state/
 .agents/memory/.auto_bootstrap_running
+
+# Added by the agentmemory SessionStart/bootstrap flow.


### PR DESCRIPTION
## Summary

- The agentmemory SessionStart hook appends a trailing comment to `.gitignore` each session, leaving the working tree dirty after every session start
- This PR commits the expected comment line so subsequent sessions become a no-op against the tracked file
- Unblocks clean-tree pre-flight checks for the release skill and any other workflow that expects a clean working tree

## Changes

| File | What changed |
|---|---|
| `.gitignore` | Append the agentmemory SessionStart/bootstrap comment line that the hook emits |

## Test plan

- [x] `git status` clean after commit

<!-- pr-review-prep:start -->
## PR Composition

Based on changed lines (added + deleted) vs. base branch `main`.

| Change Type | Lines Changed | Percentage |
|---|---:|---:|
| Core logic changes | 0 | 0% |
| Documentation | 0 | 0% |
| Tests | 0 | 0% |
| Other | 2 | 100% |
| Total | 2 | 100% |
<!-- pr-review-prep:end -->

<!-- pr-content-attribution:start -->
## Content Attribution Summary

Based on changed lines across counted PR commits.

| Attribution Type | Commits | Lines Changed | Percentage |
|---|---:|---:|---:|
| AI-attributed | 1 | 2 | 100% |
| Human-attributed | 0 | 0 | 0% |
| Bot-attributed | 0 | 0 | 0% |
| Total | 1 | 2 | 100% |
<!-- pr-content-attribution:end -->