### PR TITLE
fix: include offending value in Gemini video validator errors (2.5.4)

### DIFF
--- a/.agents/memory/daily/2026-04-19/events/2026-04-19T22-37-21Z--2355287-davecthomas--thread_0407f408-a895-496a-9531-9bcfa6c94600--turn_40d0ff8d1f.md
+++ b/.agents/memory/daily/2026-04-19/events/2026-04-19T22-37-21Z--2355287-davecthomas--thread_0407f408-a895-496a-9531-9bcfa6c94600--turn_40d0ff8d1f.md
@@ -1,0 +1,49 @@
+---
+agentmemory_version: "0.4.4"
+timestamp: "2026-04-19T22:37:21Z"
+author: "2355287-davecthomas"
+branch: "fix/gemini-validator-error-messages-include-value"
+thread_id: "0407f408-a895-496a-9531-9bcfa6c94600"
+turn_id: "40d0ff8d1f"
+workstream_id: "thread-0407f408-a895-496a-9531-9bcfa6c94600"
+workstream_scope: "thread"
+episode_id: "episode-main-b34c818a56"
+episode_scope: "mixed"
+checkpoint_goal: "Keep the Google Gemini (Veo) video-properties validator a trustworthy fail-fast boundary so callers always receive actionable, debuggable errors when a Veo-unsupported field is set."
+checkpoint_surface: "AIGoogleGeminiVideoProperties._validate_google_video_properties in src/ai_api_unified/videos/ai_google_gemini_videos.py \u2014 the provider-owned pydantic validation layer that ADR-0008 assigns responsibility for Veo-specific capability enforcement."
+checkpoint_outcome: "All six validator rejection paths (fps, aspect_ratio, resolution, person_generation, compression_quality, output_gcs_uri) now interpolate the offending value into their ValueError message, and a regression test pins a general 'error names the offending value' contract via resolution='8k'."
+decision_candidate: false
+enriched: true
+ai_generated: true
+ai_model: "claude-unknown"
+ai_tool: "claude"
+ai_surface: "claude-code"
+ai_executor: "local-agent"
+related_adrs:
+files_touched:
+  - "src/ai_api_unified/videos/ai_google_gemini_videos.py"
+  - "tests/test_google_gemini_videos.py"
+design_docs_touched:
+verification:
+  - "git diff:  2 files changed, 27 insertions(+), 10 deletions(-); f\"Google Gemini (Veo) does not support the 'fps' parameter \"; f\"(received fps={self.fps!r}). Remove fps from your video \"; f\"properties for this provider.\""
+source_pending_shards:
+  - ".agents/memory/pending/2026-04-19/2026-04-19T22-37-21Z--2355287-davecthomas--thread_0407f408-a895-496a-9531-9bcfa6c94600--turn_40d0ff8d1f.md"
+---
+
+## Why
+
+- The prior fps-rejection fix introduced the pattern of naming the offending value in the error message, but the other five rejection paths still produced generic 'must be X' messages that left callers to re-read their config to guess what they had actually submitted. That asymmetry undermined the fail-fast Properties boundary: a caller who mistyped resolution='8k' or person_generation='allow_all' got a message describing the allowed set without echoing the rejected value, which is exactly the debuggability gap the Properties-layer validation is supposed to close (per the 2026-04-18 daily summary and ADR-0008's stance that providers own their capability surface). Aligning all six messages with the fps form preserves the contract the fps fix already made and keeps Veo-specific capability knowledge inside the provider module instead of leaking to remote errors or opaque local silence.
+
+## What changed
+
+- The six raise ValueError statements in _validate_google_video_properties were converted to f-strings that interpolate self.<field>!r into the message, mirroring the fps form ("received fps={self.fps!r}"). Existing test regexes for "must be ..." were loosened to [Mm]ust patterns because several messages now start the allowed-set clause mid-sentence after the interpolated value. A new positive-contract test, test_google_video_properties_rejection_message_includes_offending_value, uses resolution='8k' and matches r"resolution='8k'" to lock in that the offending value must appear in the raised message going forward. Net change is +27/-10 across the provider module and its test file; no behavior change beyond error-message content and the matching regex relaxations.
+
+## Evidence
+
+- src/ai_api_unified/videos/ai_google_gemini_videos.py: six ValueError messages in _validate_google_video_properties now include !r-formatted offending values for fps, aspect_ratio, resolution, person_generation, compression_quality, and output_gcs_uri. tests/test_google_gemini_videos.py: new test_google_video_properties_rejection_message_includes_offending_value regression test, plus three existing tests relaxed to [Mm]ust patterns. ADR-0008 (Explicit VIDEO_ENGINE selection required with provider-owned model defaults) anchors the provider-owned-validation boundary. The 2026-04-18 daily summary documents the fps-rejection precedent this turn generalizes, and flags the broader 'audit other video providers for the same silently-accepted-but-unsupported parameter pattern' follow-up. Active branch is fix/gemini-validator-error-messages-include-value, continuing the thread that produced merged PRs #12 (fps rejection) and #15 (audit / opt-in fields).
+
+## Next
+
+- Propagate the include-offending-value pattern to other video providers' Properties validators as part of the 2026-04-18 follow-up audit, so debuggability is uniform across vendors.
+- Consider lifting the 'rejection message names the offending value' rule into a shared contract (base-class helper or shared test fixture) rather than per-provider regex assertions.
+- Land this change through the normal PR flow so the new regression test gates future validator-message regressions.

--- a/.agents/memory/daily/2026-04-19/summary.md
+++ b/.agents/memory/daily/2026-04-19/summary.md
@@ -1,0 +1,41 @@
+# 2026-04-19 summary
+
+## Snapshot
+
+- Captured 1 memory event.
+- Main work: The six raise ValueError statements in _validate_google_video_properties were converted to f-strings that interpolate self.<field>!r into the message, mirroring the fps form ("received fps={self.fps!r}"). Existing test regexes for "must be ..." were loosened to [Mm]ust patterns because several messages now start the allowed-set clause mid-sentence after the interpolated value. A new positive-contract test, test_google_video_properties_rejection_message_includes_offending_value, uses resolution='8k' and matches r"resolution='8k'" to lock in that the offending value must appear in the raised message going forward. Net change is +27/-10 across the provider module and its test file; no behavior change beyond error-message content and the matching regex relaxations.
+- Top decision: None.
+- Blockers: None.
+
+| Metric | Value |
+|---|---|
+| Memory events captured | 1 |
+| Repo files changed | 1 |
+| Decision candidates | 0 |
+| Active blockers | 0 |
+
+## Major work completed
+
+- The six raise ValueError statements in _validate_google_video_properties were converted to f-strings that interpolate self.<field>!r into the message, mirroring the fps form ("received fps={self.fps!r}"). Existing test regexes for "must be ..." were loosened to [Mm]ust patterns because several messages now start the allowed-set clause mid-sentence after the interpolated value. A new positive-contract test, test_google_video_properties_rejection_message_includes_offending_value, uses resolution='8k' and matches r"resolution='8k'" to lock in that the offending value must appear in the raised message going forward. Net change is +27/-10 across the provider module and its test file; no behavior change beyond error-message content and the matching regex relaxations.
+
+## Why this mattered
+
+- The prior fps-rejection fix introduced the pattern of naming the offending value in the error message, but the other five rejection paths still produced generic 'must be X' messages that left callers to re-read their config to guess what they had actually submitted. That asymmetry undermined the fail-fast Properties boundary: a caller who mistyped resolution='8k' or person_generation='allow_all' got a message describing the allowed set without echoing the rejected value, which is exactly the debuggability gap the Properties-layer validation is supposed to close (per the 2026-04-18 daily summary and ADR-0008's stance that providers own their capability surface). Aligning all six messages with the fps form preserves the contract the fps fix already made and keeps Veo-specific capability knowledge inside the provider module instead of leaking to remote errors or opaque local silence.
+
+## Active blockers
+
+- None
+
+## Decision candidates
+
+- None
+
+## Next likely steps
+
+- Propagate the include-offending-value pattern to other video providers' Properties validators as part of the 2026-04-18 follow-up audit, so debuggability is uniform across vendors.
+- Consider lifting the 'rejection message names the offending value' rule into a shared contract (base-class helper or shared test fixture) rather than per-provider regex assertions.
+- Land this change through the normal PR flow so the new regression test gates future validator-message regressions.
+
+## Relevant event shards
+
+- [2026-04-19 22:37:21 UTC by 2355287-davecthomas](events/2026-04-19T22-37-21Z--2355287-davecthomas--thread_0407f408-a895-496a-9531-9bcfa6c94600--turn_40d0ff8d1f.md)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@
 [project]
 name = "ai_api_unified"
 
-version = "2.5.3" # keep in sync with src/ai_api_unified/__version__.py
+version = "2.5.4" # keep in sync with src/ai_api_unified/__version__.py
 description = "Unified access layer for AI completions (LLM), embedding (semantic), image, video, and voice services"
 authors = [{ name = "Dave Thomas", email = "davidcthomas@gmail.com" }]
 license = "MIT"

--- a/src/ai_api_unified/__version__.py
+++ b/src/ai_api_unified/__version__.py
@@ -9,4 +9,4 @@ from __future__ import annotations
 
 __all__: list[str] = ["__version__"]
 
-__version__: str = "2.5.3"
+__version__: str = "2.5.4"

--- a/src/ai_api_unified/videos/ai_google_gemini_videos.py
+++ b/src/ai_api_unified/videos/ai_google_gemini_videos.py
@@ -57,42 +57,49 @@ class AIGoogleGeminiVideoProperties(AIBaseVideoProperties):
     def _validate_google_video_properties(self) -> "AIGoogleGeminiVideoProperties":
         if self.fps is not None:
             raise ValueError(
-                "Google Gemini (Veo) does not support the 'fps' parameter. "
-                "Remove fps from your video properties for this provider."
+                f"Google Gemini (Veo) does not support the 'fps' parameter "
+                f"(received fps={self.fps!r}). Remove fps from your video "
+                f"properties for this provider."
             )
         if (
             self.aspect_ratio is not None
             and self.aspect_ratio not in self._ALLOWED_ASPECT_RATIOS
         ):
             raise ValueError(
-                "Google Gemini video aspect_ratio must be '16:9' or '9:16'."
+                f"Google Gemini video aspect_ratio={self.aspect_ratio!r} is "
+                f"not supported. Must be one of '16:9' or '9:16'."
             )
         if (
             self.resolution is not None
             and self.resolution not in self._ALLOWED_RESOLUTIONS
         ):
             raise ValueError(
-                "Google Gemini video resolution must be one of 720p or 1080p."
+                f"Google Gemini video resolution={self.resolution!r} is not "
+                f"supported. Must be one of 720p or 1080p."
             )
         if (
             self.person_generation is not None
             and self.person_generation not in self._ALLOWED_PERSON_GENERATION
         ):
             raise ValueError(
-                "Google Gemini person_generation must be one of dont_allow or allow_adult."
+                f"Google Gemini person_generation={self.person_generation!r} "
+                f"is not supported. Must be one of dont_allow or allow_adult."
             )
         if self.compression_quality is not None:
             normalized: str = self.compression_quality.upper()
             if normalized not in self._ALLOWED_COMPRESSION_QUALITY:
                 raise ValueError(
-                    "Google Gemini compression_quality must be 'OPTIMIZED' or 'LOSSLESS'."
+                    f"Google Gemini compression_quality="
+                    f"{self.compression_quality!r} is not supported. "
+                    f"Must be 'OPTIMIZED' or 'LOSSLESS'."
                 )
             self.compression_quality = normalized
         if self.output_gcs_uri is not None and not self.output_gcs_uri.startswith(
             "gs://"
         ):
             raise ValueError(
-                "Google Gemini output_gcs_uri must be a gs:// URI."
+                f"Google Gemini output_gcs_uri={self.output_gcs_uri!r} is "
+                f"not supported. Must be a gs:// URI."
             )
         return self
 

--- a/tests/test_google_gemini_videos.py
+++ b/tests/test_google_gemini_videos.py
@@ -203,9 +203,19 @@ def test_google_video_properties_reject_fps() -> None:
 def test_google_video_properties_reject_4k_resolution() -> None:
     """Veo does not support 4k — only 720p and 1080p are valid."""
 
-    with pytest.raises(ValueError, match="must be one of 720p or 1080p"):
+    with pytest.raises(ValueError, match=r"[Mm]ust be one of 720p or 1080p"):
         AIGoogleGeminiVideoProperties(
             resolution="4k",
+            output_dir=Path("/tmp/google-videos"),
+        )
+
+
+def test_google_video_properties_rejection_message_includes_offending_value() -> None:
+    """Error messages must name the offending value so callers can debug without guessing."""
+
+    with pytest.raises(ValueError, match=r"resolution='8k'"):
+        AIGoogleGeminiVideoProperties(
+            resolution="8k",
             output_dir=Path("/tmp/google-videos"),
         )
 
@@ -213,7 +223,7 @@ def test_google_video_properties_reject_4k_resolution() -> None:
 def test_google_video_properties_reject_allow_all_person_generation() -> None:
     """Veo only accepts dont_allow or allow_adult for person_generation."""
 
-    with pytest.raises(ValueError, match="must be one of dont_allow or allow_adult"):
+    with pytest.raises(ValueError, match=r"[Mm]ust be one of dont_allow or allow_adult"):
         AIGoogleGeminiVideoProperties(
             person_generation="allow_all",
             output_dir=Path("/tmp/google-videos"),
@@ -233,7 +243,7 @@ def test_google_video_properties_reject_invalid_compression_quality() -> None:
 def test_google_video_properties_reject_non_gs_output_gcs_uri() -> None:
     """output_gcs_uri must be a gs:// URI."""
 
-    with pytest.raises(ValueError, match="must be a gs:// URI"):
+    with pytest.raises(ValueError, match=r"[Mm]ust be a gs:// URI"):
         AIGoogleGeminiVideoProperties(
             output_gcs_uri="https://example.com/out/",
             output_dir=Path("/tmp/google-videos"),


### PR DESCRIPTION
## Summary

Immediate patch-level improvement while #16 tracks the larger per-model capability redesign.

- **Problem:** 2.5.3 surfaced a validator rejection (`resolution must be one of 720p or 1080p`) whose message did not include the offending value. Pydantic truncates the input dict in its default representation, so callers could not tell what they had actually passed.
- **Fix:** Each Gemini video validator error now embeds the offending value via `!r`, e.g. `resolution='4k' is not supported. Must be one of 720p or 1080p.`
- **Version bump:** 2.5.3 → 2.5.4.

## Why not more?

The bigger issue (no per-model capability awareness, hardcoded allowed sets, coerce-vs-raise policy) is tracked in #16. This PR is a low-risk debuggability patch so callers can self-diagnose validation failures while the larger redesign is in flight.

## Changes

| File | What changed |
|---|---|
| `src/ai_api_unified/videos/ai_google_gemini_videos.py` | Each validator error now embeds the offending value (fps, aspect_ratio, resolution, person_generation, compression_quality, output_gcs_uri) |
| `tests/test_google_gemini_videos.py` | Loosen existing regex matchers for new capitalization; add `test_google_video_properties_rejection_message_includes_offending_value` |
| `pyproject.toml` | Version 2.5.3 → 2.5.4 |
| `src/ai_api_unified/__version__.py` | Version 2.5.3 → 2.5.4 |

## Test plan

- [x] `poetry run pytest tests/test_google_gemini_videos.py` — 16/16 pass
- [ ] Confirm the new error text displays the offending value in the downstream caller's logs

<!-- pr-review-prep:start -->
## PR Composition

Based on changed lines (added + deleted) vs. base branch `main`.

| Change Type | Lines Changed | Percentage |
|---|---:|---:|
| Core logic changes | 21 | 51% |
| Tests | 16 | 39% |
| Other | 4 | 10% |
| Total | 41 | 100% |
<!-- pr-review-prep:end -->

<!-- pr-content-attribution:start -->
## Content Attribution Summary

Based on changed lines across counted PR commits.

| Attribution Type | Commits | Lines Changed | Percentage |
|---|---:|---:|---:|
| AI-attributed | 2 | 41 | 100% |
| Human-attributed | 0 | 0 | 0% |
| Bot-attributed | 0 | 0 | 0% |
| Total | 2 | 41 | 100% |
<!-- pr-content-attribution:end -->