### PR TITLE
feat: capability-gated streaming completions across providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -442,6 +442,32 @@ Optional service-account mode:
 
 This auth policy applies across Google completions, embeddings, images, videos, and voice.
 
+##### Google auth modes per capability
+
+The two `GOOGLE_AUTH_METHOD` values select different google-genai clients:
+`api_key` creates the Gemini Developer client
+(`genai.Client(api_key=...)`, generativelanguage endpoint) and
+`service_account` creates the Vertex client
+(`genai.Client(vertexai=True, project=..., location=...)`). Some capabilities
+work in only one client:
+
+| Google capability | `api_key` (Developer) | `service_account` (Vertex) | Notes |
+| --- | :---: | :---: | --- |
+| Completions (incl. streaming) | ✅ | ✅ | |
+| Text embeddings | ✅ | ✅ | |
+| Image generation (Imagen) | ✅ | ✅ | |
+| Multimodal (media) embeddings | ✅ | ❌ | the SDK sends only text parts to the Vertex embedding endpoint, so the library raises `NotImplementedError` when media is attached in Vertex mode |
+| Text-to-video with local download | ✅ | ❌ | downloaded via the Files API (`client.files.download`), which the SDK supports only in the Developer client; under Vertex set `download_outputs=False` to receive a remote `gs://` URI instead |
+| `source_video` (video continuation) | ❌ | ✅ | the library raises `NotImplementedError` in `api_key` mode; this path requires Vertex |
+| Voice (Gemini TTS / STT) | ⚠️ | ✅ | the library wires API keys into the Cloud TTS/STT clients, but Google may reject API keys that are not enabled for those APIs; `service_account` is the reliable mode |
+
+Pick the mode for what you need: multimodal-media embeddings and
+text-to-video-with-download require `api_key`, and `source_video` requires
+`service_account`. Running both families means switching `GOOGLE_AUTH_METHOD`
+between runs or constructing two clients. For a single call, `get_client(...,
+use_api_key=True)` on the shared Google base forces the Developer client
+without changing the environment.
+
 #### Azure TTS
 
 Required:

--- a/README.md
+++ b/README.md
@@ -156,6 +156,27 @@ response: str = client.send_prompt("Say hello in one short sentence.")
 print(response)
 ```
 
+### Streaming Completions
+
+Every completions client exposes a `capabilities` descriptor with a
+`supports_streaming` flag set per model. Models without streaming support raise
+`AiProviderCapabilityUnsupportedError` from `send_prompt_streaming`. OpenAI,
+Google Gemini, and Bedrock chat models all stream:
+
+```python
+from ai_api_unified import AIFactory
+
+client = AIFactory.get_ai_completions_client()
+
+if client.capabilities.supports_streaming:
+    for chunk in client.send_prompt_streaming("Tell me a short story."):
+        print(chunk, end="", flush=True)
+```
+
+Streaming is unavailable while the PII redaction middleware is enabled
+(`AiProviderConfigurationError`): redaction cannot be guaranteed across chunk
+boundaries, so use `send_prompt` in PII-redacting deployments.
+
 ### Embeddings
 
 ```python

--- a/src/ai_api_unified/ai_base.py
+++ b/src/ai_api_unified/ai_base.py
@@ -27,6 +27,7 @@ from ai_api_unified.ai_completions_exceptions import (
 )
 from ai_api_unified.ai_provider_exceptions import (
     AiProviderCapabilityUnsupportedError,
+    AiProviderConfigurationError,
 )
 from ai_api_unified.middleware.observability import (
     AiApiObservabilityMiddleware,
@@ -40,6 +41,7 @@ from ai_api_unified.middleware.observability_runtime import (
     TOKEN_COUNT_SOURCE_NONE,
     TOKEN_COUNT_SOURCE_PROVIDER,
     execute_observed_call,
+    execute_observed_streaming_call,
     get_observability_context,
     resolve_originating_caller,
 )
@@ -73,6 +75,7 @@ class AICompletionsCapabilitiesBase(BaseModel):
     reasoning: bool = False
     supported_data_types: list[SupportedDataType] = [SupportedDataType.TEXT]
     supports_data_residency_constraint: bool = False
+    supports_streaming: bool = False
 
 
 class AIIncludedMediaParamsBase(BaseModel):
@@ -1577,6 +1580,165 @@ class AIBaseCompletions(AIBase):
             prompt: The text prompt to send
             other_params: Optional provider-specific parameters
         """
+
+    @property
+    def capabilities(self) -> AICompletionsCapabilitiesBase:
+        """
+        Returns the capabilities descriptor for the configured completions model.
+
+        Providers override this with model-specific capabilities. The base
+        default describes a text-only, non-streaming model at the configured
+        context window.
+        """
+        # Normal return with conservative default completions capabilities.
+        return AICompletionsCapabilitiesBase(
+            context_window_length=self.max_context_tokens
+        )
+
+    def send_prompt_streaming(
+        self,
+        prompt: str,
+        *,
+        other_params: AICompletionsPromptParamsBase | None = None,
+    ) -> Iterator[str]:
+        """
+        Sends a prompt and yields response text chunks as the provider streams them.
+
+        Template method: capability and configuration gating happen here so
+        providers cannot skip them. Providers whose capabilities declare
+        streaming support implement _send_prompt_streaming_provider.
+
+        Args:
+            prompt: The text prompt to send.
+            other_params: Optional provider-specific parameters.
+
+        Returns:
+            Iterator of response text chunks in provider order.
+
+        Raises:
+            AiProviderCapabilityUnsupportedError: When the configured model does
+                not support streaming completions.
+            AiProviderConfigurationError: When PII redaction middleware is
+                enabled; chunk-boundary redaction cannot be guaranteed for
+                streamed output.
+        """
+        if not prompt or not prompt.strip():
+            raise ValueError("Prompt cannot be empty or None")
+        if not self.capabilities.supports_streaming:
+            raise AiProviderCapabilityUnsupportedError(
+                f"{type(self).__name__} model '{self.model_name}' does not support "
+                "streaming completions. Use send_prompt, or configure a model whose "
+                "capabilities include streaming."
+            )
+        if self.pii_middleware.bool_enabled:
+            raise AiProviderConfigurationError(
+                "Streaming completions are unavailable while PII redaction "
+                "middleware is enabled: redaction cannot be guaranteed across "
+                "stream chunk boundaries. Use send_prompt, or disable the PII "
+                "redaction middleware profile."
+            )
+        # Normal return with the provider-implemented streaming iterator.
+        return self._send_prompt_streaming_provider(prompt, other_params=other_params)
+
+    def _send_prompt_streaming_provider(
+        self,
+        prompt: str,
+        *,
+        other_params: AICompletionsPromptParamsBase | None = None,
+    ) -> Iterator[str]:
+        """
+        Provider hook for streaming completion generation.
+
+        The base implementation raises: a provider whose capabilities declare
+        streaming support must implement this hook.
+
+        Args:
+            prompt: Validated text prompt to send.
+            other_params: Optional provider-specific parameters.
+
+        Raises:
+            AiProviderCapabilityUnsupportedError: Always, in the base class.
+        """
+        raise AiProviderCapabilityUnsupportedError(
+            f"{type(self).__name__} does not implement streaming completions."
+        )
+
+    def _execute_streaming_provider_call_with_observability(
+        self,
+        *,
+        operation: str,
+        dict_input_metadata: dict[str, ObservabilityMetadataValue] | None,
+        callable_open_stream: Callable[[], Iterator[str]],
+        callable_build_result_summary: Callable[[float], AiApiCallResultSummaryModel],
+        legacy_caller_id: str | None = None,
+    ) -> Iterator[str]:
+        """
+        Wraps one streaming provider call with shared observability lifecycle helpers.
+
+        Args:
+            operation: Public operation name such as `send_prompt_streaming`.
+            dict_input_metadata: Optional scalar request metadata safe for input-event logs.
+            callable_open_stream: Zero-argument callable that opens the provider stream.
+            callable_build_result_summary: Callable that summarizes accumulated output
+                using elapsed milliseconds; caller-owned accumulators supply output state.
+            legacy_caller_id: Optional explicit legacy caller hint supplied by existing config.
+
+        Returns:
+            Iterator of caller-facing stream chunks with observability emission attached.
+        """
+        # Normal return with the observability-wrapped streaming iterator.
+        return execute_observed_streaming_call(
+            observability_middleware=self._get_observability_middleware(),
+            callable_build_call_context=lambda: self._build_observability_call_context(
+                capability=self.CLIENT_TYPE_COMPLETIONS,
+                operation=operation,
+                dict_metadata=dict_input_metadata,
+                legacy_caller_id=legacy_caller_id,
+            ),
+            callable_open_stream=callable_open_stream,
+            callable_build_result_summary=callable_build_result_summary,
+        )
+
+    def _build_streaming_completions_observability_result_summary(
+        self,
+        *,
+        observed_result: AiApiObservedCompletionsResultModel[str],
+        provider_elapsed_ms: float,
+        int_chunk_count: int,
+        bool_stream_completed: bool,
+    ) -> AiApiCallResultSummaryModel:
+        """
+        Builds metadata-only output fields for one observed streaming completion.
+
+        Args:
+            observed_result: Accumulated stream state shaped as an observed completions result.
+            provider_elapsed_ms: Elapsed milliseconds spanning the full stream consumption.
+            int_chunk_count: Number of text chunks yielded to the caller.
+            bool_stream_completed: False when the caller abandoned the stream early.
+
+        Returns:
+            AiApiCallResultSummaryModel containing output metadata safe for observability logging.
+        """
+        call_result_summary: AiApiCallResultSummaryModel = (
+            self._build_completions_observability_result_summary(
+                observed_result=AiApiObservedCompletionsResultModel(
+                    return_value=observed_result.return_value,
+                    raw_output_text=observed_result.raw_output_text,
+                    finish_reason=observed_result.finish_reason,
+                    provider_prompt_tokens=observed_result.provider_prompt_tokens,
+                    provider_completion_tokens=observed_result.provider_completion_tokens,
+                    provider_total_tokens=observed_result.provider_total_tokens,
+                    dict_metadata={
+                        "stream_chunk_count": int_chunk_count,
+                        "stream_completed": bool_stream_completed,
+                        **observed_result.dict_metadata,
+                    },
+                ),
+                provider_elapsed_ms=provider_elapsed_ms,
+            )
+        )
+        # Normal return with the streaming completions output summary.
+        return call_result_summary
 
 
 class AIBaseImageProperties(BaseModel):

--- a/src/ai_api_unified/completions/ai_bedrock_completions.py
+++ b/src/ai_api_unified/completions/ai_bedrock_completions.py
@@ -2,6 +2,7 @@
 
 import json
 import logging
+from collections.abc import Iterator
 from typing import Any, ClassVar, Type
 
 from pydantic import ValidationError
@@ -11,14 +12,42 @@ from ..ai_base import (
     AIBaseCompletions,
     AiApiObservedCompletionsResultModel,
     AIStructuredPrompt,
+    AICompletionsCapabilitiesBase,
     AICompletionsPromptParamsBase,
     SupportedDataType,
 )
 from ..ai_bedrock_base import AIBedrockBase, ClientError
-from ..middleware.observability_runtime import ObservabilityMetadataValue
+from ..middleware.observability_runtime import (
+    AiApiCallResultSummaryModel,
+    ObservabilityMetadataValue,
+)
 from ..util.env_settings import EnvSettings
 
 _LOGGER: logging.Logger = logging.getLogger(__name__)
+
+
+class AICompletionsCapabilitiesBedrock(AICompletionsCapabilitiesBase):
+    """
+    Bedrock-specific completions capabilities.
+
+    Based on https://docs.aws.amazon.com/bedrock/latest/userguide/conversation-inference.html
+    """
+
+    @classmethod
+    def for_model(
+        cls,
+        model_name: str,
+        *,
+        context_window_length: int,
+    ) -> "AICompletionsCapabilitiesBedrock":
+        """Create capabilities instance for the requested Bedrock model."""
+        # Normal return with Bedrock capabilities; every chat model this client
+        # targets streams via the ConverseStream API.
+        return cls(
+            context_window_length=context_window_length,
+            supported_data_types=[SupportedDataType.TEXT, SupportedDataType.IMAGE],
+            supports_streaming=True,
+        )
 
 
 class AiBedrockCompletions(AIBedrockBase, AIBaseCompletions):
@@ -85,6 +114,14 @@ class AiBedrockCompletions(AIBedrockBase, AIBaseCompletions):
             "amazon.nova-premier-v1:0",
             "us.anthropic.claude-3-5-haiku-20241022-v1:0",
         ]
+
+    @property
+    def capabilities(self) -> AICompletionsCapabilitiesBedrock:
+        """Return model capabilities for the current Bedrock model."""
+        return AICompletionsCapabilitiesBedrock.for_model(
+            self.completions_model,
+            context_window_length=self.max_context_tokens,
+        )
 
     def _extract_json_text_from_converse_response(self, resp: dict[str, Any]) -> str:
         content = resp.get("output", {}).get("message", {}).get("content", [])
@@ -406,6 +443,118 @@ class AiBedrockCompletions(AIBedrockBase, AIBaseCompletions):
         )
         # Normal return with sanitized Bedrock text output after observability wrapping.
         return sanitized_output
+
+    def _send_prompt_streaming_provider(
+        self,
+        prompt: str,
+        *,
+        other_params: AICompletionsPromptParamsBase | None = None,
+    ) -> Iterator[str]:
+        """
+        Stream a text prompt response from Bedrock's ConverseStream API chunk by chunk.
+
+        Capability and PII gating already ran in the base template method.
+        There is no retry wrapper: retrying a partially consumed stream would
+        duplicate output.
+
+        Args:
+            prompt: Validated text prompt to send.
+            other_params: Optional provider-specific parameters.
+
+        Returns:
+            Iterator of response text chunks in provider order.
+        """
+        user_content: list[dict[str, Any]] = self._build_user_content(
+            prompt, other_params
+        )
+        messages = [{"role": "user", "content": user_content}]
+        system_prompt: str = (
+            other_params.system_prompt
+            if other_params is not None and other_params.system_prompt is not None
+            else AICompletionsPromptParamsBase.DEFAULT_SYSTEM_PROMPT
+        )
+        inference_config = {"temperature": 0.2, "topP": 0.85, "maxTokens": 256}
+        dict_input_metadata: dict[str, ObservabilityMetadataValue] = (
+            self._build_completions_observability_input_metadata(
+                prompt=prompt,
+                system_prompt=system_prompt,
+                other_params=other_params,
+                response_mode=self.RESPONSE_MODE_TEXT,
+            )
+        )
+        dict_input_metadata["response_streaming"] = True
+
+        dict_stream_state: dict[str, Any] = {
+            "list_text_parts": [],
+            "int_chunk_count": 0,
+            "finish_reason": None,
+            "metadata_event": None,
+            "bool_completed": False,
+        }
+
+        def _open_stream() -> Iterator[str]:
+            response = self.client.converse_stream(
+                modelId=self.model,
+                messages=messages,
+                system=[{"text": system_prompt}],
+                inferenceConfig=inference_config,
+            )
+            # Loop through ConverseStream events so callers see text as it arrives.
+            for event in response.get("stream", []):
+                if "contentBlockDelta" in event:
+                    str_chunk_text: str = (
+                        event["contentBlockDelta"].get("delta", {}).get("text", "")
+                    )
+                    if str_chunk_text:
+                        dict_stream_state["int_chunk_count"] += 1
+                        dict_stream_state["list_text_parts"].append(str_chunk_text)
+                        yield str_chunk_text
+                elif "messageStop" in event:
+                    dict_stream_state["finish_reason"] = str(
+                        event["messageStop"].get("stopReason", "")
+                    )
+                elif "metadata" in event:
+                    dict_stream_state["metadata_event"] = event["metadata"]
+            dict_stream_state["bool_completed"] = True
+
+        def _build_summary(provider_elapsed_ms: float) -> AiApiCallResultSummaryModel:
+            # ConverseStream reports usage in the terminal metadata event using the
+            # same shape as the synchronous converse response.
+            dict_usage_response: dict[str, Any] = (
+                dict_stream_state["metadata_event"] or {}
+            )
+            str_full_text: str = "".join(dict_stream_state["list_text_parts"])
+            observed_result: AiApiObservedCompletionsResultModel[str] = (
+                AiApiObservedCompletionsResultModel(
+                    return_value=str_full_text,
+                    raw_output_text=str_full_text,
+                    finish_reason=dict_stream_state["finish_reason"],
+                    provider_prompt_tokens=self._extract_bedrock_prompt_tokens(
+                        dict_usage_response
+                    ),
+                    provider_completion_tokens=self._extract_bedrock_completion_tokens(
+                        dict_usage_response
+                    ),
+                    provider_total_tokens=self._extract_bedrock_total_tokens(
+                        dict_usage_response
+                    ),
+                )
+            )
+            # Normal return with the streaming summary built from accumulated events.
+            return self._build_streaming_completions_observability_result_summary(
+                observed_result=observed_result,
+                provider_elapsed_ms=provider_elapsed_ms,
+                int_chunk_count=dict_stream_state["int_chunk_count"],
+                bool_stream_completed=dict_stream_state["bool_completed"],
+            )
+
+        # Normal return with the observability-wrapped Bedrock stream.
+        return self._execute_streaming_provider_call_with_observability(
+            operation="send_prompt_streaming",
+            dict_input_metadata=dict_input_metadata,
+            callable_open_stream=_open_stream,
+            callable_build_result_summary=_build_summary,
+        )
 
     @staticmethod
     def _extract_bedrock_prompt_tokens(response: dict[str, Any]) -> int | None:

--- a/src/ai_api_unified/completions/ai_google_gemini_capabilities.py
+++ b/src/ai_api_unified/completions/ai_google_gemini_capabilities.py
@@ -30,6 +30,8 @@ class AICompletionsCapabilitiesGoogle(AICompletionsCapabilitiesBase):
                 SupportedDataType.AUDIO,
                 SupportedDataType.PDF,
             ],
+            # All Gemini chat models stream via generate_content_stream.
+            "supports_streaming": True,
         }
 
         # Model-specific capabilities

--- a/src/ai_api_unified/completions/ai_google_gemini_completions.py
+++ b/src/ai_api_unified/completions/ai_google_gemini_completions.py
@@ -31,6 +31,7 @@ from __future__ import annotations
 import base64
 import json
 import logging
+from collections.abc import Iterator
 from typing import Any, Type
 
 from google import genai
@@ -51,7 +52,10 @@ from ..ai_base import (
     AICompletionsPromptParamsBase,
     SupportedDataType,
 )
-from ..middleware.observability_runtime import ObservabilityMetadataValue
+from ..middleware.observability_runtime import (
+    AiApiCallResultSummaryModel,
+    ObservabilityMetadataValue,
+)
 from ..util.env_settings import EnvSettings
 from .ai_google_gemini_capabilities import (
     AICompletionsCapabilitiesGoogle,
@@ -318,6 +322,115 @@ class GoogleGeminiCompletions(AIBaseCompletions, AIGoogleBase):
         )
         # Normal return with sanitized Gemini text after observability wrapping.
         return sanitized_output
+
+    def _send_prompt_streaming_provider(
+        self,
+        prompt: str,
+        *,
+        other_params: AICompletionsPromptParamsBase | None = None,
+    ) -> Iterator[str]:
+        """
+        Stream a text prompt response from Google Gemini chunk by chunk.
+
+        Capability and PII gating already ran in the base template method, so
+        the streamed chunks are yielded to the caller unmodified. There is no
+        retry wrapper: retrying a partially consumed stream would duplicate
+        output.
+
+        Args:
+            prompt: Validated text prompt to send.
+            other_params: Optional Google-specific parameters (AICompletionsPromptParamsGoogle).
+
+        Returns:
+            Iterator of response text chunks in provider order.
+        """
+        params = self._coerce_params(other_params)
+        system_prompt: str | None = params.system_prompt
+        dict_input_metadata: dict[str, ObservabilityMetadataValue] = (
+            self._build_completions_observability_input_metadata(
+                prompt=prompt,
+                system_prompt=system_prompt,
+                other_params=params,
+                response_mode=self.RESPONSE_MODE_TEXT,
+            )
+        )
+        dict_input_metadata["response_streaming"] = True
+
+        dict_stream_state: dict[str, Any] = {
+            "list_text_parts": [],
+            "int_chunk_count": 0,
+            "last_chunk": None,
+            "bool_completed": False,
+        }
+
+        def _open_stream() -> Iterator[str]:
+            contents: list[dict[str, Any]] = self._build_contents(
+                prompt=prompt, params=params
+            )
+            config: genai.types.GenerateContentConfig = self._build_config(
+                params=params,
+                system_prompt=system_prompt,
+                max_output_tokens=params.max_output_tokens,
+            )
+            stream = self.client.models.generate_content_stream(
+                model=self.completions_model,
+                contents=contents,
+                config=config,
+            )
+            # Loop through provider chunks so callers see text as it arrives.
+            for chunk in stream:
+                dict_stream_state["last_chunk"] = chunk
+                str_chunk_text: str | None = chunk.text
+                if str_chunk_text:
+                    dict_stream_state["int_chunk_count"] += 1
+                    dict_stream_state["list_text_parts"].append(str_chunk_text)
+                    yield str_chunk_text
+            dict_stream_state["bool_completed"] = True
+
+        def _build_summary(provider_elapsed_ms: float) -> AiApiCallResultSummaryModel:
+            last_chunk = dict_stream_state["last_chunk"]
+            str_full_text: str = "".join(dict_stream_state["list_text_parts"])
+            observed_result: AiApiObservedCompletionsResultModel[str] = (
+                AiApiObservedCompletionsResultModel(
+                    return_value=str_full_text,
+                    raw_output_text=str_full_text,
+                    finish_reason=(
+                        self._extract_gemini_finish_reason(last_chunk)
+                        if last_chunk is not None
+                        else None
+                    ),
+                    provider_prompt_tokens=(
+                        self._extract_gemini_prompt_tokens(last_chunk)
+                        if last_chunk is not None
+                        else None
+                    ),
+                    provider_completion_tokens=(
+                        self._extract_gemini_completion_tokens(last_chunk)
+                        if last_chunk is not None
+                        else None
+                    ),
+                    provider_total_tokens=(
+                        self._extract_gemini_total_tokens(last_chunk)
+                        if last_chunk is not None
+                        else None
+                    ),
+                )
+            )
+            # Normal return with the streaming summary built from accumulated chunks.
+            return self._build_streaming_completions_observability_result_summary(
+                observed_result=observed_result,
+                provider_elapsed_ms=provider_elapsed_ms,
+                int_chunk_count=dict_stream_state["int_chunk_count"],
+                bool_stream_completed=dict_stream_state["bool_completed"],
+            )
+
+        # Normal return with the observability-wrapped Gemini stream.
+        return self._execute_streaming_provider_call_with_observability(
+            operation="send_prompt_streaming",
+            dict_input_metadata=dict_input_metadata,
+            callable_open_stream=_open_stream,
+            callable_build_result_summary=_build_summary,
+        )
 
     def strict_schema_prompt(
         self,

--- a/src/ai_api_unified/completions/ai_openai_completions.py
+++ b/src/ai_api_unified/completions/ai_openai_completions.py
@@ -4,6 +4,7 @@ import base64
 import json
 import logging
 import time
+from collections.abc import Iterator
 from datetime import date
 from typing import Any, ClassVar, Type
 
@@ -22,7 +23,10 @@ from ..ai_base import (
     AICompletionsPromptParamsBase,
     SupportedDataType,
 )
-from ..middleware.observability_runtime import ObservabilityMetadataValue
+from ..middleware.observability_runtime import (
+    AiApiCallResultSummaryModel,
+    ObservabilityMetadataValue,
+)
 
 
 _LOGGER: logging.Logger = logging.getLogger(__name__)
@@ -44,6 +48,8 @@ class AICompletionsCapabilitiesOpenAI(AICompletionsCapabilitiesBase):
             SupportedDataType.AUDIO,
         ],
         "supports_data_residency_constraint": True,
+        # All supported chat models stream via chat.completions stream=True.
+        "supports_streaming": True,
     }
 
     # Context window sizes (max tokens each model can handle)
@@ -595,6 +601,121 @@ class AiOpenAICompletions(AIOpenAIBase, AIBaseCompletions):
         except Exception as e:
             _LOGGER.exception("An error occurred while sending the prompt: %s", e)
             raise
+
+    def _send_prompt_streaming_provider(
+        self,
+        prompt: str,
+        *,
+        other_params: AICompletionsPromptParamsBase | None = None,
+    ) -> Iterator[str]:
+        """
+        Stream a chat completion response from OpenAI chunk by chunk.
+
+        Capability and PII gating already ran in the base template method.
+        Unlike send_prompt, streaming does not auto-continue on a `length`
+        finish reason: the caller sees exactly one provider stream. There is
+        no retry wrapper: retrying a partially consumed stream would duplicate
+        output.
+
+        Args:
+            prompt: Validated text prompt to send.
+            other_params: Optional provider-specific parameters.
+
+        Returns:
+            Iterator of response text chunks in provider order.
+        """
+        system_prompt: str = (
+            other_params.system_prompt
+            if other_params is not None and other_params.system_prompt is not None
+            else AICompletionsPromptParamsBase.DEFAULT_SYSTEM_PROMPT
+        )
+        user_content = self._build_user_message_content(prompt, other_params)
+        dict_input_metadata: dict[str, ObservabilityMetadataValue] = (
+            self._build_completions_observability_input_metadata(
+                prompt=prompt,
+                system_prompt=system_prompt,
+                other_params=other_params,
+                response_mode=self.RESPONSE_MODE_TEXT,
+            )
+        )
+        dict_input_metadata["response_streaming"] = True
+
+        dict_stream_state: dict[str, Any] = {
+            "list_text_parts": [],
+            "int_chunk_count": 0,
+            "finish_reason": None,
+            "usage_chunk": None,
+            "bool_completed": False,
+        }
+
+        def _open_stream() -> Iterator[str]:
+            stream = self.client.chat.completions.create(
+                model=self.completions_model,
+                messages=[
+                    {"role": "system", "content": system_prompt},
+                    {"role": "user", "content": user_content},
+                ],
+                stream=True,
+                stream_options={"include_usage": True},
+            )
+            # Loop through provider chunks so callers see text as it arrives.
+            for chunk in stream:
+                if chunk.usage is not None:
+                    dict_stream_state["usage_chunk"] = chunk
+                if not chunk.choices:
+                    # Usage-only terminal chunk carries no delta content.
+                    continue
+                choice = chunk.choices[0]
+                if choice.finish_reason is not None:
+                    dict_stream_state["finish_reason"] = str(choice.finish_reason)
+                str_chunk_text: str | None = choice.delta.content
+                if str_chunk_text:
+                    dict_stream_state["int_chunk_count"] += 1
+                    dict_stream_state["list_text_parts"].append(str_chunk_text)
+                    yield str_chunk_text
+            dict_stream_state["bool_completed"] = True
+
+        def _build_summary(provider_elapsed_ms: float) -> AiApiCallResultSummaryModel:
+            usage_chunk = dict_stream_state["usage_chunk"]
+            str_full_text: str = "".join(dict_stream_state["list_text_parts"])
+            observed_result: AiApiObservedCompletionsResultModel[str] = (
+                AiApiObservedCompletionsResultModel(
+                    return_value=str_full_text,
+                    raw_output_text=str_full_text,
+                    finish_reason=dict_stream_state["finish_reason"],
+                    provider_prompt_tokens=(
+                        self._extract_openai_prompt_tokens(usage_chunk)
+                        if usage_chunk is not None
+                        else None
+                    ),
+                    provider_completion_tokens=(
+                        self._extract_openai_completion_tokens(usage_chunk)
+                        if usage_chunk is not None
+                        else None
+                    ),
+                    provider_total_tokens=(
+                        self._extract_openai_total_tokens(usage_chunk)
+                        if usage_chunk is not None
+                        else None
+                    ),
+                )
+            )
+            # Normal return with the streaming summary built from accumulated chunks.
+            return self._build_streaming_completions_observability_result_summary(
+                observed_result=observed_result,
+                provider_elapsed_ms=provider_elapsed_ms,
+                int_chunk_count=dict_stream_state["int_chunk_count"],
+                bool_stream_completed=dict_stream_state["bool_completed"],
+            )
+
+        # Normal return with the observability-wrapped OpenAI stream.
+        return self._execute_streaming_provider_call_with_observability(
+            operation="send_prompt_streaming",
+            dict_input_metadata=dict_input_metadata,
+            callable_open_stream=_open_stream,
+            callable_build_result_summary=_build_summary,
+            legacy_caller_id=self.user,
+        )
 
     @staticmethod
     def _extract_openai_prompt_tokens(completion: Any) -> int | None:

--- a/src/ai_api_unified/middleware/observability_runtime.py
+++ b/src/ai_api_unified/middleware/observability_runtime.py
@@ -12,7 +12,7 @@ from dataclasses import dataclass, field, replace
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING, TypeVar
 
-from collections.abc import Callable, Mapping
+from collections.abc import Callable, Iterator, Mapping
 
 if TYPE_CHECKING:
     from ai_api_unified.middleware.observability import (
@@ -387,6 +387,123 @@ def execute_observed_call(
     )
     # Normal return with the original provider result after observability emission.
     return provider_result
+
+
+def execute_observed_streaming_call(
+    *,
+    observability_middleware: AiApiObservabilityMiddleware,
+    callable_build_call_context: Callable[[], AiApiCallContextModel],
+    callable_open_stream: Callable[[], Iterator[str]],
+    callable_build_result_summary: Callable[[float], AiApiCallResultSummaryModel],
+) -> Iterator[str]:
+    """
+    Wraps one streaming provider call with shared observability lifecycle emission.
+
+    Mirrors execute_observed_call for generator-shaped provider calls: the
+    input event fires before the stream opens, elapsed time spans the full
+    stream consumption, and the output event fires when the stream is
+    exhausted or abandoned by the caller.
+
+    Args:
+        observability_middleware: Effective observability middleware implementation for the call.
+        callable_build_call_context: Zero-argument callable that builds the shared call context
+            only when observability is enabled.
+        callable_open_stream: Zero-argument callable that opens the provider stream and
+            returns an iterator of caller-facing chunks.
+        callable_build_result_summary: Callable that summarizes accumulated provider output
+            using elapsed milliseconds; caller-owned accumulators supply the output state.
+
+    Yields:
+        Caller-facing stream chunks unchanged from `callable_open_stream`.
+
+    Raises:
+        Propagates the original provider exception unchanged when the stream fails.
+    """
+    if not observability_middleware.bool_enabled:
+        # Early yield-through because observability is disabled and the stream is unchanged.
+        yield from callable_open_stream()
+        return
+
+    try:
+        call_context: AiApiCallContextModel = callable_build_call_context()
+    except Exception as exception:
+        _LOGGER.warning(
+            OBSERVABILITY_CONTEXT_HOOK_FAILURE_LOG_MESSAGE,
+            "build_call_context",
+            exception.__class__.__name__,
+        )
+        # Early yield-through because call-context construction failed and observability fails open.
+        yield from callable_open_stream()
+        return
+
+    _safe_emit_observability_hook(
+        stage="before_call",
+        callable_emit=lambda: observability_middleware.before_call(
+            call_context=call_context.with_direction(OBSERVABILITY_DIRECTION_INPUT)
+        ),
+    )
+
+    float_started_at: float = time.perf_counter()
+    bool_output_event_emitted: bool = False
+
+    def _emit_output_event() -> None:
+        """Emits the after-call summary exactly once per stream lifecycle."""
+        nonlocal bool_output_event_emitted
+        if bool_output_event_emitted:
+            # Early return because the output event already fired for this stream.
+            return None
+        bool_output_event_emitted = True
+        provider_elapsed_ms: float = (time.perf_counter() - float_started_at) * 1000.0
+        try:
+            call_result_summary: AiApiCallResultSummaryModel = (
+                callable_build_result_summary(provider_elapsed_ms)
+            )
+        except Exception as exception:
+            _LOGGER.warning(
+                OBSERVABILITY_CONTEXT_HOOK_FAILURE_LOG_MESSAGE,
+                "build_result_summary",
+                exception.__class__.__name__,
+            )
+            # Early return because result-summary construction failed and observability fails open.
+            return None
+        _safe_emit_observability_hook(
+            stage="after_call",
+            callable_emit=lambda: observability_middleware.after_call(
+                call_context=call_context.with_direction(
+                    OBSERVABILITY_DIRECTION_OUTPUT
+                ),
+                call_result_summary=call_result_summary,
+            ),
+        )
+        # Normal return after emitting the streaming output event.
+        return None
+
+    try:
+        # Loop through provider chunks so callers stream output while observability accrues.
+        for str_chunk in callable_open_stream():
+            yield str_chunk
+    except GeneratorExit:
+        # The caller abandoned the stream; summarize what was consumed so far.
+        _emit_output_event()
+        raise
+    except Exception as exception:
+        caught_exception: Exception = exception
+        bool_output_event_emitted = True
+        provider_elapsed_ms = (time.perf_counter() - float_started_at) * 1000.0
+        _safe_emit_observability_hook(
+            stage="on_error",
+            callable_emit=lambda: observability_middleware.on_error(
+                call_context=call_context.with_direction(OBSERVABILITY_DIRECTION_ERROR),
+                exception=caught_exception,
+                float_elapsed_ms=provider_elapsed_ms,
+            ),
+        )
+        # Early return via re-raise because provider exception behavior must remain unchanged.
+        raise
+
+    _emit_output_event()
+    # Normal return after the stream is exhausted and the output event has fired.
+    return
 
 
 def _safe_emit_observability_hook(

--- a/tests/test_completions_streaming.py
+++ b/tests/test_completions_streaming.py
@@ -1,0 +1,338 @@
+# test_completions_streaming.py
+"""
+Tests for streaming completions support.
+
+Covers:
+    - supports_streaming capability flags per provider
+    - Base-class template gating (capability, PII configuration, empty prompt)
+    - execute_observed_streaming_call lifecycle (events, abandonment, errors)
+    - Provider stream call shape and chunk forwarding with mocked SDK clients
+"""
+
+import os
+from typing import Any
+from unittest.mock import Mock, patch
+
+import pytest
+
+from ai_api_unified.ai_base import (
+    AIBaseCompletions,
+    AICompletionsCapabilitiesBase,
+    AICompletionsPromptParamsBase,
+    AIStructuredPrompt,
+)
+from ai_api_unified.ai_provider_exceptions import (
+    AiProviderCapabilityUnsupportedError,
+    AiProviderConfigurationError,
+)
+from ai_api_unified.middleware.observability_runtime import (
+    execute_observed_streaming_call,
+)
+
+
+class _StubCompletions(AIBaseCompletions):
+    """Minimal concrete completions client relying on base-class defaults."""
+
+    def __init__(self) -> None:
+        super().__init__(model="stub-model")
+
+    @property
+    def list_model_names(self) -> list[str]:
+        return ["stub-model"]
+
+    @property
+    def max_context_tokens(self) -> int:
+        return 1000
+
+    @property
+    def price_per_1k_tokens(self) -> float:
+        return 0.0
+
+    def send_prompt(
+        self, prompt: str, *, other_params: AICompletionsPromptParamsBase | None = None
+    ) -> str:
+        return "stub"
+
+    def strict_schema_prompt(
+        self,
+        prompt: str,
+        response_model: type[AIStructuredPrompt],
+        max_response_tokens: int = AIBaseCompletions.STRUCTURED_DEFAULT_MAX_RESPONSE_TOKENS,
+        *,
+        other_params: AICompletionsPromptParamsBase | None = None,
+    ) -> AIStructuredPrompt:
+        raise NotImplementedError
+
+
+class _StreamingStubCompletions(_StubCompletions):
+    """Stub whose capabilities declare streaming support."""
+
+    @property
+    def capabilities(self) -> AICompletionsCapabilitiesBase:
+        return AICompletionsCapabilitiesBase(
+            context_window_length=1000, supports_streaming=True
+        )
+
+    def _send_prompt_streaming_provider(self, prompt, *, other_params=None):
+        yield "chunk-1"
+        yield "chunk-2"
+
+
+class TestStreamingCapabilityFlags:
+    """supports_streaming values across capability descriptors."""
+
+    def test_base_default_is_off(self) -> None:
+        capabilities = AICompletionsCapabilitiesBase(context_window_length=1)
+        assert capabilities.supports_streaming is False
+
+    def test_google_models_support_streaming(self) -> None:
+        pytest.importorskip("google.genai")
+        from ai_api_unified.completions.ai_google_gemini_capabilities import (
+            AICompletionsCapabilitiesGoogle,
+        )
+
+        assert (
+            AICompletionsCapabilitiesGoogle.for_model(
+                "gemini-2.5-flash"
+            ).supports_streaming
+            is True
+        )
+
+    def test_openai_models_support_streaming(self) -> None:
+        pytest.importorskip("openai")
+        from ai_api_unified.completions.ai_openai_completions import (
+            AICompletionsCapabilitiesOpenAI,
+        )
+
+        assert (
+            AICompletionsCapabilitiesOpenAI.for_model("gpt-4o-mini").supports_streaming
+            is True
+        )
+
+    def test_bedrock_models_support_streaming(self) -> None:
+        pytest.importorskip("boto3")
+        from ai_api_unified.completions.ai_bedrock_completions import (
+            AICompletionsCapabilitiesBedrock,
+        )
+
+        capabilities = AICompletionsCapabilitiesBedrock.for_model(
+            "amazon.nova-lite-v1:0", context_window_length=8_192_000
+        )
+        assert capabilities.supports_streaming is True
+
+
+class TestBaseStreamingGates:
+    """Template-method gating on AIBaseCompletions.send_prompt_streaming."""
+
+    def test_non_streaming_model_raises_capability_error(self) -> None:
+        client = _StubCompletions()
+        with pytest.raises(
+            AiProviderCapabilityUnsupportedError, match="does not support streaming"
+        ):
+            client.send_prompt_streaming("hello")
+
+    def test_empty_prompt_raises_value_error(self) -> None:
+        client = _StreamingStubCompletions()
+        with pytest.raises(ValueError, match="cannot be empty"):
+            client.send_prompt_streaming("   ")
+
+    def test_pii_enabled_raises_configuration_error(self) -> None:
+        client = _StreamingStubCompletions()
+        client.pii_middleware.bool_enabled = True
+        with pytest.raises(AiProviderConfigurationError, match="PII redaction"):
+            client.send_prompt_streaming("hello")
+
+    def test_streaming_stub_yields_chunks(self) -> None:
+        client = _StreamingStubCompletions()
+        assert list(client.send_prompt_streaming("hello")) == ["chunk-1", "chunk-2"]
+
+    def test_base_provider_hook_raises(self) -> None:
+        client = _StubCompletions()
+        with pytest.raises(AiProviderCapabilityUnsupportedError):
+            list(client._send_prompt_streaming_provider("hello"))
+
+
+class _RecordingMiddleware:
+    """Fake observability middleware recording lifecycle events."""
+
+    def __init__(self) -> None:
+        self.bool_enabled = True
+        self.list_events: list[str] = []
+        self.list_summaries: list[Any] = []
+
+    def before_call(self, *, call_context) -> None:
+        self.list_events.append("before_call")
+
+    def after_call(self, *, call_context, call_result_summary) -> None:
+        self.list_events.append("after_call")
+        self.list_summaries.append(call_result_summary)
+
+    def on_error(self, *, call_context, exception, float_elapsed_ms) -> None:
+        self.list_events.append("on_error")
+
+
+class _FakeCallContext:
+    def with_direction(self, direction: str) -> "_FakeCallContext":
+        return self
+
+
+class TestExecuteObservedStreamingCall:
+    """Lifecycle semantics of the streaming observability runtime helper."""
+
+    @staticmethod
+    def _run(
+        middleware: _RecordingMiddleware,
+        chunks: list[str],
+        *,
+        fail_after: int | None = None,
+    ):
+        def _open_stream():
+            for index, chunk in enumerate(chunks):
+                if fail_after is not None and index == fail_after:
+                    raise RuntimeError("stream failed")
+                yield chunk
+
+        return execute_observed_streaming_call(
+            observability_middleware=middleware,
+            callable_build_call_context=lambda: _FakeCallContext(),
+            callable_open_stream=_open_stream,
+            callable_build_result_summary=lambda elapsed_ms: {"elapsed_ms": elapsed_ms},
+        )
+
+    def test_disabled_middleware_passes_through(self) -> None:
+        middleware = _RecordingMiddleware()
+        middleware.bool_enabled = False
+        assert list(self._run(middleware, ["a", "b"])) == ["a", "b"]
+        assert middleware.list_events == []
+
+    def test_exhaustion_emits_before_and_after(self) -> None:
+        middleware = _RecordingMiddleware()
+        assert list(self._run(middleware, ["a", "b"])) == ["a", "b"]
+        assert middleware.list_events == ["before_call", "after_call"]
+        assert middleware.list_summaries[0]["elapsed_ms"] >= 0
+
+    def test_abandonment_emits_after_call_once(self) -> None:
+        middleware = _RecordingMiddleware()
+        stream = self._run(middleware, ["a", "b", "c"])
+        assert next(stream) == "a"
+        stream.close()
+        assert middleware.list_events == ["before_call", "after_call"]
+
+    def test_stream_error_emits_on_error_and_propagates(self) -> None:
+        middleware = _RecordingMiddleware()
+        stream = self._run(middleware, ["a", "b"], fail_after=1)
+        assert next(stream) == "a"
+        with pytest.raises(RuntimeError, match="stream failed"):
+            next(stream)
+        assert middleware.list_events == ["before_call", "on_error"]
+
+
+class TestGoogleGeminiStreaming:
+    """Mocked Gemini streaming call shape."""
+
+    @staticmethod
+    def _build_client(mock_client: Mock) -> Any:
+        pytest.importorskip("google.genai")
+        from ai_api_unified.completions.ai_google_gemini_completions import (
+            GoogleGeminiCompletions,
+        )
+
+        with patch.object(
+            GoogleGeminiCompletions,
+            "_initialize_client",
+            lambda self: setattr(self, "client", mock_client),
+        ):
+            # Normal return with a Gemini completions client whose SDK client is mocked.
+            return GoogleGeminiCompletions(model="gemini-2.5-flash")
+
+    def test_streaming_yields_chunk_text(self) -> None:
+        mock_client = Mock()
+        mock_client.models.generate_content_stream.return_value = iter(
+            [Mock(text="Hello "), Mock(text=None), Mock(text="world")]
+        )
+        client = self._build_client(mock_client)
+
+        list_chunks: list[str] = list(client.send_prompt_streaming("greet me"))
+
+        assert list_chunks == ["Hello ", "world"]
+        stream_kwargs = mock_client.models.generate_content_stream.call_args.kwargs
+        assert stream_kwargs["model"] == "gemini-2.5-flash"
+        assert stream_kwargs["contents"]
+
+
+class TestOpenAIStreaming:
+    """Mocked OpenAI streaming call shape."""
+
+    @staticmethod
+    def _build_client() -> Any:
+        pytest.importorskip("openai")
+        from ai_api_unified.completions.ai_openai_completions import (
+            AiOpenAICompletions,
+        )
+
+        with patch.dict(os.environ, {"OPENAI_API_KEY": "test-key"}):
+            client = AiOpenAICompletions(model="gpt-4o-mini")
+        client.client = Mock()
+        # Normal return with an OpenAI completions client whose SDK client is mocked.
+        return client
+
+    def test_streaming_yields_delta_content(self) -> None:
+        client = self._build_client()
+        client.client.chat.completions.create.return_value = iter(
+            [
+                Mock(
+                    usage=None,
+                    choices=[Mock(delta=Mock(content="Hel"), finish_reason=None)],
+                ),
+                Mock(
+                    usage=None,
+                    choices=[Mock(delta=Mock(content="lo"), finish_reason="stop")],
+                ),
+                Mock(usage=Mock(), choices=[]),
+            ]
+        )
+
+        list_chunks: list[str] = list(client.send_prompt_streaming("greet me"))
+
+        assert list_chunks == ["Hel", "lo"]
+        create_kwargs = client.client.chat.completions.create.call_args.kwargs
+        assert create_kwargs["stream"] is True
+        assert create_kwargs["stream_options"] == {"include_usage": True}
+        assert create_kwargs["model"] == "gpt-4o-mini"
+
+
+class TestBedrockStreaming:
+    """Mocked Bedrock ConverseStream call shape."""
+
+    @staticmethod
+    def _build_client() -> Any:
+        pytest.importorskip("boto3")
+        with patch("ai_api_unified.ai_bedrock_base.boto3"):
+            from ai_api_unified.completions.ai_bedrock_completions import (
+                AiBedrockCompletions,
+            )
+
+            client = AiBedrockCompletions(model="amazon.nova-lite-v1:0")
+        client.client = Mock()
+        # Normal return with a Bedrock completions client whose SDK client is mocked.
+        return client
+
+    def test_streaming_yields_content_block_deltas(self) -> None:
+        client = self._build_client()
+        client.client.converse_stream.return_value = {
+            "stream": iter(
+                [
+                    {"contentBlockDelta": {"delta": {"text": "Hel"}}},
+                    {"contentBlockDelta": {"delta": {"text": "lo"}}},
+                    {"messageStop": {"stopReason": "end_turn"}},
+                    {"metadata": {"usage": {"inputTokens": 3, "outputTokens": 2}}},
+                ]
+            )
+        }
+
+        list_chunks: list[str] = list(client.send_prompt_streaming("greet me"))
+
+        assert list_chunks == ["Hel", "lo"]
+        converse_kwargs = client.client.converse_stream.call_args.kwargs
+        assert converse_kwargs["modelId"] == "amazon.nova-lite-v1:0"
+        assert converse_kwargs["messages"][0]["role"] == "user"

--- a/tests/test_google_gemini_nonmock.py
+++ b/tests/test_google_gemini_nonmock.py
@@ -303,6 +303,25 @@ class TestNonMockedGoogleGeminiModules:
             len(result["embedding"]) == override_dim
         ), f"Expected vector length {override_dim}, got {len(result['embedding'])}"
 
+    def test_gemini_completions_streaming(
+        self, gemini_client: AIBaseCompletions
+    ) -> None:
+        """Streaming completions yield incremental chunks that join into a response."""
+        assert gemini_client.capabilities.supports_streaming is True
+        try:
+            list_chunks: list[str] = list(
+                gemini_client.send_prompt_streaming(
+                    "Count from 1 to 5 as words, one per line."
+                )
+            )
+        except Exception as exception:
+            _skip_if_google_quota_exhausted(exception)
+            raise
+
+        assert len(list_chunks) >= 1
+        str_full_text: str = "".join(list_chunks)
+        assert "one" in str_full_text.lower()
+
     def test_gemini_embeddings_multimodal_image_and_text(self) -> None:
         """gemini-embedding-2 embeds interleaved text + image into one vector."""
         try:


### PR DESCRIPTION
Adds capability-gated streaming chat support across all three completions providers, using the same template-method capabilities pattern as multimodal embeddings: `supports_streaming` on `AICompletionsCapabilitiesBase` (per provider, per model), gating in `AIBaseCompletions.send_prompt_streaming()`, and provider hooks for OpenAI (`stream=True` + usage), Google Gemini (`generate_content_stream`), and Bedrock (`converse_stream`). A new generator-shaped `execute_observed_streaming_call` mirrors the synchronous observability lifecycle (input event at stream open, elapsed spanning consumption, output event on exhaustion or abandonment, error event on failure). Streaming refuses to run while PII redaction middleware is enabled, since redaction cannot be guaranteed across chunk boundaries.

Also adds a "Google auth modes per capability" README section (requested from sample-app findings, every claim verified against source): a matrix of which Google capabilities work under `api_key` vs `service_account`, mode-selection guidance, and the `use_api_key` override.

Verified: 324 mocked tests passing (17 new: capability flags, template gates, observability lifecycle including abandonment and mid-stream errors, per-provider call shapes), including a live Gemini streaming call against the real API. Ruff and black clean.

<!-- pr-review-prep:start -->
## PR Composition

| Change Type | Lines Changed | Percentage |
|---|---:|---:|
| Core logic changes | 672 | 62% |
| Documentation | 47 | 5% |
| Tests | 357 | 33% |
| Total | 1,076 | 100% |

Composition percentages are based on changed lines (added + deleted) vs. base branch `main`.
<!-- pr-review-prep:end -->

<!-- pr-content-attribution:start -->
## Content Attribution Summary

Based on changed lines across counted PR commits in this PR. Pure data files are excluded — their content is deterministic process output, not authored work.

| Attribution Type | Commits | Lines Changed | Percentage |
|---|---:|---:|---:|
| AI-attributed | 2 | 1,076 | 100% |
| Human-attributed | 0 | 0 | 0% |
| Bot-attributed | 0 | 0 | 0% |
| Total | 2 | 1,076 | 100% |

Excluded from attribution: none (no data files changed)
<!-- pr-content-attribution:end -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)
