### PR TITLE
chore: update provider SDKs to latest (openai 2.x major); fix factory-default embeddings 400

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# ai-api-unified 2.7.0
+# ai-api-unified 2.7.1
 
 `ai-api-unified` is a unified Python library for AI completions, embeddings, image generation, video generation, and voice. Application code targets stable base interfaces and factory entry points while concrete providers are selected at runtime from environment configuration.
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -109,19 +109,19 @@ files = [
 
 [[package]]
 name = "azure-cognitiveservices-speech"
-version = "1.48.2"
+version = "1.50.0"
 description = "Microsoft Cognitive Services Speech SDK for Python"
 optional = true
 python-versions = ">=3.7"
 groups = ["main"]
 markers = "extra == \"azure-tts\""
 files = [
-    {file = "azure_cognitiveservices_speech-1.48.2-py3-none-macosx_10_14_x86_64.whl", hash = "sha256:62918332eb53e26b71c1d6000bf3e255f7b2b7c8cb327ea2ec7d37181313c885"},
-    {file = "azure_cognitiveservices_speech-1.48.2-py3-none-macosx_11_0_arm64.whl", hash = "sha256:47ffaead342a53ffca74c54bd0843a9c4aabdedd385d45742dac0404c551e384"},
-    {file = "azure_cognitiveservices_speech-1.48.2-py3-none-manylinux1_x86_64.whl", hash = "sha256:9b03c2a0e36d926f5eb3c4c8588c5b444af257be2b7d801575faafc086a62581"},
-    {file = "azure_cognitiveservices_speech-1.48.2-py3-none-manylinux2014_aarch64.whl", hash = "sha256:0f01e5c9326224845031c67812664436da9ba96d19230dfa2f44a4402fbda0e5"},
-    {file = "azure_cognitiveservices_speech-1.48.2-py3-none-win_amd64.whl", hash = "sha256:acd2549b3e716968e0cc9e95dc9cd512042129323158a4eeb74dfb740e53c065"},
-    {file = "azure_cognitiveservices_speech-1.48.2-py3-none-win_arm64.whl", hash = "sha256:a8538e3732a2b157f8379063a6f9ad21c71cb3bcc24e8f2b1ee0c90023ca0d4c"},
+    {file = "azure_cognitiveservices_speech-1.50.0-py3-none-macosx_10_14_x86_64.whl", hash = "sha256:a199cac027f4f3c4972b9c76efb425dd7479eabd4beb9c613140fe5549c649c6"},
+    {file = "azure_cognitiveservices_speech-1.50.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:2621d1c95741c0864d418f88c59d1355bde0d893beb57c609b6ae4819c99e591"},
+    {file = "azure_cognitiveservices_speech-1.50.0-py3-none-manylinux1_x86_64.whl", hash = "sha256:e58faf51d82963b395c06a7e65dd6bead71c242e013695c62949ff8b9607d77e"},
+    {file = "azure_cognitiveservices_speech-1.50.0-py3-none-manylinux2014_aarch64.whl", hash = "sha256:828891baac849137d9773d980910939c0541cbfc4653265597fea592684efafd"},
+    {file = "azure_cognitiveservices_speech-1.50.0-py3-none-win_amd64.whl", hash = "sha256:c600bdab8bcc12b3e7e1297c0026dbe09edf90d9b399a719303132c216bc8002"},
+    {file = "azure_cognitiveservices_speech-1.50.0-py3-none-win_arm64.whl", hash = "sha256:44279ad5430db7484ef412d89599f926e623b184a365a2258056f4ffdee34e55"},
 ]
 
 [package.dependencies]
@@ -246,45 +246,45 @@ numpy = {version = ">=1.19.0,<3.0.0", markers = "python_version >= \"3.9\""}
 
 [[package]]
 name = "boto3"
-version = "1.38.35"
+version = "1.43.40"
 description = "The AWS SDK for Python"
 optional = true
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 groups = ["main"]
 markers = "extra == \"bedrock\""
 files = [
-    {file = "boto3-1.38.35-py3-none-any.whl", hash = "sha256:97606fe56e33b2548c4110dd7cdc49487266d503ba09eaff9abf98b028baee9e"},
-    {file = "boto3-1.38.35.tar.gz", hash = "sha256:38a407e467b24914ce24e5816f53305288ea44072778f88d2b4b6a2cffbcb220"},
+    {file = "boto3-1.43.40-py3-none-any.whl", hash = "sha256:5fa80de4b4b7bab383dd8c563e235d51fcc7df4502662af56f0a2472c3c15651"},
+    {file = "boto3-1.43.40.tar.gz", hash = "sha256:a7108b9ce25b8f92d1ce96b9e35090794d5c58b219ff2f6a7a65c8986a4ed6f4"},
 ]
 
 [package.dependencies]
-botocore = ">=1.38.35,<1.39.0"
+botocore = ">=1.43.40,<1.44.0"
 jmespath = ">=0.7.1,<2.0.0"
-s3transfer = ">=0.13.0,<0.14.0"
+s3transfer = ">=0.19.0,<0.20.0"
 
 [package.extras]
 crt = ["botocore[crt] (>=1.21.0,<2.0a0)"]
 
 [[package]]
 name = "botocore"
-version = "1.38.35"
+version = "1.43.40"
 description = "Low-level, data-driven core of boto 3."
 optional = true
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 groups = ["main"]
 markers = "extra == \"bedrock\""
 files = [
-    {file = "botocore-1.38.35-py3-none-any.whl", hash = "sha256:bbfae3f13a5d75ad73bf71b5ba5ff3ccd055d947d63593e8a0e84acc95a8bfa4"},
-    {file = "botocore-1.38.35.tar.gz", hash = "sha256:3c7032948e066eed5f91d64cd51ee9664d1db9beaf3279ac27da608176bb3d54"},
+    {file = "botocore-1.43.40-py3-none-any.whl", hash = "sha256:0bc9d352267c9e48415c5d7bb61ff05c3f193eac2fc7e69cfd229a05fbab67d6"},
+    {file = "botocore-1.43.40.tar.gz", hash = "sha256:2085a4314cfd2c8bc1d08ab8039f76c92e99278db0d2a0e2437010526d5d5d70"},
 ]
 
 [package.dependencies]
 jmespath = ">=0.7.1,<2.0.0"
 python-dateutil = ">=2.1,<3.0.0"
-urllib3 = {version = ">=1.25.4,<2.2.0 || >2.2.0,<3", markers = "python_version >= \"3.10\""}
+urllib3 = ">=1.25.4,<2.2.0 || >2.2.0,<3"
 
 [package.extras]
-crt = ["awscrt (==0.23.8)"]
+crt = ["awscrt (==0.32.2)"]
 
 [[package]]
 name = "catalogue"
@@ -758,15 +758,15 @@ files = [
 
 [[package]]
 name = "elevenlabs"
-version = "2.36.1"
+version = "2.56.0"
 description = ""
 optional = true
 python-versions = "<4.0,>=3.8"
 groups = ["main"]
 markers = "extra == \"elevenlabs\""
 files = [
-    {file = "elevenlabs-2.36.1-py3-none-any.whl", hash = "sha256:c60c03b463565704038364703b0d54746fd0b67dea0341c2d53da445c32c75cc"},
-    {file = "elevenlabs-2.36.1.tar.gz", hash = "sha256:9b278f861679824ee03ee06da049d6fd9ca3886950e77d8d49dab2530ed837d3"},
+    {file = "elevenlabs-2.56.0-py3-none-any.whl", hash = "sha256:45192dd89047470895a7aad8df0cebb776a337af14b3f426ddb86fd65cfcc31a"},
+    {file = "elevenlabs-2.56.0.tar.gz", hash = "sha256:ed7b15af50e95e2b4a6bc91ac33a59af12c7e6a02c002d75921ffd867b7562b8"},
 ]
 
 [package.dependencies]
@@ -775,7 +775,7 @@ pydantic = ">=1.9.2"
 pydantic-core = ">=2.18.2"
 requests = ">=2.20"
 typing_extensions = ">=4.0.0"
-websockets = ">=11.0"
+websockets = ">=13.0"
 
 [package.extras]
 pyaudio = ["pyaudio (>=0.2.14)"]
@@ -1587,28 +1587,30 @@ files = [
 
 [[package]]
 name = "openai"
-version = "1.86.0"
+version = "2.44.0"
 description = "The official Python library for the openai API"
 optional = true
-python-versions = ">=3.8"
+python-versions = ">=3.9"
 groups = ["main"]
 markers = "extra == \"openai\""
 files = [
-    {file = "openai-1.86.0-py3-none-any.whl", hash = "sha256:c8889c39410621fe955c230cc4c21bfe36ec887f4e60a957de05f507d7e1f349"},
-    {file = "openai-1.86.0.tar.gz", hash = "sha256:c64d5b788359a8fdf69bd605ae804ce41c1ce2e78b8dd93e2542e0ee267f1e4b"},
+    {file = "openai-2.44.0-py3-none-any.whl", hash = "sha256:0a2a3ab2e29aeda368700f662ff9ba0f9df17ba4c54577a64e08b8115a3cc0ad"},
+    {file = "openai-2.44.0.tar.gz", hash = "sha256:68a5a5ffad82b8ff7d451c437529fb64f7c3b8123aaf0c021966a882d9e3947d"},
 ]
 
 [package.dependencies]
 anyio = ">=3.5.0,<5"
 distro = ">=1.7.0,<2"
 httpx = ">=0.23.0,<1"
-jiter = ">=0.4.0,<1"
+jiter = ">=0.10.0,<1"
 pydantic = ">=1.9.0,<3"
 sniffio = "*"
 tqdm = ">4"
-typing-extensions = ">=4.11,<5"
+typing-extensions = ">=4.14,<5"
 
 [package.extras]
+aiohttp = ["aiohttp", "httpx-aiohttp (>=0.1.9)"]
+bedrock = ["botocore (>=1.40.0,<1.43) ; python_version < \"3.10\"", "botocore (>=1.40.0,<2) ; python_version >= \"3.10\""]
 datalib = ["numpy (>=1)", "pandas (>=1.2.3)", "pandas-stubs (>=1.1.0.11)"]
 realtime = ["websockets (>=13,<16)"]
 voice-helpers = ["numpy (>=2.0.2)", "sounddevice (>=0.5.1)"]
@@ -2640,15 +2642,15 @@ files = [
 
 [[package]]
 name = "s3transfer"
-version = "0.13.0"
+version = "0.19.0"
 description = "An Amazon S3 Transfer Manager"
 optional = true
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 groups = ["main"]
 markers = "extra == \"bedrock\""
 files = [
-    {file = "s3transfer-0.13.0-py3-none-any.whl", hash = "sha256:0148ef34d6dd964d0d8cf4311b2b21c474693e57c2e069ec708ce043d2b527be"},
-    {file = "s3transfer-0.13.0.tar.gz", hash = "sha256:f5e6db74eb7776a37208001113ea7aa97695368242b364d73e91c981ac522177"},
+    {file = "s3transfer-0.19.0-py3-none-any.whl", hash = "sha256:777cc2415536f1debadb5c2ef7779275d0fc0fe0e042411cdd6caebeb2685262"},
+    {file = "s3transfer-0.19.0.tar.gz", hash = "sha256:ce436931687addc4c1712d52d40b32f53e88315723f107ffa20ba82b05a0f685"},
 ]
 
 [package.dependencies]
@@ -3137,7 +3139,7 @@ description = "HTTP library with thread-safe connection pooling, file post, and 
 optional = true
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "extra == \"bedrock\" or extra == \"azure-tts\" or extra == \"elevenlabs\" or extra == \"google-gemini\" or extra == \"middleware-pii-redaction\" or extra == \"middleware-pii-redaction-small\" or extra == \"middleware-pii-redaction-large\""
+markers = "extra == \"azure-tts\" or extra == \"elevenlabs\" or extra == \"google-gemini\" or extra == \"middleware-pii-redaction\" or extra == \"middleware-pii-redaction-small\" or extra == \"middleware-pii-redaction-large\" or extra == \"bedrock\""
 files = [
     {file = "urllib3-2.4.0-py3-none-any.whl", hash = "sha256:4e16665048960a0900c702d4a66415956a584919c03361cac9f1df5c5dd7e813"},
     {file = "urllib3-2.4.0.tar.gz", hash = "sha256:414bc6535b787febd7567804cc015fee39daab8ad86268f1310a9250697de466"},
@@ -3409,4 +3411,4 @@ video-frames = ["Pillow", "imageio", "imageio-ffmpeg"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<3.14"
-content-hash = "4327df364ef01d3d6dc2d3dd2c1729d6c216dfbba2b5396c68a1a74be72a3c76"
+content-hash = "ca5b54710e4588f0f8417758e5186c54a00aeb2dd223156be94375e80b91747d"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@
 [project]
 name = "ai_api_unified"
 
-version = "2.7.0" # keep in sync with src/ai_api_unified/__version__.py and the README.md title
+version = "2.7.1" # keep in sync with src/ai_api_unified/__version__.py and the README.md title
 description = "Unified access layer for AI completions (LLM), embedding (semantic), image, video, and voice services"
 authors = [{ name = "Dave Thomas", email = "davidcthomas@gmail.com" }]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,7 +79,7 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = ["pytest>=8.4.0,<9.0.0", "ruff>=0.4.4,<1.0.0", "black>=24.4.2,<25.0.0"]
-openai = ["openai>=1.25.0,<2.0.0"]
+openai = ["openai>=2.0.0,<3.0.0"]
 azure_tts = ["azure-cognitiveservices-speech>=1.37.0,<2.0.0"]
 bedrock = ["boto3>=1.34.0,<2.0.0"]
 elevenlabs = ["elevenlabs>=2.3.0,<3.0.0"]

--- a/src/ai_api_unified/__version__.py
+++ b/src/ai_api_unified/__version__.py
@@ -9,4 +9,4 @@ from __future__ import annotations
 
 __all__: list[str] = ["__version__"]
 
-__version__: str = "2.7.0"
+__version__: str = "2.7.1"

--- a/src/ai_api_unified/embeddings/ai_openai_embeddings.py
+++ b/src/ai_api_unified/embeddings/ai_openai_embeddings.py
@@ -88,8 +88,16 @@ class AiOpenAIEmbeddings(AIBaseEmbeddings, AIOpenAIBase):
     def __init__(self, model: str = "text-embedding-3-small", dimensions: int = 512):
         env = EnvSettings()
         self.api_key = env.get_setting("OPENAI_API_KEY")
-        self.embedding_model = model
-        self.dimensions = dimensions
+        # The factory passes empty/zero values when EMBEDDING_MODEL_NAME or
+        # EMBEDDING_DIMENSIONS are unset; fall back to the model's own default
+        # so the provider never receives model="" or dimensions=0 (a 400).
+        self.embedding_model = model or self.embedding_model_default
+        self.dimensions = (
+            dimensions
+            or AIEmbeddingsCapabilitiesOpenAI.for_model(
+                self.embedding_model
+            ).default_dimensions
+        )
         self.base_url = self.get_api_base_url()
         self.client = OpenAI(api_key=self.api_key, base_url=self.base_url)
         self.backoff_delays = [1, 2, 4, 8, 16]

--- a/tests/test_embeddings_capabilities.py
+++ b/tests/test_embeddings_capabilities.py
@@ -288,6 +288,34 @@ class TestGoogleEmbeddingsCapabilities:
         assert "config" not in embed_kwargs
 
 
+class TestOpenAIEmbeddingsFactoryDefaults:
+    """Factory-style falsy model/dimensions inputs resolve to model defaults."""
+
+    @staticmethod
+    def _build_client(model: str, dimensions: int) -> Any:
+        pytest.importorskip("openai")
+        import os
+        from ai_api_unified.embeddings.ai_openai_embeddings import AiOpenAIEmbeddings
+
+        with patch.dict(os.environ, {"OPENAI_API_KEY": "test-key"}):
+            # Normal return with an OpenAI embeddings client built factory-style.
+            return AiOpenAIEmbeddings(model=model, dimensions=dimensions)
+
+    def test_zero_dimensions_resolves_to_model_default(self) -> None:
+        client = self._build_client("text-embedding-3-small", 0)
+        assert client.dimensions == 1536
+
+    def test_empty_model_resolves_to_default_model(self) -> None:
+        client = self._build_client("", 0)
+        assert client.embedding_model == "text-embedding-3-small"
+        assert client.dimensions == 1536
+
+    def test_explicit_values_win(self) -> None:
+        client = self._build_client("text-embedding-3-large", 256)
+        assert client.embedding_model == "text-embedding-3-large"
+        assert client.dimensions == 256
+
+
 class TestOpenAIEmbeddingsCapabilities:
     """OpenAI capabilities descriptor."""
 


### PR DESCRIPTION
**Ships as 2.7.1.** Updates all four non-Google provider SDKs to latest: **openai 1.86.0 → 2.44.0** (major; pin widened to `>=2.0.0,<3.0.0`), boto3/botocore 1.38.35 → 1.43.40, azure-cognitiveservices-speech 1.48.2 → 1.50.0, elevenlabs 2.36.1 → 2.56.0.

**Ripple analysis:** the lock diff is contained to the four SDKs plus boto3's companions (s3transfer). No httpx, pydantic, or Google-stack movement. OpenAI 2.x's only breaking change (Responses API output types in 2.0.0) touches an API this library never calls; every import used here survives, verified empirically.

**Conformance verification:** 329 mocked tests passing; live against real APIs on the new SDKs: OpenAI completions, streaming, embeddings, and image-input completions all pass.

**Bug found and fixed during live verification (pre-existing, not SDK-caused):** the factory passes `dimensions=0` / `model=""` to `AiOpenAIEmbeddings` when env vars are unset, and the class forwarded `dimensions=0` to the API → 400. Now resolves falsy inputs to model defaults, matching the Gemini class's behavior. 3 regression tests added.

**Known pre-existing live failure (out of scope, not caused by this PR):** OpenAI `/v1/videos` returns 400 to the hand-rolled httpx client in `ai_openai_videos.py` — that path doesn't use the openai SDK. See the new-capabilities note below for the likely fix path.

<!-- pr-review-prep:start -->
## PR Composition

| Change Type | Lines Changed | Percentage |
|---|---:|---:|
| Core logic changes | 14 | 12% |
| Documentation | 2 | 2% |
| Tests | 28 | 23% |
| Data | 72 | 60% |
| Other | 4 | 3% |
| Total | 120 | 100% |

Composition percentages are based on changed lines (added + deleted) vs. base branch `main`. `Data` is the regenerated `poetry.lock`.
<!-- pr-review-prep:end -->

<!-- pr-content-attribution:start -->
## Content Attribution Summary

Based on changed lines across counted PR commits in this PR. Pure data files are excluded — their content is deterministic process output, not authored work.

| Attribution Type | Commits | Lines Changed | Percentage |
|---|---:|---:|---:|
| AI-attributed | 3 | 48 | 100% |
| Human-attributed | 0 | 0 | 0% |
| Bot-attributed | 0 | 0 | 0% |
| Total | 3 | 48 | 100% |

Excluded from attribution:
- 72 data-file lines (`poetry.lock`)
<!-- pr-content-attribution:end -->

## New capabilities unlocked (for maintainer confirmation — none implemented here)

**OpenAI 2.x**
1. **SDK-native `client.videos`** — the SDK now covers the sora endpoints the library currently hand-rolls with httpx, including dated sora-2 slugs, video extensions/edits, and higher-resolution exports. Migrating `ai_openai_videos.py` to the SDK client would delete the custom HTTP layer and is the most likely fix for the pre-existing `/v1/videos` 400.
2. **Responses API (`client.responses`)** — OpenAI's successor to chat.completions with better reasoning-model support and websocket streaming. Could become an alternate completions engine or a per-model routing decision via the capabilities pattern.
3. **Realtime API (`client.realtime`)** — `gpt-realtime-1.5` / `gpt-audio-1.5` bidirectional voice; relevant to the voice surface.
4. **New models** — gpt-5.4, gpt-5.1-codex-max, new audio model slugs for the completions/voice capabilities tables.

**Bedrock (botocore 1.43 service model)**
5. **`CountTokens` operation** — provider-side token counting; could back a `count_tokens()` on the completions surface.
6. **`serviceTier` converse param** — priority/flex tiering per request.
7. **`InvokeModelWithBidirectionalStream`** and standalone guardrail checks (`InvokeGuardrailChecks`, `ApplyGuardrail`).

**ElevenLabs 2.56** — schema updates through the April 2026 API: `eleven_v3` model family (most expressive, 70+ languages), agents-platform turn-model configuration, audio-isolation endpoints.

**Azure Speech 1.50** — source-language autodetection for STT and `PostProcessingOption` for transcript accuracy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
