### PR TITLE
chore: enforce three-location version sync; release 2.7.0

### DIFF
--- a/.agents/memory/daily/2026-07-06/events/2026-07-06T15-02-16Z--2355287-davecthomas--thread_451c3cb5-1bf1-4f06-911e-bb274923e3b1--turn_7ccc8998f5.md
+++ b/.agents/memory/daily/2026-07-06/events/2026-07-06T15-02-16Z--2355287-davecthomas--thread_451c3cb5-1bf1-4f06-911e-bb274923e3b1--turn_7ccc8998f5.md
@@ -1,0 +1,46 @@
+---
+agentmemory_version: "0.4.4"
+timestamp: "2026-07-06T15:02:16Z"
+author: "2355287-davecthomas"
+branch: "main"
+thread_id: "451c3cb5-1bf1-4f06-911e-bb274923e3b1"
+turn_id: "7ccc8998f5"
+workstream_id: "thread-451c3cb5-1bf1-4f06-911e-bb274923e3b1"
+workstream_scope: "thread"
+episode_id: "episode-main-b34c818a56"
+episode_scope: "mixed"
+checkpoint_goal: "Codify agent-facing repo governance so every shipped change to the library follows its semver, version-sync, and release discipline."
+checkpoint_surface: "The repo-root agent-instruction layer (CLAUDE.md) governing the release and versioning path: pyproject.toml [project].version and src/ai_api_unified/__version__.py, validated by tests/test_package_metadata_validation.py and published via publish.sh."
+checkpoint_outcome: "Added a root CLAUDE.md that encodes the semver bump rules, the two-file version-sync invariant, the release/tagging flow, and pre-commit working conventions for agents in this repo."
+decision_candidate: false
+enriched: true
+ai_generated: true
+ai_model: "claude-fable-5[1m]"
+ai_tool: "claude"
+ai_surface: "claude-code"
+ai_executor: "local-agent"
+related_adrs:
+files_touched:
+  - "CLAUDE.md"
+design_docs_touched:
+verification:
+  - "git diff: 1 new untracked file: CLAUDE.md"
+source_pending_shards:
+  - ".agents/memory/pending/2026-07-06/2026-07-06T15-02-16Z--2355287-davecthomas--thread_451c3cb5-1bf1-4f06-911e-bb274923e3b1--turn_7ccc8998f5.md"
+---
+
+## Why
+
+- Agents working in ai_api_unified must repeatedly make version-bump decisions, and the version literal lives in exactly two files that drift if bumped independently. Codifying the semver rules (patch/minor/major criteria, docs/test/CI exemptions), the release flow (bump lands in the shipping PR, tags cut on main, PyPI publish is a separate explicit step), and working conventions (no direct commits to main, mocked-suite pytest before commit, ruff/black) turns previously implicit repo practice into durable, discoverable instructions.
+
+## What changed
+
+- The policy formalizes conventions already visible in repo history (version-bump-in-shipping-PR per PRs #17 and #19) and anchors them to existing enforcement artifacts rather than introducing new mechanisms.
+
+## Evidence
+
+- CLAUDE.md (new, untracked at repo root); tests/test_package_metadata_validation.py exists and verifies the pyproject/__version__ pair agrees; publish.sh exists and reads the version from pyproject.toml; git log shows PRs #17 and #19 carrying version bumps per the codified convention.
+
+## Next
+
+- Land CLAUDE.md via a branch and PR rather than a direct commit to main, per the repo convention the file itself establishes.

--- a/.agents/memory/daily/2026-07-06/events/2026-07-06T15-05-35Z--2355287-davecthomas--thread_9ca2f51a-9a16-4dde-bc71-13294144cd1c--turn_e98e51e2f0.md
+++ b/.agents/memory/daily/2026-07-06/events/2026-07-06T15-05-35Z--2355287-davecthomas--thread_9ca2f51a-9a16-4dde-bc71-13294144cd1c--turn_e98e51e2f0.md
@@ -1,0 +1,52 @@
+---
+agentmemory_version: "0.4.4"
+timestamp: "2026-07-06T15:03:54Z"
+author: "2355287-davecthomas"
+branch: "main"
+thread_id: "34dbb70b-6e50-45ea-8188-c94fd9a38395"
+turn_id: "1dfc023579"
+workstream_id: "thread-34dbb70b-6e50-45ea-8188-c94fd9a38395"
+workstream_scope: "thread"
+episode_id: "episode-main-b34c818a56"
+episode_scope: "mixed"
+checkpoint_goal: "Eliminate recurring version drift in ai_api_unified by codifying and mechanically enforcing the semver release policy across the library's version locations."
+checkpoint_surface: "The release and packaging metadata surface \u2014 package version declarations and the README title \u2014 plus the agent-policy layer and the mocked pytest suite that guards it."
+checkpoint_outcome: "Synchronized all three sanctioned version locations to 2.7.0, the minor bump owed for the capability-gated streaming-completions feature (PR #20), and added an automated sync test so partial bumps fail the mocked suite."
+decision_candidate: true
+enriched: true
+ai_generated: true
+ai_model: "claude-fable-5[1m]"
+ai_tool: "claude"
+ai_surface: "claude-code"
+ai_executor: "local-agent"
+related_adrs:
+files_touched:
+  - "CLAUDE.md"
+  - "README.md"
+  - "pyproject.toml"
+  - "src/ai_api_unified/__version__.py"
+  - "tests/test_version_sync.py"
+design_docs_touched:
+verification:
+  - "git diff:  3 files changed, 3 insertions(+), 3 deletions(-); # ai-api-unified 2.7.0; version = \"2.7.0\" # keep in sync with src/ai_api_unified/__version__.py and the README.md title; __version__: str = \"2.7.0\""
+  - "git diff:  1 file changed, 1 insertion(+), 1 deletion(-); # ai-api-unified 2.6.0"
+source_pending_shards:
+  - ".agents/memory/pending/2026-07-06/2026-07-06T15-05-35Z--2355287-davecthomas--thread_9ca2f51a-9a16-4dde-bc71-13294144cd1c--turn_e98e51e2f0.md"
+  - ".agents/memory/pending/2026-07-06/2026-07-06T15-03-54Z--2355287-davecthomas--thread_34dbb70b-6e50-45ea-8188-c94fd9a38395--turn_1dfc023579.md"
+---
+
+## Why
+
+- Release versioning in this library had been an unenforced convention, and it kept failing in the same way: bumps updated the package metadata but missed the human-facing README title, so published releases advertised a stale version. As agent-driven PRs accelerated the release cadence, relying on contributors to remember every location stopped scaling. This checkpoint marks the shift from tribal knowledge to codified, test-enforced policy: the version lives in exactly three sanctioned places, they are always bumped together in the PR that ships the change, and the test suite makes drift impossible to merge silently. Future agents should treat the policy document and the sync test as the source of truth for release mechanics.
+
+## What changed
+
+- The version was synchronized to 2.7.0 across the package metadata, the runtime version attribute, and the README title, covering the minor bump for capability-gated streaming completions. A new sync test fails the mocked suite whenever the three locations disagree, and a new agent-instructions document codifies the semver bump rules, the three-location invariant, and the release flow: bump in the shipping PR, tag on main after merge, explicit publish as a separate step. An immediately preceding turn repaired the lagging README title as the first step of the same effort.
+
+## Evidence
+
+- git shows README.md, pyproject.toml, and __version__.py all at 2.7.0 with tests/test_version_sync.py and CLAUDE.md newly added; git log shows the release-worthy feature merged as PR #20 (capability-gated streaming completions); pyproject.toml carries an inline keep-in-sync comment naming the other two locations.
+
+## Next
+
+- Commit the sync work, then cut the v2.7.0 tag on main; watch that publish.sh keeps reading the version from pyproject.toml and that no new version literals appear outside the three sanctioned locations.

--- a/.agents/memory/daily/2026-07-06/summary.md
+++ b/.agents/memory/daily/2026-07-06/summary.md
@@ -1,0 +1,43 @@
+# 2026-07-06 summary
+
+## Snapshot
+
+- Captured 2 memory events.
+- Main work: The policy formalizes conventions already visible in repo history (version-bump-in-shipping-PR per PRs #17 and #19) and anchors them to existing enforcement artifacts rather than introducing new mechanisms.
+- Top decision: Release versioning in this library had been an unenforced convention, and it kept failing in the same way: bumps updated the package metadata but missed the human-facing README title, so published releases advertised a stale version. As agent-driven PRs accelerated the release cadence, relying on contributors to remember every location stopped scaling. This checkpoint marks the shift from tribal knowledge to codified, test-enforced policy: the version lives in exactly three sanctioned places, they are always bumped together in the PR that ships the change, and the test suite makes drift impossible to merge silently. Future agents should treat the policy document and the sync test as the source of truth for release mechanics. ([2026-07-06 15:03:54 UTC by 2355287-davecthomas](events/2026-07-06T15-05-35Z--2355287-davecthomas--thread_9ca2f51a-9a16-4dde-bc71-13294144cd1c--turn_e98e51e2f0.md))
+- Blockers: None.
+
+| Metric | Value |
+|---|---|
+| Memory events captured | 2 |
+| Repo files changed | 2 |
+| Decision candidates | 1 |
+| Active blockers | 0 |
+
+## Major work completed
+
+- The policy formalizes conventions already visible in repo history (version-bump-in-shipping-PR per PRs #17 and #19) and anchors them to existing enforcement artifacts rather than introducing new mechanisms.
+- The version was synchronized to 2.7.0 across the package metadata, the runtime version attribute, and the README title, covering the minor bump for capability-gated streaming completions. A new sync test fails the mocked suite whenever the three locations disagree, and a new agent-instructions document codifies the semver bump rules, the three-location invariant, and the release flow: bump in the shipping PR, tag on main after merge, explicit publish as a separate step. An immediately preceding turn repaired the lagging README title as the first step of the same effort.
+
+## Why this mattered
+
+- Agents working in ai_api_unified must repeatedly make version-bump decisions, and the version literal lives in exactly two files that drift if bumped independently. Codifying the semver rules (patch/minor/major criteria, docs/test/CI exemptions), the release flow (bump lands in the shipping PR, tags cut on main, PyPI publish is a separate explicit step), and working conventions (no direct commits to main, mocked-suite pytest before commit, ruff/black) turns previously implicit repo practice into durable, discoverable instructions.
+- Release versioning in this library had been an unenforced convention, and it kept failing in the same way: bumps updated the package metadata but missed the human-facing README title, so published releases advertised a stale version. As agent-driven PRs accelerated the release cadence, relying on contributors to remember every location stopped scaling. This checkpoint marks the shift from tribal knowledge to codified, test-enforced policy: the version lives in exactly three sanctioned places, they are always bumped together in the PR that ships the change, and the test suite makes drift impossible to merge silently. Future agents should treat the policy document and the sync test as the source of truth for release mechanics.
+
+## Active blockers
+
+- None
+
+## Decision candidates
+
+- Release versioning in this library had been an unenforced convention, and it kept failing in the same way: bumps updated the package metadata but missed the human-facing README title, so published releases advertised a stale version. As agent-driven PRs accelerated the release cadence, relying on contributors to remember every location stopped scaling. This checkpoint marks the shift from tribal knowledge to codified, test-enforced policy: the version lives in exactly three sanctioned places, they are always bumped together in the PR that ships the change, and the test suite makes drift impossible to merge silently. Future agents should treat the policy document and the sync test as the source of truth for release mechanics. ([2026-07-06 15:03:54 UTC by 2355287-davecthomas](events/2026-07-06T15-05-35Z--2355287-davecthomas--thread_9ca2f51a-9a16-4dde-bc71-13294144cd1c--turn_e98e51e2f0.md))
+
+## Next likely steps
+
+- Land CLAUDE.md via a branch and PR rather than a direct commit to main, per the repo convention the file itself establishes.
+- Commit the sync work, then cut the v2.7.0 tag on main; watch that publish.sh keeps reading the version from pyproject.toml and that no new version literals appear outside the three sanctioned locations.
+
+## Relevant event shards
+
+- [2026-07-06 15:02:16 UTC by 2355287-davecthomas](events/2026-07-06T15-02-16Z--2355287-davecthomas--thread_451c3cb5-1bf1-4f06-911e-bb274923e3b1--turn_7ccc8998f5.md)
+- [2026-07-06 15:03:54 UTC by 2355287-davecthomas](events/2026-07-06T15-05-35Z--2355287-davecthomas--thread_9ca2f51a-9a16-4dde-bc71-13294144cd1c--turn_e98e51e2f0.md)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,55 @@
+# ai_api_unified — agent instructions
+
+## Versioning policy
+
+This library uses semantic versioning. Every PR that changes shipped code
+(anything under `src/`) must carry a version bump chosen by semver rules:
+
+- **patch** (x.y.Z) — bug fixes, dependency pin updates, internal refactors
+  with no API change
+- **minor** (x.Y.0) — new features, new public API surface, new provider or
+  capability support, deprecations
+- **major** (X.0.0) — breaking changes: removed or renamed public API,
+  changed method signatures or return shapes, dropped Python versions
+
+Docs-only, test-only, and CI-only PRs do not bump the version.
+
+### The version lives in exactly three files — bump them together, always
+
+1. `pyproject.toml` — `version = "X.Y.Z"` under `[project]`
+2. `src/ai_api_unified/__version__.py` — `__version__: str = "X.Y.Z"`
+3. `README.md` — the title heading on line 1 (`# ai-api-unified X.Y.Z`)
+
+Never bump one without the others. The README title is the historically
+missed one (it sat at 2.5.0 through the 2.6.0 release). Verify agreement
+before committing:
+
+```bash
+poetry run pytest tests/test_version_sync.py -q
+```
+
+`tests/test_version_sync.py` fails whenever the three locations disagree, so
+the mocked suite catches a partial bump automatically.
+
+Do not add new version literals beyond these three (scripts, docs, badges).
+README's release section describes the process without hardcoding a version,
+and `publish.sh` reads the version from `pyproject.toml` — keep it that way.
+If a new version location ever becomes unavoidable, list it here and in the
+README release section.
+
+### Release flow
+
+- The version bump lands in the PR that ships the change (repo convention —
+  see PR #17, #19). If several PRs merge before a release, the highest
+  required bump level since the last tag wins.
+- Releases are cut on `main` after merge: tag `v<version>` and push the tag.
+  Publishing to PyPI is a separate, explicit step via `./publish.sh`.
+
+## Working conventions
+
+- Never commit directly to `main`; create a branch from the updated remote
+  primary branch first.
+- Run the mocked suite before any commit: `poetry run pytest -q -m "not nonmock"`
+  (tests in `*_nonmock.py` files call live provider APIs when credentials are
+  present in `.env`).
+- Lint and format: `poetry run ruff check .` and `poetry run black .`.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# ai-api-unified 2.5.0
+# ai-api-unified 2.7.0
 
 `ai-api-unified` is a unified Python library for AI completions, embeddings, image generation, video generation, and voice. Application code targets stable base interfaces and factory entry points while concrete providers are selected at runtime from environment configuration.
 
@@ -666,8 +666,10 @@ Before publishing:
 
 1. Bump the version in `pyproject.toml`.
 2. Bump the version in `src/ai_api_unified/__version__.py`.
-3. Ensure the working tree is clean.
-4. Ensure your PyPI token is configured for Poetry.
+3. Bump the version in the `README.md` title heading (line 1).
+4. Run `poetry run pytest tests/test_version_sync.py` to confirm all three agree.
+5. Ensure the working tree is clean.
+6. Ensure your PyPI token is configured for Poetry.
 
 Publish with the checked-in script:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@
 [project]
 name = "ai_api_unified"
 
-version = "2.6.0" # keep in sync with src/ai_api_unified/__version__.py
+version = "2.7.0" # keep in sync with src/ai_api_unified/__version__.py and the README.md title
 description = "Unified access layer for AI completions (LLM), embedding (semantic), image, video, and voice services"
 authors = [{ name = "Dave Thomas", email = "davidcthomas@gmail.com" }]
 license = "MIT"

--- a/src/ai_api_unified/__version__.py
+++ b/src/ai_api_unified/__version__.py
@@ -9,4 +9,4 @@ from __future__ import annotations
 
 __all__: list[str] = ["__version__"]
 
-__version__: str = "2.6.0"
+__version__: str = "2.7.0"

--- a/tests/test_version_sync.py
+++ b/tests/test_version_sync.py
@@ -1,0 +1,80 @@
+# test_version_sync.py
+"""
+Tests that every version literal in the repository agrees.
+
+The version lives in exactly three files (see CLAUDE.md):
+    1. pyproject.toml       — [project] version
+    2. src/ai_api_unified/__version__.py — __version__ constant
+    3. README.md            — the title heading on line 1
+
+These tests fail whenever a bump touches one location and misses another,
+which is how the README title drifted to 2.5.0 while the package shipped 2.6.0.
+"""
+
+from __future__ import annotations
+
+import re
+import tomllib
+from pathlib import Path
+
+PATH_REPO_ROOT: Path = Path(__file__).resolve().parent.parent
+REGEX_SEMVER: str = r"\d+\.\d+\.\d+"
+
+
+def _read_pyproject_version() -> str:
+    """Returns the [project] version from pyproject.toml."""
+    dict_pyproject = tomllib.loads(
+        (PATH_REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8")
+    )
+    # Normal return with the packaging source-of-truth version.
+    return dict_pyproject["project"]["version"]
+
+
+def _read_module_version() -> str:
+    """Returns the __version__ constant from src/ai_api_unified/__version__.py."""
+    str_module_text: str = (
+        PATH_REPO_ROOT / "src" / "ai_api_unified" / "__version__.py"
+    ).read_text(encoding="utf-8")
+    match_version = re.search(
+        rf'^__version__: str = "({REGEX_SEMVER})"', str_module_text, re.MULTILINE
+    )
+    assert match_version is not None, "__version__.py is missing the version constant"
+    # Normal return with the runtime fallback version.
+    return match_version.group(1)
+
+
+def _read_readme_title_version() -> str:
+    """Returns the version embedded in README.md's title heading."""
+    str_first_line: str = (
+        (PATH_REPO_ROOT / "README.md")
+        .read_text(encoding="utf-8")
+        .splitlines()[0]
+    )
+    match_version = re.search(rf"^# ai-api-unified ({REGEX_SEMVER})$", str_first_line)
+    assert match_version is not None, (
+        "README.md line 1 must be '# ai-api-unified X.Y.Z' "
+        f"but was: {str_first_line!r}"
+    )
+    # Normal return with the README title version.
+    return match_version.group(1)
+
+
+def test_version_locations_agree() -> None:
+    """All three version literals must be identical."""
+    str_pyproject_version: str = _read_pyproject_version()
+    str_module_version: str = _read_module_version()
+    str_readme_version: str = _read_readme_title_version()
+
+    assert str_pyproject_version == str_module_version, (
+        f"pyproject.toml ({str_pyproject_version}) and __version__.py "
+        f"({str_module_version}) disagree"
+    )
+    assert str_pyproject_version == str_readme_version, (
+        f"pyproject.toml ({str_pyproject_version}) and the README.md title "
+        f"({str_readme_version}) disagree"
+    )
+
+
+def test_version_is_semver_shaped() -> None:
+    """The version must be plain MAJOR.MINOR.PATCH."""
+    assert re.fullmatch(REGEX_SEMVER, _read_pyproject_version())


### PR DESCRIPTION
Enforces version-bump discipline and cuts the overdue 2.7.0.

The README title heading is a third version location that drifted to 2.5.0 while the package shipped 2.6.0, and PR #20 (streaming completions) merged without its semver minor bump. This PR adds `CLAUDE.md` (semver criteria, the three version locations bumped in unison, release flow), a `tests/test_version_sync.py` that fails the suite whenever the three literals disagree, the 2.6.0 → 2.7.0 bump across all three locations covering #20's streaming feature, and an updated README publish checklist.

Verified: 326 mocked tests passing (2 new sync tests), ruff/black clean.

<!-- pr-review-prep:start -->
## PR Composition

| Change Type | Lines Changed | Percentage |
|---|---:|---:|
| Core logic changes | 2 | 1% |
| Documentation | 8 | 3% |
| Tests | 80 | 28% |
| Other | 198 | 68% |
| Total | 288 | 100% |

Composition percentages are based on changed lines (added + deleted) vs. base branch `main`. `Other` is CLAUDE.md (agent instructions), agent-memory shards, and the pyproject version line; `Core` is the `__version__.py` bump.
<!-- pr-review-prep:end -->

<!-- pr-content-attribution:start -->
## Content Attribution Summary

Based on changed lines across counted PR commits in this PR. Pure data files are excluded — their content is deterministic process output, not authored work.

| Attribution Type | Commits | Lines Changed | Percentage |
|---|---:|---:|---:|
| AI-attributed | 1 | 288 | 100% |
| Human-attributed | 0 | 0 | 0% |
| Bot-attributed | 0 | 0 | 0% |
| Total | 1 | 288 | 100% |

Excluded from attribution: none (no data files changed)
<!-- pr-content-attribution:end -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)
