### PR TITLE
fix: align Gemini video validators with SDK + expose opt-in fields (closes #14)

### DIFF
--- a/.agents/memory/daily/2026-04-18/events/2026-04-18T23-52-58Z--2355287-davecthomas--thread_0407f408-a895-496a-9531-9bcfa6c94600--turn_c66a9c9687.md
+++ b/.agents/memory/daily/2026-04-18/events/2026-04-18T23-52-58Z--2355287-davecthomas--thread_0407f408-a895-496a-9531-9bcfa6c94600--turn_c66a9c9687.md
@@ -1,0 +1,49 @@
+---
+agentmemory_version: "0.4.4"
+timestamp: "2026-04-18T23:52:58Z"
+author: "2355287-davecthomas"
+branch: "issue/14-gemini-video-property-audit"
+thread_id: "0407f408-a895-496a-9531-9bcfa6c94600"
+turn_id: "c66a9c9687"
+workstream_id: "thread-0407f408-a895-496a-9531-9bcfa6c94600"
+workstream_scope: "thread"
+episode_id: "episode-main-b34c818a56"
+episode_scope: "mixed"
+checkpoint_goal: "Close provider-capability leaky abstractions in the Google Gemini (Veo) video Properties model by extending the fail-fast upstream-validation pattern (established by the fps rejection in PR #12) to the full set of Veo-supported and Veo-rejected generate_videos parameters, under issue/14's Gemini video property audit."
+checkpoint_surface: "AIGoogleGeminiVideoProperties in src/ai_api_unified/videos/ai_google_gemini_videos.py \u2014 its declared fields, the _validate_google_video_properties model_validator, and the AIGoogleGeminiVideos.submit_video_generation config_kwargs builder that forwards properties into google.genai types.GenerateVideosConfig."
+checkpoint_outcome: "Extended the Gemini video Properties model with negative_prompt, enhance_prompt, output_gcs_uri, and compression_quality (mapped to types.VideoCompressionQuality); tightened _ALLOWED_RESOLUTIONS to {720p, 1080p} and _ALLOWED_PERSON_GENERATION to {dont_allow, allow_adult}; added gs:// URI and enum validation for the new fields; wired all four into config forwarding; and added 5 pytest cases pinning both rejection and forwarding behavior."
+decision_candidate: false
+enriched: true
+ai_generated: true
+ai_model: "claude-unknown"
+ai_tool: "claude"
+ai_surface: "claude-code"
+ai_executor: "local-agent"
+related_adrs:
+files_touched:
+  - "src/ai_api_unified/videos/ai_google_gemini_videos.py"
+  - "tests/test_google_gemini_videos.py"
+design_docs_touched:
+verification:
+  - "git diff:  2 files changed, 100 insertions(+), 4 deletions(-); negative_prompt: str | None = None; enhance_prompt: bool | None = None; output_gcs_uri: str | None = None"
+source_pending_shards:
+  - ".agents/memory/pending/2026-04-18/2026-04-18T23-52-58Z--2355287-davecthomas--thread_0407f408-a895-496a-9531-9bcfa6c94600--turn_c66a9c9687.md"
+---
+
+## Why
+
+- Veo's real capability surface is narrower than earlier code implied: '4k' and 'allow_all' were accepted client-side but rejected or silently dropped by the remote API, and four useful parameters (negative_prompt, enhance_prompt, output_gcs_uri, compression_quality) were not exposed at all. Leaving these gaps in place would keep the same class of leaky abstraction the fps fix addressed — callers getting either opaque remote errors or silent behavior loss. Validating at the Properties layer keeps provider-specific capability knowledge owned by the provider module per ADR-0008, gives callers actionable errors at the right boundary, and prepares a regression-gated path to expose the rest of Veo's supported surface.
+
+## What changed
+
+- AIGoogleGeminiVideoProperties gained four optional fields (negative_prompt, enhance_prompt, output_gcs_uri, compression_quality) with upstream validation: compression_quality is normalized to uppercase and checked against the SDK enum set {OPTIMIZED, LOSSLESS}; output_gcs_uri must start with gs://. The _ALLOWED_RESOLUTIONS set lost '4k' and _ALLOWED_PERSON_GENERATION lost 'allow_all', with matching error messages updated. The config_kwargs builder in AIGoogleGeminiVideos now forwards each new field into the generate_videos config, converting compression_quality through types.VideoCompressionQuality. This is a net +100/-4 change across the provider and its test module, continuing the same fail-fast-at-the-Properties-boundary pattern introduced for fps.
+
+## Evidence
+
+- src/ai_api_unified/videos/ai_google_gemini_videos.py — new fields, tightened ClassVar allowed sets, new validator branches, and config_kwargs forwarding block. tests/test_google_gemini_videos.py — test_google_video_properties_reject_4k_resolution, test_google_video_properties_reject_allow_all_person_generation, test_google_video_properties_reject_invalid_compression_quality, test_google_video_properties_reject_non_gs_output_gcs_uri, and test_google_video_submit_forwards_optional_config_fields (asserts each new field reaches GenerateVideosConfig). Builds directly on commit 6c5e68f (PR #12, fps rejection) summarized in .agents/memory/daily/2026-04-18/summary.md's 'Next likely steps', which called for exactly this audit. Aligns with ADR-0008 (explicit VIDEO_ENGINE + provider-owned defaults).
+
+## Next
+
+- Land this change through the normal PR flow on issue/14 so the five new tests gate future regressions.
+- Run the same audit on the other video providers (per the 2026-04-18 summary's follow-up item) and mirror the pattern.
+- Consider whether the recurring per-provider 'unsupported / rejected fields' shape warrants lifting into a shared declaration on AIBaseVideoProperties rather than repeating model_validator blocks per provider — candidate discussion, not yet a decision.

--- a/.agents/memory/daily/2026-04-18/summary.md
+++ b/.agents/memory/daily/2026-04-18/summary.md
@@ -2,25 +2,27 @@
 
 ## Snapshot
 
-- Captured 1 memory event.
+- Captured 2 memory events.
 - Main work: AIGoogleGeminiVideoProperties._validate_google_video_properties now raises ValueError with a message naming the unsupported 'fps' parameter when it is set. The config_kwargs builder in AIGoogleGeminiVideos no longer forwards fps into the generate_videos config; the previous forwarding block is replaced with a comment explaining that validation upstream prevents this case. Tests removed fps=24 from the 'forwards supported generate_videos config fields' scenario (which is no longer a valid property set) and added test_google_video_properties_reject_fps to pin down the rejection behavior via pytest.raises.
 - Top decision: None.
 - Blockers: None.
 
 | Metric | Value |
 |---|---|
-| Memory events captured | 1 |
-| Repo files changed | 1 |
+| Memory events captured | 2 |
+| Repo files changed | 2 |
 | Decision candidates | 0 |
 | Active blockers | 0 |
 
 ## Major work completed
 
 - AIGoogleGeminiVideoProperties._validate_google_video_properties now raises ValueError with a message naming the unsupported 'fps' parameter when it is set. The config_kwargs builder in AIGoogleGeminiVideos no longer forwards fps into the generate_videos config; the previous forwarding block is replaced with a comment explaining that validation upstream prevents this case. Tests removed fps=24 from the 'forwards supported generate_videos config fields' scenario (which is no longer a valid property set) and added test_google_video_properties_reject_fps to pin down the rejection behavior via pytest.raises.
+- AIGoogleGeminiVideoProperties gained four optional fields (negative_prompt, enhance_prompt, output_gcs_uri, compression_quality) with upstream validation: compression_quality is normalized to uppercase and checked against the SDK enum set {OPTIMIZED, LOSSLESS}; output_gcs_uri must start with gs://. The _ALLOWED_RESOLUTIONS set lost '4k' and _ALLOWED_PERSON_GENERATION lost 'allow_all', with matching error messages updated. The config_kwargs builder in AIGoogleGeminiVideos now forwards each new field into the generate_videos config, converting compression_quality through types.VideoCompressionQuality. This is a net +100/-4 change across the provider and its test module, continuing the same fail-fast-at-the-Properties-boundary pattern introduced for fps.
 
 ## Why this mattered
 
 - Veo does not accept fps; the previous code forwarded it into the generate_videos config, which either triggered a remote rejection or was silently dropped — a leaky abstraction that hid a provider capability gap from the caller. Validating at the Properties layer gives callers a clear, actionable error at the right boundary and keeps provider-specific capability handling owned by the provider code, consistent with ADR-0008's stance on explicit video-engine selection and provider-owned defaults.
+- Veo's real capability surface is narrower than earlier code implied: '4k' and 'allow_all' were accepted client-side but rejected or silently dropped by the remote API, and four useful parameters (negative_prompt, enhance_prompt, output_gcs_uri, compression_quality) were not exposed at all. Leaving these gaps in place would keep the same class of leaky abstraction the fps fix addressed — callers getting either opaque remote errors or silent behavior loss. Validating at the Properties layer keeps provider-specific capability knowledge owned by the provider module per ADR-0008, gives callers actionable errors at the right boundary, and prepares a regression-gated path to expose the rest of Veo's supported surface.
 
 ## Active blockers
 
@@ -35,7 +37,11 @@
 - Audit the other video providers for analogous silently-accepted-but-unsupported parameters and apply the same fail-fast validation pattern.
 - Decide whether AIBaseVideoProperties should grow an explicit per-provider 'unsupported fields' declaration mechanism, or whether per-provider model_validators remain the right surface.
 - Land this fix through the normal PR flow so the new rejection test gates future regressions.
+- Land this change through the normal PR flow on issue/14 so the five new tests gate future regressions.
+- Run the same audit on the other video providers (per the 2026-04-18 summary's follow-up item) and mirror the pattern.
+- Consider whether the recurring per-provider 'unsupported / rejected fields' shape warrants lifting into a shared declaration on AIBaseVideoProperties rather than repeating model_validator blocks per provider — candidate discussion, not yet a decision.
 
 ## Relevant event shards
 
 - [2026-04-18 21:56:37 UTC by 2355287-davecthomas](events/2026-04-18T21-56-37Z--2355287-davecthomas--thread_0407f408-a895-496a-9531-9bcfa6c94600--turn_7ef0d1ee04.md)
+- [2026-04-18 23:52:58 UTC by 2355287-davecthomas](events/2026-04-18T23-52-58Z--2355287-davecthomas--thread_0407f408-a895-496a-9531-9bcfa6c94600--turn_c66a9c9687.md)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@
 [project]
 name = "ai_api_unified"
 
-version = "2.5.2" # keep in sync with src/ai_api_unified/__version__.py
+version = "2.5.3" # keep in sync with src/ai_api_unified/__version__.py
 description = "Unified access layer for AI completions (LLM), embedding (semantic), image, video, and voice services"
 authors = [{ name = "Dave Thomas", email = "davidcthomas@gmail.com" }]
 license = "MIT"

--- a/src/ai_api_unified/__version__.py
+++ b/src/ai_api_unified/__version__.py
@@ -9,4 +9,4 @@ from __future__ import annotations
 
 __all__: list[str] = ["__version__"]
 
-__version__: str = "2.5.2"
+__version__: str = "2.5.3"

--- a/src/ai_api_unified/videos/ai_google_gemini_videos.py
+++ b/src/ai_api_unified/videos/ai_google_gemini_videos.py
@@ -40,14 +40,18 @@ class AIGoogleGeminiVideoProperties(AIBaseVideoProperties):
     last_frame_image: AIMediaReference | None = None
     person_generation: str | None = None
     generate_audio: bool | None = None
+    negative_prompt: str | None = None
+    enhance_prompt: bool | None = None
+    output_gcs_uri: str | None = None
+    compression_quality: str | None = None
 
     _ALLOWED_ASPECT_RATIOS: ClassVar[set[str]] = {"16:9", "9:16"}
-    _ALLOWED_RESOLUTIONS: ClassVar[set[str]] = {"720p", "1080p", "4k"}
+    _ALLOWED_RESOLUTIONS: ClassVar[set[str]] = {"720p", "1080p"}
     _ALLOWED_PERSON_GENERATION: ClassVar[set[str]] = {
         "dont_allow",
         "allow_adult",
-        "allow_all",
     }
+    _ALLOWED_COMPRESSION_QUALITY: ClassVar[set[str]] = {"OPTIMIZED", "LOSSLESS"}
 
     @model_validator(mode="after")
     def _validate_google_video_properties(self) -> "AIGoogleGeminiVideoProperties":
@@ -68,14 +72,27 @@ class AIGoogleGeminiVideoProperties(AIBaseVideoProperties):
             and self.resolution not in self._ALLOWED_RESOLUTIONS
         ):
             raise ValueError(
-                "Google Gemini video resolution must be one of 720p, 1080p, or 4k."
+                "Google Gemini video resolution must be one of 720p or 1080p."
             )
         if (
             self.person_generation is not None
             and self.person_generation not in self._ALLOWED_PERSON_GENERATION
         ):
             raise ValueError(
-                "Google Gemini person_generation must be one of dont_allow, allow_adult, or allow_all."
+                "Google Gemini person_generation must be one of dont_allow or allow_adult."
+            )
+        if self.compression_quality is not None:
+            normalized: str = self.compression_quality.upper()
+            if normalized not in self._ALLOWED_COMPRESSION_QUALITY:
+                raise ValueError(
+                    "Google Gemini compression_quality must be 'OPTIMIZED' or 'LOSSLESS'."
+                )
+            self.compression_quality = normalized
+        if self.output_gcs_uri is not None and not self.output_gcs_uri.startswith(
+            "gs://"
+        ):
+            raise ValueError(
+                "Google Gemini output_gcs_uri must be a gs:// URI."
             )
         return self
 
@@ -372,6 +389,16 @@ class AIGoogleGeminiVideos(AIGoogleBase, AIBaseVideos):
             config_kwargs["generate_audio"] = google_properties.generate_audio
         if google_properties.person_generation is not None:
             config_kwargs["person_generation"] = google_properties.person_generation
+        if google_properties.negative_prompt is not None:
+            config_kwargs["negative_prompt"] = google_properties.negative_prompt
+        if google_properties.enhance_prompt is not None:
+            config_kwargs["enhance_prompt"] = google_properties.enhance_prompt
+        if google_properties.output_gcs_uri is not None:
+            config_kwargs["output_gcs_uri"] = google_properties.output_gcs_uri
+        if google_properties.compression_quality is not None:
+            config_kwargs["compression_quality"] = types.VideoCompressionQuality(
+                google_properties.compression_quality
+            )
         if google_properties.last_frame_image is not None:
             config_kwargs["last_frame"] = self._to_google_image(
                 google_properties.last_frame_image

--- a/tests/test_google_gemini_videos.py
+++ b/tests/test_google_gemini_videos.py
@@ -200,6 +200,75 @@ def test_google_video_properties_reject_fps() -> None:
         )
 
 
+def test_google_video_properties_reject_4k_resolution() -> None:
+    """Veo does not support 4k — only 720p and 1080p are valid."""
+
+    with pytest.raises(ValueError, match="must be one of 720p or 1080p"):
+        AIGoogleGeminiVideoProperties(
+            resolution="4k",
+            output_dir=Path("/tmp/google-videos"),
+        )
+
+
+def test_google_video_properties_reject_allow_all_person_generation() -> None:
+    """Veo only accepts dont_allow or allow_adult for person_generation."""
+
+    with pytest.raises(ValueError, match="must be one of dont_allow or allow_adult"):
+        AIGoogleGeminiVideoProperties(
+            person_generation="allow_all",
+            output_dir=Path("/tmp/google-videos"),
+        )
+
+
+def test_google_video_properties_reject_invalid_compression_quality() -> None:
+    """compression_quality must be one of the SDK enum values."""
+
+    with pytest.raises(ValueError, match="'OPTIMIZED' or 'LOSSLESS'"):
+        AIGoogleGeminiVideoProperties(
+            compression_quality="ultra",
+            output_dir=Path("/tmp/google-videos"),
+        )
+
+
+def test_google_video_properties_reject_non_gs_output_gcs_uri() -> None:
+    """output_gcs_uri must be a gs:// URI."""
+
+    with pytest.raises(ValueError, match="must be a gs:// URI"):
+        AIGoogleGeminiVideoProperties(
+            output_gcs_uri="https://example.com/out/",
+            output_dir=Path("/tmp/google-videos"),
+        )
+
+
+def test_google_video_submit_forwards_optional_config_fields() -> None:
+    """Newly exposed optional fields should forward into GenerateVideosConfig when set."""
+
+    operation: SimpleNamespace = SimpleNamespace(
+        done=False,
+        error=None,
+        name="models/veo-3.1-lite-generate-preview/operations/test-op",
+        response=None,
+    )
+    provider: _InspectableGoogleGeminiVideos = _InspectableGoogleGeminiVideos(operation)
+    properties: AIGoogleGeminiVideoProperties = AIGoogleGeminiVideoProperties(
+        negative_prompt="no text overlays",
+        enhance_prompt=True,
+        output_gcs_uri="gs://my-bucket/out/",
+        compression_quality="optimized",
+        output_dir=Path("/tmp/google-videos"),
+    )
+
+    provider.submit_video_generation("A lighthouse in a storm.", properties)
+
+    captured_call: dict[str, Any] = provider.client.models.calls[0]
+    config: Any = captured_call["config"]
+    assert config.negative_prompt == "no text overlays"
+    assert config.enhance_prompt is True
+    assert config.output_gcs_uri == "gs://my-bucket/out/"
+    assert config.compression_quality is not None
+    assert str(config.compression_quality).upper().endswith("OPTIMIZED")
+
+
 def test_google_video_submit_rejects_source_video_when_api_key_auth_is_selected(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_google_gemini_videos.py
+++ b/tests/test_google_gemini_videos.py
@@ -265,8 +265,7 @@ def test_google_video_submit_forwards_optional_config_fields() -> None:
     assert config.negative_prompt == "no text overlays"
     assert config.enhance_prompt is True
     assert config.output_gcs_uri == "gs://my-bucket/out/"
-    assert config.compression_quality is not None
-    assert str(config.compression_quality).upper().endswith("OPTIMIZED")
+    assert config.compression_quality == "OPTIMIZED"
 
 
 def test_google_video_submit_rejects_source_video_when_api_key_auth_is_selected(


### PR DESCRIPTION
## Summary

Closes #14.

Two-part fix for the Gemini video property layer:

- **Part A (must-fix):** the validator accepted `resolution=4k` and `person_generation=allow_all`, both of which the Google genai SDK / Veo API reject with a 400. `resolution=4k` was confirmed to cause a cryptic non-retryable 400 in production.
- **Part B (opt-in gaps):** expose four `GenerateVideosConfig` fields the adapter was not forwarding — `negative_prompt`, `enhance_prompt`, `output_gcs_uri`, `compression_quality`.
- **Version bump:** 2.5.2 → 2.5.3.

## Changes

| File | What changed |
|---|---|
| `src/ai_api_unified/videos/ai_google_gemini_videos.py` | Drop `4k` and `allow_all` from allowed lists; add 4 optional fields + validators; forward new fields into `GenerateVideosConfig` |
| `tests/test_google_gemini_videos.py` | 4 rejection tests + 1 forwarding test for new fields |
| `pyproject.toml` | Version 2.5.2 → 2.5.3 |
| `src/ai_api_unified/__version__.py` | Version 2.5.2 → 2.5.3 |

## Audit source

All allowed values and supported fields were cross-checked against the `GenerateVideosConfig` type definition in `google.genai.types` (the Google genai Python SDK).

## Out of scope

Model-dependent guardrails (e.g. Veo 3 audio support, Veo 2 duration range, 1080p availability by model). Tracked for a follow-up if callers need these beyond what the API enforces.

## Test plan

- [x] `poetry run pytest tests/test_google_gemini_videos.py` — 15/15 pass
- [x] Full unit suite (minus live-API nonmock tests): 285 pass
- [ ] Verify storyboard path with `resolution=720p` against Veo end-to-end

<!-- pr-review-prep:start -->
## PR Composition

Based on changed lines (added + deleted) vs. base branch `main`.

| Change Type | Lines Changed | Percentage |
|---|---:|---:|
| Core logic changes | 35 | 33% |
| Tests | 68 | 64% |
| Other | 4 | 3% |
| Total | 107 | 100% |
<!-- pr-review-prep:end -->

<!-- pr-content-attribution:start -->
## Content Attribution Summary

Based on changed lines across counted PR commits.

| Attribution Type | Commits | Lines Changed | Percentage |
|---|---:|---:|---:|
| AI-attributed | 3 | 111 | 100% |
| Human-attributed | 0 | 0 | 0% |
| Bot-attributed | 0 | 0 | 0% |
| Total | 3 | 111 | 100% |
<!-- pr-content-attribution:end -->