### PR TITLE
feat: native Anthropic Claude completions engine (claude) — 2.11.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# ai-api-unified 2.10.0
+# ai-api-unified 2.11.0
 
 `ai-api-unified` is a unified Python library for AI completions, embeddings, image generation, video generation, and voice. Application code targets stable base interfaces and factory entry points while concrete providers are selected at runtime from environment configuration.
 
@@ -37,7 +37,7 @@ The public entry points are the stable base interfaces and factories:
 
 | Capability  | Stable interface    | Engines                                                                                                                       | Required extra(s)                                    |
 | ----------- | ------------------- | ----------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
-| Completions | `AIBaseCompletions` | `openai`, `google-gemini`, Bedrock-routed aliases such as `nova`, `anthropic`, `llama`, `mistral`, `cohere`, `ai21`, `rerank` | `openai`, `google_gemini`, `bedrock`                 |
+| Completions | `AIBaseCompletions` | `openai`, `openai-responses`, `claude`, `google-gemini`, Bedrock-routed aliases such as `nova`, `anthropic`, `llama`, `mistral`, `cohere`, `ai21`, `rerank` | `openai`, `anthropic`, `google_gemini`, `bedrock`    |
 | Embeddings  | `AIBaseEmbeddings`  | `openai`, `titan`, `google-gemini`                                                                                            | `openai`, `bedrock`, `google_gemini`                 |
 | Images      | `AIBaseImages`      | `openai`, `google-gemini`, `nova-canvas` and Bedrock image aliases                                                            | `openai`, `google_gemini`, `bedrock`                 |
 | Videos      | `AIBaseVideos`      | `openai`, `google-gemini`, `nova-reel` and Bedrock video aliases                                                              | `openai`, `google_gemini`, `bedrock`                 |
@@ -46,6 +46,7 @@ The public entry points are the stable base interfaces and factories:
 
 Default model guidance in the checked-in OSS env files:
 
+- Anthropic completions: `claude-opus-4-8`
 - Google completions: `gemini-2.5-flash`
 - Google embeddings: `gemini-embedding-001` (text-only) or `gemini-embedding-2` (multimodal)
 - Google images: `imagen-4.0-generate-001`
@@ -71,6 +72,7 @@ Install with one or more provider extras:
 ```bash
 poetry add 'ai-api-unified[google_gemini]'
 poetry add 'ai-api-unified[openai]'
+poetry add 'ai-api-unified[anthropic]'
 poetry add 'ai-api-unified[bedrock,google_gemini]'
 poetry add 'ai-api-unified[google_gemini,video_frames]'
 poetry add 'ai-api-unified[openai,video_frames]'
@@ -100,6 +102,7 @@ poetry install --all-extras --with dev
 | Extra                            | Installs                                                               |
 | -------------------------------- | ---------------------------------------------------------------------- |
 | `openai`                         | OpenAI completions, embeddings, images, and voice                      |
+| `anthropic`                      | Anthropic Claude completions via the native Anthropic API (`claude` engine) |
 | `google_gemini`                  | Google Gemini completions, embeddings, images, and Google voice        |
 | `bedrock`                        | AWS Bedrock completions, Titan embeddings, Bedrock image providers, and Bedrock video providers |
 | `video_frames`                   | Optional frame extraction helpers backed by ImageIO + Pillow           |
@@ -161,7 +164,7 @@ print(response)
 Every completions client exposes a `capabilities` descriptor with a
 `supports_streaming` flag set per model. Models without streaming support raise
 `AiProviderCapabilityUnsupportedError` from `send_prompt_streaming`. OpenAI,
-Google Gemini, and Bedrock chat models all stream:
+Anthropic, Google Gemini, and Bedrock chat models all stream:
 
 ```python
 from ai_api_unified import AIFactory
@@ -181,11 +184,12 @@ boundaries, so use `send_prompt` in PII-redacting deployments.
 
 Providers whose capabilities include `supports_token_counting` can return a
 provider-counted input token total without running inference. Bedrock supports
-this via its `CountTokens` operation; other providers raise
+this via its `CountTokens` operation and the native Anthropic API via its
+`count_tokens` endpoint; other providers raise
 `AiProviderCapabilityUnsupportedError`.
 
 ```python
-client = AIFactory.get_ai_completions_client(completions_engine="nova")
+client = AIFactory.get_ai_completions_client(completions_engine="claude")
 
 if client.capabilities.supports_token_counting:
     print(client.count_tokens("How many tokens is this prompt?"))
@@ -199,6 +203,35 @@ uses the Responses API, OpenAI's successor to Chat Completions. Both implement
 `send_prompt`, `strict_schema_prompt`, and
 `send_prompt_streaming`. The Responses engine is text-only for now; use the
 `openai` engine for image inputs.
+
+### Anthropic Claude engines
+
+Claude models are reachable through two completions engines:
+
+- `claude` — the native Anthropic API (api.anthropic.com) via the official
+  `anthropic` SDK. Requires the `anthropic` extra and `ANTHROPIC_API_KEY`.
+- `anthropic` — Claude on Amazon Bedrock via the Converse API. Requires the
+  `bedrock` extra and AWS credentials.
+
+The two engines expose the same caller-facing API (`send_prompt`,
+`strict_schema_prompt`, `send_prompt_streaming`, `count_tokens`); switching
+between them is a configuration change. Use `claude` for the current model
+lineup on Anthropic's own endpoint; use `anthropic` when your Claude access is
+provisioned through AWS.
+
+```dotenv
+COMPLETIONS_ENGINE=claude
+COMPLETIONS_MODEL_NAME=claude-opus-4-8
+ANTHROPIC_API_KEY=...
+```
+
+Models catalogued for the `claude` engine (alias model IDs):
+`claude-fable-5`, `claude-opus-4-8` (default), `claude-opus-4-7`,
+`claude-opus-4-6`, `claude-sonnet-4-6`, and `claude-haiku-4-5`. Capabilities
+per model include the context window (1M tokens except `claude-haiku-4-5` at
+200K), streaming, provider-side token counting, image inputs, and registry
+pricing. Structured output uses the Messages API JSON-schema response format,
+so `strict_schema_prompt` works on every catalogued model.
 
 ### Model pricing
 
@@ -414,7 +447,7 @@ There is no implicit default provider. Set the selector for each capability you 
 
 | Environment variable | Valid values                                                                                                                  |
 | -------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
-| `COMPLETIONS_ENGINE` | `openai`, `openai-responses`, `google-gemini`, Bedrock-routed aliases such as `nova`, `anthropic`, `llama`, `mistral`, `cohere`, `ai21`, `rerank` |
+| `COMPLETIONS_ENGINE` | `openai`, `openai-responses`, `claude`, `google-gemini`, Bedrock-routed aliases such as `nova`, `anthropic`, `llama`, `mistral`, `cohere`, `ai21`, `rerank` |
 | `EMBEDDING_ENGINE`   | `openai`, `titan`, `google-gemini`                                                                                            |
 | `IMAGE_ENGINE`       | `openai`, `google-gemini`, `nova-canvas`, `bedrock`, `nova`                                                                   |
 | `VIDEO_ENGINE`       | `openai`, `google-gemini`, `bedrock`, `nova`, `nova-reel`                                                                     |
@@ -454,6 +487,25 @@ Common optional settings:
 - `VIDEO_MODEL_NAME`
 - `EMBEDDING_DIMENSIONS`
 - `AI_API_GEO_RESIDENCY`
+
+#### Anthropic (native Claude API)
+
+Required for the `claude` completions engine:
+
+- `ANTHROPIC_API_KEY`
+
+Common optional settings:
+
+- `COMPLETIONS_MODEL_NAME` (defaults to `claude-opus-4-8`)
+
+Claude via Amazon Bedrock (the `anthropic` engine) does not use
+`ANTHROPIC_API_KEY`; it authenticates with AWS credentials like the other
+Bedrock engines below.
+
+For current model IDs and pricing, use the Anthropic documentation:
+
+- [Claude model overview](https://platform.claude.com/docs/en/about-claude/models/overview)
+- [Claude API pricing](https://platform.claude.com/docs/en/pricing)
 
 #### AWS Bedrock and Titan
 

--- a/README.md
+++ b/README.md
@@ -231,7 +231,11 @@ Models catalogued for the `claude` engine (alias model IDs):
 per model include the context window (1M tokens except `claude-haiku-4-5` at
 200K), streaming, provider-side token counting, image inputs, and registry
 pricing. Structured output uses the Messages API JSON-schema response format,
-so `strict_schema_prompt` works on every catalogued model.
+so `strict_schema_prompt` works on every catalogued model. On
+`claude-fable-5`, whose thinking is always on and counts against `max_tokens`,
+pass a `max_response_tokens` well above the 2048 default so the budget covers
+thinking plus the JSON body. Image attachments are capped at Anthropic's 5MB
+per-image limit.
 
 ### Model pricing
 

--- a/docs/pricing_research.md
+++ b/docs/pricing_research.md
@@ -66,8 +66,19 @@ models split into input / cached-input / output.
 | Bedrock | amazon.nova-pro | 0.80 | n/a | 3.20 | high |
 | Bedrock | amazon.nova-premier | 2.50 | n/a | 12.50 | high |
 | Bedrock | claude-3-5-haiku | 0.80 | n/a | 4.00 | high |
+| Anthropic | claude-fable-5 | 10.00 | 1.00 | 50.00 | high |
+| Anthropic | claude-opus-4-8 | 5.00 | 0.50 | 25.00 | high |
+| Anthropic | claude-opus-4-7 | 5.00 | 0.50 | 25.00 | high |
+| Anthropic | claude-opus-4-6 | 5.00 | 0.50 | 25.00 | high |
+| Anthropic | claude-sonnet-4-6 | 3.00 | 0.30 | 15.00 | high |
+| Anthropic | claude-haiku-4-5 | 1.00 | 0.10 | 5.00 | high |
 
-Notes: Gemini audio input is priced higher than text (2.5-flash audio input
+Notes: Anthropic rates are the native-API list (added 2026-07 with the `claude`
+engine); the cached-input column is the documented 0.1x prompt-cache read rate,
+and 5-minute cache writes bill 1.25x input (not modeled). Anthropic lifecycle
+entries also cover claude-opus-4-1 (deprecated, retires 2026-08-05, replace
+with claude-opus-4-8) and the retired claude-3-7-sonnet, claude-3-5-haiku, and
+claude-3-opus snapshots. Gemini audio input is priced higher than text (2.5-flash audio input
 $1.00/1M). Gemini rates shown are the Gemini Developer API list; Vertex differs
 for the 2.0 family ($0.15 in / $0.60 out). Bedrock on-demand; cross-region
 inference profiles add ~10%, batch ≈50% off.
@@ -220,5 +231,6 @@ layer needs; building it first is why this work comes before the middleware.
 - OpenAI: developers.openai.com/api/docs/pricing and per-model `/models/<name>` pages
 - Google: ai.google.dev/gemini-api/docs/pricing, cloud.google.com/vertex-ai/generative-ai/pricing, ai.google.dev/gemini-api/docs/deprecations
 - AWS: aws.amazon.com/bedrock/pricing, aws.amazon.com/nova/pricing (tables are JS-rendered; AWS figures cross-checked via search, med confidence on embeddings/images/video)
+- Anthropic: platform.claude.com/docs/en/about-claude/models/overview and platform.claude.com/docs/en/pricing (high confidence)
 - Azure: azure.microsoft.com/en-us/pricing/details/cognitive-services/speech-services (page timed out; search-derived, med confidence)
 - ElevenLabs: elevenlabs.io/pricing/api (high confidence)

--- a/docs/pricing_research.md
+++ b/docs/pricing_research.md
@@ -72,6 +72,7 @@ models split into input / cached-input / output.
 | Anthropic | claude-opus-4-6 | 5.00 | 0.50 | 25.00 | high |
 | Anthropic | claude-sonnet-4-6 | 3.00 | 0.30 | 15.00 | high |
 | Anthropic | claude-haiku-4-5 | 1.00 | 0.10 | 5.00 | high |
+| Anthropic | claude-opus-4-1 ⚠ | 15.00 | 1.50 | 75.00 | high |
 
 Notes: Anthropic rates are the native-API list (added 2026-07 with the `claude`
 engine); the cached-input column is the documented 0.1x prompt-cache read rate,

--- a/env_template
+++ b/env_template
@@ -11,18 +11,22 @@ EMBEDDING_ENGINE=google-gemini
 ########################################################################
 # --- OpenAI ---
 OPENAI_API_KEY=
+# --- Anthropic (native Claude API; used by COMPLETIONS_ENGINE=claude) ---
+ANTHROPIC_API_KEY=
 # Geo-residency constraint (optional: US | USA | United States)
 AI_API_GEO_RESIDENCY=
 GOOGLE_GEMINI_API_KEY=
 GOOGLE_AUTH_METHOD=api_key
+# Completions engine (openai | openai-responses | claude | google-gemini | nova | anthropic | ...)
 COMPLETIONS_ENGINE=google-gemini
 
 # Generic AI settings
 # Embedding model name (text-embedding-3-small | amazon.titan-embed-text-v2:0 | gemini-embedding-001)
 EMBEDDING_MODEL_NAME=gemini-embedding-001
 # EMBEDDING_MODEL_NAME=amazon.titan-embed-text-v2:0
-# Completions model name (gpt-4o-mini | amazon.nova-micro-v1:0 | amazon.nova-lite-v1:0 | gemini-2.5-flash)
+# Completions model name (gpt-4o-mini | claude-opus-4-8 | amazon.nova-micro-v1:0 | amazon.nova-lite-v1:0 | gemini-2.5-flash)
 COMPLETIONS_MODEL_NAME=gemini-2.5-flash
+# COMPLETIONS_MODEL_NAME=claude-opus-4-8
 # COMPLETIONS_MODEL_NAME=amazon.nova-lite-v1:0
 # Embedding dimensions (1536 for OpenAI | 1024 for Titan | 3072 default for Gemini)
 # Leave unset to use the provider default for the selected engine.

--- a/poetry.lock
+++ b/poetry.lock
@@ -26,6 +26,37 @@ files = [
 ]
 
 [[package]]
+name = "anthropic"
+version = "0.116.0"
+description = "The official Python library for the anthropic API"
+optional = true
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "extra == \"anthropic\""
+files = [
+    {file = "anthropic-0.116.0-py3-none-any.whl", hash = "sha256:6c0a7698e8d652455da3499978279bb2588c7264d0a35be3666009a4258c8256"},
+    {file = "anthropic-0.116.0.tar.gz", hash = "sha256:5fc248fbb9fe03ef686f8a774f81586bca31a043260aab88b387ea3660f4a396"},
+]
+
+[package.dependencies]
+anyio = ">=3.5.0,<5"
+distro = ">=1.7.0,<2"
+docstring-parser = ">=0.15,<1"
+httpx = ">=0.25.0,<1"
+jiter = ">=0.4.0,<1"
+pydantic = ">=1.9.0,<3"
+sniffio = "*"
+typing-extensions = ">=4.14,<5"
+
+[package.extras]
+aiohttp = ["aiohttp", "httpx-aiohttp (>=0.1.9)"]
+aws = ["boto3 (>=1.28.57)", "botocore (>=1.31.57)"]
+bedrock = ["boto3 (>=1.28.57)", "botocore (>=1.31.57)"]
+mcp = ["mcp (>=1.0) ; python_version >= \"3.10\""]
+vertex = ["google-auth[requests] (>=2,<3)"]
+webhooks = ["standardwebhooks (>=1.0.1,<2)"]
+
+[[package]]
 name = "anyio"
 version = "4.9.0"
 description = "High level compatibility layer for multiple asynchronous event loop implementations"
@@ -750,11 +781,29 @@ description = "Distro - an OS platform information API"
 optional = true
 python-versions = ">=3.6"
 groups = ["main"]
-markers = "extra == \"openai\" or extra == \"google-gemini\""
+markers = "extra == \"openai\" or extra == \"anthropic\" or extra == \"google-gemini\""
 files = [
     {file = "distro-1.9.0-py3-none-any.whl", hash = "sha256:7bffd925d65168f85027d8da9af6bddab658135b840670a223589bc0c8ef02b2"},
     {file = "distro-1.9.0.tar.gz", hash = "sha256:2fa77c6fd8940f116ee1d6b94a2f90b13b5ea8d019b98bc8bafdcabcdd9bdbed"},
 ]
+
+[[package]]
+name = "docstring-parser"
+version = "0.18.0"
+description = "Parse Python docstrings in reST, Google and Numpydoc format"
+optional = true
+python-versions = ">=3.8"
+groups = ["main"]
+markers = "extra == \"anthropic\""
+files = [
+    {file = "docstring_parser-0.18.0-py3-none-any.whl", hash = "sha256:b3fcbed555c47d8479be0796ef7e19c2670d428d72e96da63f3a40122860374b"},
+    {file = "docstring_parser-0.18.0.tar.gz", hash = "sha256:292510982205c12b1248696f44959db3cdd1740237a968ea1e2e7a900eeb2015"},
+]
+
+[package.extras]
+dev = ["pre-commit (>=2.16.0) ; python_version >= \"3.9\"", "pydoctor (>=25.4.0)", "pytest"]
+docs = ["pydoctor (>=25.4.0)"]
+test = ["pytest"]
 
 [[package]]
 name = "elevenlabs"
@@ -1198,7 +1247,7 @@ description = "Fast iterable JSON parser."
 optional = true
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "extra == \"openai\""
+markers = "extra == \"openai\" or extra == \"anthropic\""
 files = [
     {file = "jiter-0.10.0-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:cd2fb72b02478f06a900a5782de2ef47e0396b3e1f7d5aba30daeb1fce66f303"},
     {file = "jiter-0.10.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:32bb468e3af278f095d3fa5b90314728a6916d89ba3d0ffb726dd9bf7367285e"},
@@ -3396,6 +3445,7 @@ files = [
 dev = ["pytest", "setuptools"]
 
 [extras]
+anthropic = ["anthropic"]
 azure-tts = ["azure-cognitiveservices-speech"]
 bedrock = ["boto3"]
 dev = ["black", "pytest", "ruff"]
@@ -3411,4 +3461,4 @@ video-frames = ["Pillow", "imageio", "imageio-ffmpeg"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<3.14"
-content-hash = "ca5b54710e4588f0f8417758e5186c54a00aeb2dd223156be94375e80b91747d"
+content-hash = "8254169749ab6f83f89de471b787167f7d30c1d0a73f3f820191a7490756cf05"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@
 [project]
 name = "ai_api_unified"
 
-version = "2.10.0" # keep in sync with src/ai_api_unified/__version__.py and the README.md title
+version = "2.11.0" # keep in sync with src/ai_api_unified/__version__.py and the README.md title
 description = "Unified access layer for AI completions (LLM), embedding (semantic), image, video, and voice services"
 authors = [{ name = "Dave Thomas", email = "davidcthomas@gmail.com" }]
 license = "MIT"
@@ -44,6 +44,8 @@ readme = "README.md"
 keywords = [
   "llm",
   "openai",
+  "anthropic",
+  "claude",
   "bedrock",
   "gemini",
   "vertex",
@@ -80,6 +82,7 @@ dependencies = [
 [project.optional-dependencies]
 dev = ["pytest>=8.4.0,<9.0.0", "ruff>=0.4.4,<1.0.0", "black>=24.4.2,<25.0.0"]
 openai = ["openai>=2.0.0,<3.0.0"]
+anthropic = ["anthropic>=0.116.0,<1.0.0"]
 azure_tts = ["azure-cognitiveservices-speech>=1.37.0,<2.0.0"]
 bedrock = ["boto3>=1.34.0,<2.0.0"]
 elevenlabs = ["elevenlabs>=2.3.0,<3.0.0"]

--- a/src/ai_api_unified/__version__.py
+++ b/src/ai_api_unified/__version__.py
@@ -9,4 +9,4 @@ from __future__ import annotations
 
 __all__: list[str] = ["__version__"]
 
-__version__: str = "2.10.0"
+__version__: str = "2.11.0"

--- a/src/ai_api_unified/ai_anthropic_base.py
+++ b/src/ai_api_unified/ai_anthropic_base.py
@@ -1,0 +1,39 @@
+# ai_anthropic_base.py
+
+"""
+Shared client setup for providers backed by the native Anthropic API
+(api.anthropic.com). Claude models are also reachable through Amazon Bedrock
+via the `anthropic` completions engine; this base is only for the direct
+Anthropic API path (`claude` engine), which authenticates with
+ANTHROPIC_API_KEY.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from anthropic import Anthropic
+
+from ai_api_unified.util.env_settings import EnvSettings
+
+_LOGGER: logging.Logger = logging.getLogger(__name__)
+
+
+class AIAnthropicBase:
+    """
+    Base class for native Anthropic API interactions.
+    """
+
+    def __init__(self, **kwargs: Any):
+        """
+        Initialize the AIAnthropicBase class with environment settings and API credentials.
+        """
+        self.env = EnvSettings()
+        self.api_key = self.env.get_setting("ANTHROPIC_API_KEY")
+        self.user = self.env.get_setting("ANTHROPIC_USER", "default_user")
+        if not self.api_key or self.api_key.strip() == "":
+            raise ValueError("ANTHROPIC_API_KEY environment variable must be set.")
+
+        self.client = Anthropic(api_key=self.api_key)
+        self.backoff_delays = [1, 2, 4, 8, 16]

--- a/src/ai_api_unified/ai_base.py
+++ b/src/ai_api_unified/ai_base.py
@@ -288,7 +288,9 @@ class AIBase(ABC):
     PROVIDER_VENDOR_GOOGLE = "google"
     PROVIDER_VENDOR_AZURE = "azure"
     PROVIDER_VENDOR_ELEVENLABS = "elevenlabs"
+    PROVIDER_VENDOR_ANTHROPIC = "anthropic"
     PROVIDER_ENGINE_GOOGLE_GEMINI = "google-gemini"
+    PROVIDER_ENGINE_CLAUDE = "claude"
     _observability_middleware: AiApiObservabilityMiddleware | None = None
 
     def __init__(self, model: str | None = None, **kwargs):
@@ -444,6 +446,9 @@ class AIBase(ABC):
             Best-effort provider vendor label derived from the concrete client module or class.
         """
         lower_module_name: str = self.__class__.__module__.lower()
+        if "anthropic" in lower_module_name:
+            # Early return for native Anthropic API clients.
+            return self.PROVIDER_VENDOR_ANTHROPIC
         if "openai" in lower_module_name:
             # Early return for OpenAI-backed clients.
             return self.PROVIDER_VENDOR_OPENAI
@@ -473,6 +478,9 @@ class AIBase(ABC):
             Best-effort provider engine label derived from the concrete client module or class.
         """
         lower_module_name: str = self.__class__.__module__.lower()
+        if "anthropic" in lower_module_name:
+            # Early return for native Anthropic API clients (the claude engine).
+            return self.PROVIDER_ENGINE_CLAUDE
         if "google_gemini" in lower_module_name or "gemini" in lower_module_name:
             # Early return for Gemini-backed clients.
             return self.PROVIDER_ENGINE_GOOGLE_GEMINI

--- a/src/ai_api_unified/ai_provider_registry.py
+++ b/src/ai_api_unified/ai_provider_registry.py
@@ -131,6 +131,19 @@ DICT_TUPLE_AI_PROVIDER_REGISTRY: dict[TypeAiProviderRegistryKey, AiProviderSpec]
     ),
     (
         AI_PROVIDER_CAPABILITY_COMPLETIONS,
+        "claude",
+    ): AiProviderSpec(
+        str_capability=AI_PROVIDER_CAPABILITY_COMPLETIONS,
+        str_engine="claude",
+        str_module_path=("ai_api_unified.completions.ai_anthropic_completions"),
+        str_class_name="AiAnthropicCompletions",
+        str_required_extra="anthropic",
+        str_consumer_install_command=("poetry add 'ai-api-unified[anthropic]'"),
+        str_local_install_command='poetry install --extras "anthropic"',
+        set_str_dependency_roots={"anthropic"},
+    ),
+    (
+        AI_PROVIDER_CAPABILITY_COMPLETIONS,
         "anthropic",
     ): AiProviderSpec(
         str_capability=AI_PROVIDER_CAPABILITY_COMPLETIONS,

--- a/src/ai_api_unified/completions/ai_anthropic_completions.py
+++ b/src/ai_api_unified/completions/ai_anthropic_completions.py
@@ -103,6 +103,11 @@ class AiAnthropicCompletions(AIAnthropicBase, AIBaseCompletions):
     SEND_PROMPT_MAX_TOKENS: ClassVar[int] = 16_000
     # Streaming has no timeout concern; give the model room.
     STREAMING_MAX_TOKENS: ClassVar[int] = 64_000
+    # Anthropic rejects images above 5MB per image, below the library-wide
+    # 20MB attachment cap, so this engine enforces the tighter limit locally.
+    MAX_IMAGE_BYTES_ANTHROPIC: ClassVar[int] = 5_000_000
+    STOP_REASON_REFUSAL: ClassVar[str] = "refusal"
+    STOP_REASON_MAX_TOKENS: ClassVar[str] = "max_tokens"
 
     def __init__(self, model: str = "", **kwargs: Any):
         """
@@ -113,10 +118,11 @@ class AiAnthropicCompletions(AIAnthropicBase, AIBaseCompletions):
             model: The Claude model to use; falls back to COMPLETIONS_MODEL_NAME.
         """
         AIAnthropicBase.__init__(self, **kwargs)
-        explicit_model: str = model.strip() if model else ""
-        self.completions_model: str = explicit_model or self.env.get_setting(
+        raw_model: str = model or self.env.get_setting(
             "COMPLETIONS_MODEL_NAME", self.DEFAULT_COMPLETIONS_MODEL
         )
+        # Normalize once so lifecycle, context, and pricing lookups agree.
+        self.completions_model: str = raw_model.strip().lower()
         AIBaseCompletions.__init__(self, model=self.completions_model, **kwargs)
         self.model = self.completions_model
         enforce_model_lifecycle(PROVIDER_ANTHROPIC, self.completions_model)
@@ -167,13 +173,18 @@ class AiAnthropicCompletions(AIAnthropicBase, AIBaseCompletions):
         # Anthropic recommends placing media blocks before the text block.
         content_parts: list[dict[str, Any]] = []
         for (
-            _index,
+            index,
             media_type,
             media_bytes,
             mime_type,
         ) in other_params.iter_included_media():
             if media_type is not SupportedDataType.IMAGE:
                 continue
+            if len(media_bytes) > self.MAX_IMAGE_BYTES_ANTHROPIC:
+                raise ValueError(
+                    f"Image attachment {index} exceeds Anthropic's per-image "
+                    f"limit of {self.MAX_IMAGE_BYTES_ANTHROPIC} bytes."
+                )
             encoded_bytes: str = base64.b64encode(media_bytes).decode("ascii")
             content_parts.append(
                 {
@@ -224,20 +235,33 @@ class AiAnthropicCompletions(AIAnthropicBase, AIBaseCompletions):
 
         The structured-output format requires additionalProperties to be false
         on every object node; Pydantic does not emit that, so this walks the
-        generated schema and sets it.
+        generated schema and sets it. The walk recurses only through known
+        schema-bearing keywords so property names like "properties" or
+        "additionalProperties" on caller models are never mistaken for schema
+        nodes.
         """
         dict_schema: dict[str, Any] = copy.deepcopy(response_model.model_json_schema())
 
         def _close_objects(node: Any) -> None:
-            if isinstance(node, dict):
-                if node.get("type") == "object" or "properties" in node:
-                    node.setdefault("additionalProperties", False)
-                # Loop through nested schema nodes so every object is closed.
-                for value in node.values():
-                    _close_objects(value)
-            elif isinstance(node, list):
-                for item in node:
-                    _close_objects(item)
+            if not isinstance(node, dict):
+                return
+            if node.get("type") == "object":
+                node.setdefault("additionalProperties", False)
+            # Recurse only through schema-bearing keywords; "properties" and
+            # "$defs" values are name->schema mappings, the rest are schemas
+            # or schema lists.
+            for mapping_key in ("properties", "$defs", "patternProperties"):
+                mapping = node.get(mapping_key)
+                if isinstance(mapping, dict):
+                    for child_schema in mapping.values():
+                        _close_objects(child_schema)
+            for schema_key in ("items", "additionalProperties", "not"):
+                _close_objects(node.get(schema_key))
+            for list_key in ("anyOf", "allOf", "oneOf", "prefixItems"):
+                list_schemas = node.get(list_key)
+                if isinstance(list_schemas, list):
+                    for child_schema in list_schemas:
+                        _close_objects(child_schema)
 
         _close_objects(dict_schema)
         return dict_schema
@@ -281,7 +305,23 @@ class AiAnthropicCompletions(AIAnthropicBase, AIBaseCompletions):
                 system=system_prompt,
                 messages=[{"role": "user", "content": user_content}],
             )
+            str_stop_reason: str = str(getattr(response, "stop_reason", "") or "")
+            if str_stop_reason == self.STOP_REASON_REFUSAL:
+                # Safety classifiers return HTTP 200 with an empty or partial
+                # body; surfacing that as a successful completion would be
+                # indistinguishable from a real answer.
+                raise RuntimeError(
+                    f"Anthropic declined the request for model "
+                    f"'{self.completions_model}' (stop_reason=refusal)."
+                )
             raw_output_text: str = self._extract_response_text(response)
+            if str_stop_reason == self.STOP_REASON_MAX_TOKENS:
+                _LOGGER.warning(
+                    "Anthropic response for model '%s' was truncated at the "
+                    "%s-token max_tokens cap.",
+                    self.completions_model,
+                    self.SEND_PROMPT_MAX_TOKENS,
+                )
             prompt_tokens, completion_tokens, total_tokens = (
                 self._extract_anthropic_usage(response)
             )
@@ -289,7 +329,7 @@ class AiAnthropicCompletions(AIAnthropicBase, AIBaseCompletions):
             return AiApiObservedCompletionsResultModel(
                 return_value=raw_output_text,
                 raw_output_text=raw_output_text,
-                finish_reason=str(getattr(response, "stop_reason", "") or ""),
+                finish_reason=str_stop_reason,
                 provider_prompt_tokens=prompt_tokens,
                 provider_completion_tokens=completion_tokens,
                 provider_total_tokens=total_tokens,
@@ -322,6 +362,11 @@ class AiAnthropicCompletions(AIAnthropicBase, AIBaseCompletions):
         """
         Generate structured output via the Messages API output_config JSON-schema
         format and parse the response into the specified Pydantic model.
+
+        On models with always-on thinking (claude-fable-5), thinking tokens
+        count against max_tokens; pass a max_response_tokens well above the
+        2048 shared default there so the budget covers thinking plus the JSON
+        body.
 
         Args:
             prompt: The prompt string to send.
@@ -376,8 +421,13 @@ class AiAnthropicCompletions(AIAnthropicBase, AIBaseCompletions):
                 output_config=dict_output_config,
             )
             str_finish_reason: str = str(getattr(response, "stop_reason", "") or "")
+            if str_finish_reason == self.STOP_REASON_REFUSAL:
+                raise RuntimeError(
+                    f"Anthropic declined the request for model "
+                    f"'{self.completions_model}' (stop_reason=refusal)."
+                )
             raw_output_text: str = self._extract_response_text(response)
-            if str_finish_reason == "max_tokens":
+            if str_finish_reason == self.STOP_REASON_MAX_TOKENS:
                 self._raise_structured_token_limit_error(
                     provider_name=self.PROVIDER_VENDOR_ANTHROPIC,
                     model_name=self.completions_model,
@@ -495,14 +545,20 @@ class AiAnthropicCompletions(AIAnthropicBase, AIBaseCompletions):
                             yield str_chunk_text
                 elif str_event_type == "message_start":
                     usage = getattr(getattr(event, "message", None), "usage", None)
-                    dict_stream_state["int_input_tokens"] = getattr(
-                        usage, "input_tokens", None
-                    )
+                    int_input_tokens: int | None = getattr(usage, "input_tokens", None)
+                    if int_input_tokens is not None:
+                        dict_stream_state["int_input_tokens"] = int_input_tokens
                 elif str_event_type == "message_delta":
                     delta = getattr(event, "delta", None)
                     str_stop_reason: str | None = getattr(delta, "stop_reason", None)
                     if str_stop_reason is not None:
                         dict_stream_state["finish_reason"] = str(str_stop_reason)
+                        if str(str_stop_reason) == self.STOP_REASON_REFUSAL:
+                            _LOGGER.warning(
+                                "Anthropic declined mid-stream for model '%s' "
+                                "(stop_reason=refusal); streamed text is partial.",
+                                self.completions_model,
+                            )
                     usage = getattr(event, "usage", None)
                     int_output_tokens: int | None = getattr(
                         usage, "output_tokens", None

--- a/src/ai_api_unified/completions/ai_anthropic_completions.py
+++ b/src/ai_api_unified/completions/ai_anthropic_completions.py
@@ -1,0 +1,612 @@
+# ai_anthropic_completions.py
+
+"""
+Anthropic Claude completions via the native Anthropic API (api.anthropic.com).
+
+This engine targets the Messages API (`client.messages`) using the official
+`anthropic` SDK and ANTHROPIC_API_KEY authentication. It is registered as the
+`claude` completions engine. Claude models remain reachable through Amazon
+Bedrock via the `anthropic` engine; the two differ only in configuration
+(native API key vs AWS credentials) and expose the same caller-facing API.
+
+Structured output uses the Messages API `output_config` JSON-schema format,
+which constrains the response to the supplied schema on all current Claude
+models (including models whose always-on thinking is incompatible with forced
+tool choice). Token counting uses the provider-side
+`client.messages.count_tokens` endpoint.
+"""
+
+from __future__ import annotations
+
+import base64
+import copy
+import json
+import logging
+from collections.abc import Iterator
+from typing import Any, ClassVar, Type
+
+from pydantic import ValidationError
+
+from ..ai_anthropic_base import AIAnthropicBase
+from ..ai_base import (
+    AIBaseCompletions,
+    AiApiObservedCompletionsResultModel,
+    AIStructuredPrompt,
+    AICompletionsCapabilitiesBase,
+    AICompletionsPromptParamsBase,
+    SupportedDataType,
+)
+from ..middleware.observability_runtime import (
+    AiApiCallResultSummaryModel,
+    ObservabilityMetadataValue,
+)
+from ..pricing.pricing_registry import (
+    PROVIDER_ANTHROPIC,
+    enforce_model_lifecycle,
+    get_model_pricing,
+)
+
+_LOGGER: logging.Logger = logging.getLogger(__name__)
+
+
+class AICompletionsCapabilitiesAnthropic(AICompletionsCapabilitiesBase):
+    """Anthropic-specific completions capabilities.
+
+    Based on https://platform.claude.com/docs/en/about-claude/models/overview
+    (current model lineup, context windows, and feature support).
+    """
+
+    # Context window sizes (max input tokens each model can handle).
+    DICT_ANTHROPIC_CONTEXT_WINDOWS: ClassVar[dict[str, int]] = {
+        "claude-fable-5": 1_000_000,
+        "claude-opus-4-8": 1_000_000,
+        "claude-opus-4-7": 1_000_000,
+        "claude-opus-4-6": 1_000_000,
+        "claude-sonnet-4-6": 1_000_000,
+        "claude-haiku-4-5": 200_000,
+    }
+
+    # Conservative context window for models absent from the lookup table.
+    DEFAULT_CONTEXT_WINDOW_LENGTH: ClassVar[int] = 200_000
+
+    @classmethod
+    def for_model(cls, model_name: str) -> "AICompletionsCapabilitiesAnthropic":
+        """Create capabilities instance for the requested Claude model.
+
+        Every current Claude model streams via the Messages API, counts input
+        tokens via the provider-side count_tokens endpoint, accepts image
+        inputs, and supports reasoning (adaptive or extended thinking).
+        """
+        normalized_name: str = model_name.strip().lower()
+        # Normal return with per-model context window and registry pricing.
+        return cls(
+            context_window_length=cls.DICT_ANTHROPIC_CONTEXT_WINDOWS.get(
+                normalized_name, cls.DEFAULT_CONTEXT_WINDOW_LENGTH
+            ),
+            reasoning=True,
+            supported_data_types=[SupportedDataType.TEXT, SupportedDataType.IMAGE],
+            supports_streaming=True,
+            supports_token_counting=True,
+            pricing=get_model_pricing(PROVIDER_ANTHROPIC, normalized_name),
+        )
+
+
+class AiAnthropicCompletions(AIAnthropicBase, AIBaseCompletions):
+    """
+    Completion client for the native Anthropic API via the Messages API,
+    with structured-output prompts, streaming, and token counting.
+    """
+
+    DEFAULT_COMPLETIONS_MODEL: ClassVar[str] = "claude-opus-4-8"
+    # The Messages API requires max_tokens on every request. Non-streaming
+    # requests stay under SDK HTTP-timeout guards at this size.
+    SEND_PROMPT_MAX_TOKENS: ClassVar[int] = 16_000
+    # Streaming has no timeout concern; give the model room.
+    STREAMING_MAX_TOKENS: ClassVar[int] = 64_000
+
+    def __init__(self, model: str = "", **kwargs: Any):
+        """
+        Initializes the AiAnthropicCompletions class, setting the model and
+        related configuration.
+
+        Args:
+            model: The Claude model to use; falls back to COMPLETIONS_MODEL_NAME.
+        """
+        AIAnthropicBase.__init__(self, **kwargs)
+        explicit_model: str = model.strip() if model else ""
+        self.completions_model: str = explicit_model or self.env.get_setting(
+            "COMPLETIONS_MODEL_NAME", self.DEFAULT_COMPLETIONS_MODEL
+        )
+        AIBaseCompletions.__init__(self, model=self.completions_model, **kwargs)
+        self.model = self.completions_model
+        enforce_model_lifecycle(PROVIDER_ANTHROPIC, self.completions_model)
+        self._capabilities: AICompletionsCapabilitiesAnthropic = (
+            AICompletionsCapabilitiesAnthropic.for_model(self.completions_model)
+        )
+
+    @property
+    def capabilities(self) -> AICompletionsCapabilitiesAnthropic:
+        """Return the resolved capabilities for the current Claude model."""
+        return self._capabilities
+
+    @property
+    def list_model_names(self) -> list[str]:
+        # Current Claude lineup on the native Anthropic API (aliases, not
+        # date-suffixed snapshots).
+        return [
+            "claude-fable-5",  # most capable, premium tier
+            "claude-opus-4-8",  # most capable Opus-tier model (default)
+            "claude-opus-4-7",  # previous-generation Opus
+            "claude-opus-4-6",  # older Opus
+            "claude-sonnet-4-6",  # speed/intelligence balance
+            "claude-haiku-4-5",  # fastest, most cost-effective
+        ]
+
+    @property
+    def max_context_tokens(self) -> int:
+        """
+        Look up the Claude context window for the current model_name.
+        Falls back to 0 if unknown (i.e. no guard will occur).
+        """
+        return AICompletionsCapabilitiesAnthropic.DICT_ANTHROPIC_CONTEXT_WINDOWS.get(
+            self.completions_model, 0
+        )
+
+    def _build_user_message_content(
+        self,
+        prompt: str,
+        other_params: AICompletionsPromptParamsBase | None,
+    ) -> str | list[dict[str, Any]]:
+        """
+        Construct Messages API user content that supports image inputs.
+        Returns a plain string for text-only prompts.
+        """
+        if other_params is None or not other_params.has_included_media:
+            return prompt
+
+        # Anthropic recommends placing media blocks before the text block.
+        content_parts: list[dict[str, Any]] = []
+        for (
+            _index,
+            media_type,
+            media_bytes,
+            mime_type,
+        ) in other_params.iter_included_media():
+            if media_type is not SupportedDataType.IMAGE:
+                continue
+            encoded_bytes: str = base64.b64encode(media_bytes).decode("ascii")
+            content_parts.append(
+                {
+                    "type": "image",
+                    "source": {
+                        "type": "base64",
+                        "media_type": mime_type,
+                        "data": encoded_bytes,
+                    },
+                }
+            )
+
+        if not content_parts:
+            return prompt
+        content_parts.append({"type": "text", "text": prompt})
+        return content_parts
+
+    @staticmethod
+    def _extract_response_text(response: Any) -> str:
+        """Join the text blocks of a Messages API response, skipping thinking."""
+        list_text_parts: list[str] = []
+        for block in getattr(response, "content", None) or []:
+            if getattr(block, "type", "") == "text":
+                list_text_parts.append(getattr(block, "text", "") or "")
+        return "".join(list_text_parts)
+
+    @staticmethod
+    def _extract_anthropic_usage(
+        response: Any,
+    ) -> tuple[int | None, int | None, int | None]:
+        """Return (input, output, total) token counts from a Messages result."""
+        usage = getattr(response, "usage", None)
+        if usage is None:
+            return None, None, None
+        int_input_tokens: int | None = getattr(usage, "input_tokens", None)
+        int_output_tokens: int | None = getattr(usage, "output_tokens", None)
+        int_total_tokens: int | None = None
+        if int_input_tokens is not None or int_output_tokens is not None:
+            int_total_tokens = (int_input_tokens or 0) + (int_output_tokens or 0)
+        return int_input_tokens, int_output_tokens, int_total_tokens
+
+    @staticmethod
+    def _build_output_config_schema(
+        response_model: Type[AIStructuredPrompt],
+    ) -> dict[str, Any]:
+        """
+        Build a Messages API output_config JSON schema from a Pydantic model.
+
+        The structured-output format requires additionalProperties to be false
+        on every object node; Pydantic does not emit that, so this walks the
+        generated schema and sets it.
+        """
+        dict_schema: dict[str, Any] = copy.deepcopy(response_model.model_json_schema())
+
+        def _close_objects(node: Any) -> None:
+            if isinstance(node, dict):
+                if node.get("type") == "object" or "properties" in node:
+                    node.setdefault("additionalProperties", False)
+                # Loop through nested schema nodes so every object is closed.
+                for value in node.values():
+                    _close_objects(value)
+            elif isinstance(node, list):
+                for item in node:
+                    _close_objects(item)
+
+        _close_objects(dict_schema)
+        return dict_schema
+
+    def send_prompt(
+        self, prompt: str, *, other_params: AICompletionsPromptParamsBase | None = None
+    ) -> str:
+        """
+        Sends a prompt to the Anthropic Messages API and returns the text result.
+
+        Args:
+            prompt: The prompt string to send.
+            other_params: Optional provider-specific parameters (system prompt,
+                image attachments).
+
+        Returns:
+            The completion result as a string.
+        """
+        if not prompt or not prompt.strip():
+            raise ValueError("Prompt cannot be empty or None")
+        prompt = self.pii_middleware.process_input(prompt)
+        system_prompt: str = (
+            other_params.system_prompt
+            if other_params is not None and other_params.system_prompt is not None
+            else AICompletionsPromptParamsBase.DEFAULT_SYSTEM_PROMPT
+        )
+        user_content = self._build_user_message_content(prompt, other_params)
+        dict_input_metadata: dict[str, ObservabilityMetadataValue] = (
+            self._build_completions_observability_input_metadata(
+                prompt=prompt,
+                system_prompt=system_prompt,
+                other_params=other_params,
+                response_mode=self.RESPONSE_MODE_TEXT,
+            )
+        )
+
+        def _execute_text_prompt() -> AiApiObservedCompletionsResultModel[str]:
+            response = self.client.messages.create(
+                model=self.completions_model,
+                max_tokens=self.SEND_PROMPT_MAX_TOKENS,
+                system=system_prompt,
+                messages=[{"role": "user", "content": user_content}],
+            )
+            raw_output_text: str = self._extract_response_text(response)
+            prompt_tokens, completion_tokens, total_tokens = (
+                self._extract_anthropic_usage(response)
+            )
+            # Normal return with the Messages text output and usage metadata.
+            return AiApiObservedCompletionsResultModel(
+                return_value=raw_output_text,
+                raw_output_text=raw_output_text,
+                finish_reason=str(getattr(response, "stop_reason", "") or ""),
+                provider_prompt_tokens=prompt_tokens,
+                provider_completion_tokens=completion_tokens,
+                provider_total_tokens=total_tokens,
+            )
+
+        observed_result: AiApiObservedCompletionsResultModel[str] = (
+            self._execute_provider_call_with_observability(
+                capability=self.CLIENT_TYPE_COMPLETIONS,
+                operation="send_prompt",
+                dict_input_metadata=dict_input_metadata,
+                callable_execute=_execute_text_prompt,
+                callable_build_result_summary=lambda result, provider_elapsed_ms: self._build_completions_observability_result_summary(
+                    observed_result=result,
+                    provider_elapsed_ms=provider_elapsed_ms,
+                ),
+                legacy_caller_id=self.user,
+            )
+        )
+        # Normal return with sanitized Messages text after observability wrapping.
+        return self.pii_middleware.process_output(observed_result.return_value)
+
+    def strict_schema_prompt(
+        self,
+        prompt: str,
+        response_model: Type[AIStructuredPrompt],
+        max_response_tokens: int = AIBaseCompletions.STRUCTURED_DEFAULT_MAX_RESPONSE_TOKENS,
+        *,
+        other_params: AICompletionsPromptParamsBase | None = None,
+    ) -> AIStructuredPrompt:
+        """
+        Generate structured output via the Messages API output_config JSON-schema
+        format and parse the response into the specified Pydantic model.
+
+        Args:
+            prompt: The prompt string to send.
+            response_model: Pydantic model class the response is validated into.
+            max_response_tokens: Maximum tokens for the response.
+            other_params: Optional provider-specific parameters (system prompt,
+                image attachments).
+
+        Returns:
+            Structured response as an instance of response_model.
+        """
+        if not prompt or not prompt.strip():
+            raise ValueError("Prompt cannot be empty or None")
+        if not issubclass(response_model, AIStructuredPrompt):
+            raise ValueError("response_model must be a subclass of AIStructuredPrompt")
+        self._validate_structured_max_response_tokens(
+            provider_name=self.PROVIDER_VENDOR_ANTHROPIC,
+            model_name=self.completions_model,
+            max_response_tokens=max_response_tokens,
+        )
+        prompt = self.pii_middleware.process_input(prompt)
+        system_prompt: str = (
+            other_params.system_prompt
+            if other_params is not None and other_params.system_prompt is not None
+            else AICompletionsPromptParamsBase.DEFAULT_STRICT_SCHEMA_SYSTEM_PROMPT
+        )
+        user_content = self._build_user_message_content(prompt, other_params)
+        dict_input_metadata: dict[str, ObservabilityMetadataValue] = (
+            self._build_completions_observability_input_metadata(
+                prompt=prompt,
+                system_prompt=system_prompt,
+                other_params=other_params,
+                response_mode=self.RESPONSE_MODE_STRUCTURED,
+                max_response_tokens=max_response_tokens,
+            )
+        )
+        dict_output_config: dict[str, Any] = {
+            "format": {
+                "type": "json_schema",
+                "schema": self._build_output_config_schema(response_model),
+            }
+        }
+
+        def _generate_structured() -> (
+            AiApiObservedCompletionsResultModel[AIStructuredPrompt]
+        ):
+            response = self.client.messages.create(
+                model=self.completions_model,
+                max_tokens=max_response_tokens,
+                system=system_prompt,
+                messages=[{"role": "user", "content": user_content}],
+                output_config=dict_output_config,
+            )
+            str_finish_reason: str = str(getattr(response, "stop_reason", "") or "")
+            raw_output_text: str = self._extract_response_text(response)
+            if str_finish_reason == "max_tokens":
+                self._raise_structured_token_limit_error(
+                    provider_name=self.PROVIDER_VENDOR_ANTHROPIC,
+                    model_name=self.completions_model,
+                    max_response_tokens=max_response_tokens,
+                    finish_reason=str_finish_reason,
+                    raw_output_text=raw_output_text,
+                )
+            if not raw_output_text:
+                raise ValueError("Empty response from Anthropic Messages API")
+            prompt_tokens, completion_tokens, total_tokens = (
+                self._extract_anthropic_usage(response)
+            )
+            try:
+                content_str: str = self.pii_middleware.process_output(raw_output_text)
+                response_data: dict[str, Any] = json.loads(content_str)
+                validated_response: AIStructuredPrompt = response_model.model_validate(
+                    response_data
+                )
+            except json.JSONDecodeError as json_error:
+                raise ValueError(f"Invalid JSON response: {json_error}") from json_error
+            except ValidationError as validation_error:
+                raise ValueError(
+                    "Response validation failed with "
+                    f"{len(validation_error.errors())} validation errors."
+                ) from None
+            # Normal return with the validated structured response and usage metadata.
+            return AiApiObservedCompletionsResultModel(
+                return_value=validated_response,
+                raw_output_text=raw_output_text,
+                finish_reason=str_finish_reason,
+                provider_prompt_tokens=prompt_tokens,
+                provider_completion_tokens=completion_tokens,
+                provider_total_tokens=total_tokens,
+            )
+
+        observed_result: AiApiObservedCompletionsResultModel[AIStructuredPrompt] = (
+            self._execute_provider_call_with_observability(
+                capability=self.CLIENT_TYPE_COMPLETIONS,
+                operation="strict_schema_prompt",
+                dict_input_metadata=dict_input_metadata,
+                callable_execute=_generate_structured,
+                callable_build_result_summary=lambda result, provider_elapsed_ms: self._build_completions_observability_result_summary(
+                    observed_result=result,
+                    provider_elapsed_ms=provider_elapsed_ms,
+                ),
+                legacy_caller_id=self.user,
+            )
+        )
+        # Normal return with the caller-facing structured response.
+        return observed_result.return_value
+
+    def _send_prompt_streaming_provider(
+        self,
+        prompt: str,
+        *,
+        other_params: AICompletionsPromptParamsBase | None = None,
+    ) -> Iterator[str]:
+        """
+        Stream a Messages API text response chunk by chunk.
+
+        Capability and PII gating already ran in the base template method. No
+        retry wrapper: retrying a partially consumed stream would duplicate
+        output.
+
+        Args:
+            prompt: Validated text prompt to send.
+            other_params: Optional provider-specific parameters.
+
+        Returns:
+            Iterator of response text chunks in provider order.
+        """
+        system_prompt: str = (
+            other_params.system_prompt
+            if other_params is not None and other_params.system_prompt is not None
+            else AICompletionsPromptParamsBase.DEFAULT_SYSTEM_PROMPT
+        )
+        user_content = self._build_user_message_content(prompt, other_params)
+        dict_input_metadata: dict[str, ObservabilityMetadataValue] = (
+            self._build_completions_observability_input_metadata(
+                prompt=prompt,
+                system_prompt=system_prompt,
+                other_params=other_params,
+                response_mode=self.RESPONSE_MODE_TEXT,
+            )
+        )
+        dict_input_metadata["response_streaming"] = True
+
+        dict_stream_state: dict[str, Any] = {
+            "list_text_parts": [],
+            "int_chunk_count": 0,
+            "finish_reason": None,
+            "int_input_tokens": None,
+            "int_output_tokens": None,
+            "bool_completed": False,
+        }
+
+        def _open_stream() -> Iterator[str]:
+            stream = self.client.messages.create(
+                model=self.completions_model,
+                max_tokens=self.STREAMING_MAX_TOKENS,
+                system=system_prompt,
+                messages=[{"role": "user", "content": user_content}],
+                stream=True,
+            )
+            # Loop through Messages stream events so callers see text as it arrives.
+            for event in stream:
+                str_event_type: str = getattr(event, "type", "")
+                if str_event_type == "content_block_delta":
+                    delta = getattr(event, "delta", None)
+                    if getattr(delta, "type", "") == "text_delta":
+                        str_chunk_text: str = getattr(delta, "text", "") or ""
+                        if str_chunk_text:
+                            dict_stream_state["int_chunk_count"] += 1
+                            dict_stream_state["list_text_parts"].append(str_chunk_text)
+                            yield str_chunk_text
+                elif str_event_type == "message_start":
+                    usage = getattr(getattr(event, "message", None), "usage", None)
+                    dict_stream_state["int_input_tokens"] = getattr(
+                        usage, "input_tokens", None
+                    )
+                elif str_event_type == "message_delta":
+                    delta = getattr(event, "delta", None)
+                    str_stop_reason: str | None = getattr(delta, "stop_reason", None)
+                    if str_stop_reason is not None:
+                        dict_stream_state["finish_reason"] = str(str_stop_reason)
+                    usage = getattr(event, "usage", None)
+                    int_output_tokens: int | None = getattr(
+                        usage, "output_tokens", None
+                    )
+                    if int_output_tokens is not None:
+                        dict_stream_state["int_output_tokens"] = int_output_tokens
+            dict_stream_state["bool_completed"] = True
+
+        def _build_summary(provider_elapsed_ms: float) -> AiApiCallResultSummaryModel:
+            int_input_tokens: int | None = dict_stream_state["int_input_tokens"]
+            int_output_tokens: int | None = dict_stream_state["int_output_tokens"]
+            int_total_tokens: int | None = None
+            if int_input_tokens is not None or int_output_tokens is not None:
+                int_total_tokens = (int_input_tokens or 0) + (int_output_tokens or 0)
+            str_full_text: str = "".join(dict_stream_state["list_text_parts"])
+            observed_result: AiApiObservedCompletionsResultModel[str] = (
+                AiApiObservedCompletionsResultModel(
+                    return_value=str_full_text,
+                    raw_output_text=str_full_text,
+                    finish_reason=dict_stream_state["finish_reason"],
+                    provider_prompt_tokens=int_input_tokens,
+                    provider_completion_tokens=int_output_tokens,
+                    provider_total_tokens=int_total_tokens,
+                )
+            )
+            # Normal return with the streaming summary built from accumulated chunks.
+            return self._build_streaming_completions_observability_result_summary(
+                observed_result=observed_result,
+                provider_elapsed_ms=provider_elapsed_ms,
+                int_chunk_count=dict_stream_state["int_chunk_count"],
+                bool_stream_completed=dict_stream_state["bool_completed"],
+            )
+
+        # Normal return with the observability-wrapped Messages stream.
+        return self._execute_streaming_provider_call_with_observability(
+            operation="send_prompt_streaming",
+            dict_input_metadata=dict_input_metadata,
+            callable_open_stream=_open_stream,
+            callable_build_result_summary=_build_summary,
+            legacy_caller_id=self.user,
+        )
+
+    def _count_tokens_provider(
+        self,
+        prompt: str,
+        *,
+        other_params: AICompletionsPromptParamsBase | None = None,
+    ) -> int:
+        """
+        Count input tokens via the Messages API count_tokens endpoint.
+
+        Builds the same request shape send_prompt would submit and asks the
+        provider to count its input tokens without running inference.
+
+        Args:
+            prompt: Validated text prompt to measure.
+            other_params: Optional provider-specific parameters.
+
+        Returns:
+            Provider-reported input token count.
+        """
+        system_prompt: str = (
+            other_params.system_prompt
+            if other_params is not None and other_params.system_prompt is not None
+            else AICompletionsPromptParamsBase.DEFAULT_SYSTEM_PROMPT
+        )
+        user_content = self._build_user_message_content(prompt, other_params)
+        dict_input_metadata: dict[str, ObservabilityMetadataValue] = (
+            self._build_completions_observability_input_metadata(
+                prompt=prompt,
+                system_prompt=system_prompt,
+                other_params=other_params,
+                response_mode=self.RESPONSE_MODE_TEXT,
+            )
+        )
+
+        def _execute_count_tokens() -> AiApiObservedCompletionsResultModel[int]:
+            response = self.client.messages.count_tokens(
+                model=self.completions_model,
+                system=system_prompt,
+                messages=[{"role": "user", "content": user_content}],
+            )
+            int_input_tokens: int = int(getattr(response, "input_tokens", 0))
+            # Normal return with the provider-counted input token total.
+            return AiApiObservedCompletionsResultModel(
+                return_value=int_input_tokens,
+                raw_output_text="",
+                provider_prompt_tokens=int_input_tokens,
+                provider_total_tokens=int_input_tokens,
+                dict_metadata={"operation": "count_tokens"},
+            )
+
+        observed_result: AiApiObservedCompletionsResultModel[int] = (
+            self._execute_provider_call_with_observability(
+                capability=self.CLIENT_TYPE_COMPLETIONS,
+                operation="count_tokens",
+                dict_input_metadata=dict_input_metadata,
+                callable_execute=_execute_count_tokens,
+                callable_build_result_summary=lambda result, provider_elapsed_ms: self._build_completions_observability_result_summary(
+                    observed_result=result,
+                    provider_elapsed_ms=provider_elapsed_ms,
+                ),
+                legacy_caller_id=self.user,
+            )
+        )
+        # Normal return with the caller-facing input token count.
+        return observed_result.return_value

--- a/src/ai_api_unified/pricing/pricing_registry.py
+++ b/src/ai_api_unified/pricing/pricing_registry.py
@@ -42,11 +42,13 @@ _SRC_OPENAI: str = "https://developers.openai.com/api/docs/pricing"
 _SRC_GOOGLE: str = "https://ai.google.dev/gemini-api/docs/pricing"
 _SRC_GOOGLE_DEP: str = "https://ai.google.dev/gemini-api/docs/deprecations"
 _SRC_BEDROCK: str = "https://aws.amazon.com/bedrock/pricing/"
+_SRC_ANTHROPIC: str = "https://platform.claude.com/docs/en/about-claude/models/overview"
 
 # Provider labels used as the first half of registry keys.
 PROVIDER_OPENAI: str = "openai"
 PROVIDER_GOOGLE: str = "google"
 PROVIDER_BEDROCK: str = "bedrock"
+PROVIDER_ANTHROPIC: str = "anthropic"
 
 
 def _tok(
@@ -295,6 +297,66 @@ DICT_MODEL_INFO: dict[tuple[str, str], AIModelInfo] = dict(
             PROVIDER_BEDROCK,
             "us.anthropic.claude-3-5-haiku-20241022-v1:0",
             _tok("0.80", "4.00", None, _SRC_BEDROCK),
+        ),
+        # ── Anthropic completions (native API; cached rate is the documented
+        # 0.1x prompt-cache read multiplier; 5-minute cache writes bill 1.25x
+        # and are not modeled) ───────────────────────────────────────────────
+        _info(
+            PROVIDER_ANTHROPIC,
+            "claude-fable-5",
+            _tok("10.00", "50.00", "1.00", _SRC_ANTHROPIC),
+        ),
+        _info(
+            PROVIDER_ANTHROPIC,
+            "claude-opus-4-8",
+            _tok("5.00", "25.00", "0.50", _SRC_ANTHROPIC),
+        ),
+        _info(
+            PROVIDER_ANTHROPIC,
+            "claude-opus-4-7",
+            _tok("5.00", "25.00", "0.50", _SRC_ANTHROPIC),
+        ),
+        _info(
+            PROVIDER_ANTHROPIC,
+            "claude-opus-4-6",
+            _tok("5.00", "25.00", "0.50", _SRC_ANTHROPIC),
+        ),
+        _info(
+            PROVIDER_ANTHROPIC,
+            "claude-sonnet-4-6",
+            _tok("3.00", "15.00", "0.30", _SRC_ANTHROPIC),
+        ),
+        _info(
+            PROVIDER_ANTHROPIC,
+            "claude-haiku-4-5",
+            _tok("1.00", "5.00", "0.10", _SRC_ANTHROPIC),
+        ),
+        # ── Anthropic completions (deprecated) ──────────────────────────────
+        _info(
+            PROVIDER_ANTHROPIC,
+            "claude-opus-4-1",
+            status=ModelLifecycleStatus.DEPRECATED,
+            sunset=date(2026, 8, 5),
+            replacement="claude-opus-4-8",
+        ),
+        # ── Anthropic completions (retired: hard 404) ───────────────────────
+        _info(
+            PROVIDER_ANTHROPIC,
+            "claude-3-7-sonnet-20250219",
+            status=ModelLifecycleStatus.RETIRED,
+            replacement="claude-sonnet-4-6",
+        ),
+        _info(
+            PROVIDER_ANTHROPIC,
+            "claude-3-5-haiku-20241022",
+            status=ModelLifecycleStatus.RETIRED,
+            replacement="claude-haiku-4-5",
+        ),
+        _info(
+            PROVIDER_ANTHROPIC,
+            "claude-3-opus-20240229",
+            status=ModelLifecycleStatus.RETIRED,
+            replacement="claude-opus-4-8",
         ),
         # ── Bedrock / Titan embeddings ──────────────────────────────────────
         _info(

--- a/src/ai_api_unified/pricing/pricing_registry.py
+++ b/src/ai_api_unified/pricing/pricing_registry.py
@@ -331,10 +331,11 @@ DICT_MODEL_INFO: dict[tuple[str, str], AIModelInfo] = dict(
             "claude-haiku-4-5",
             _tok("1.00", "5.00", "0.10", _SRC_ANTHROPIC),
         ),
-        # ── Anthropic completions (deprecated) ──────────────────────────────
+        # ── Anthropic completions (deprecated, still billable) ──────────────
         _info(
             PROVIDER_ANTHROPIC,
             "claude-opus-4-1",
+            _tok("15.00", "75.00", "1.50", _SRC_ANTHROPIC),
             status=ModelLifecycleStatus.DEPRECATED,
             sunset=date(2026, 8, 5),
             replacement="claude-opus-4-8",

--- a/src/ai_api_unified/util/env_settings.py
+++ b/src/ai_api_unified/util/env_settings.py
@@ -16,6 +16,7 @@ class EnvSettings(BaseSettings):
     COMPLETIONS_ENGINE: str | None = None
     OPENAI_API_KEY: str | None = None
     OPENAI_BASE_URL: str | None = None
+    ANTHROPIC_API_KEY: str | None = None
     EMBEDDING_MODEL_NAME: str | None = None
     COMPLETIONS_MODEL_NAME: str | None = None
     EMBEDDING_DIMENSIONS: int | None = None

--- a/tests/test_anthropic_completions.py
+++ b/tests/test_anthropic_completions.py
@@ -1,0 +1,271 @@
+# ruff: noqa: E402
+
+# test_anthropic_completions.py
+"""
+Tests for the native Anthropic API completions engine (`claude`).
+
+Covers factory resolution, capabilities, text send_prompt, structured output,
+streaming, token counting, image content assembly, pricing registry entries,
+and model lifecycle enforcement, all against a mocked SDK client.
+"""
+
+import os
+from decimal import Decimal
+from typing import Any
+from unittest.mock import Mock, patch
+
+import pytest
+
+pytest.importorskip("anthropic")
+
+from ai_api_unified.ai_base import (
+    AIStructuredPrompt,
+    SupportedDataType,
+)
+from ai_api_unified.ai_factory import AIFactory
+from ai_api_unified.ai_provider_exceptions import AiProviderConfigurationError
+from ai_api_unified.completions.ai_anthropic_completions import (
+    AiAnthropicCompletions,
+    AICompletionsCapabilitiesAnthropic,
+)
+from ai_api_unified.completions.ai_openai_completions import (
+    AICompletionsPromptParamsOpenAI,
+)
+from ai_api_unified.pricing import pricing_registry
+from ai_api_unified.pricing.pricing_registry import (
+    PROVIDER_ANTHROPIC,
+    get_model_pricing,
+)
+
+
+def _build_client(model: str = "claude-opus-4-8") -> AiAnthropicCompletions:
+    with patch.dict(os.environ, {"ANTHROPIC_API_KEY": "test-key"}):
+        client = AiAnthropicCompletions(model=model)
+    client.client = Mock()
+    return client
+
+
+def _text_response(
+    text: str,
+    *,
+    stop_reason: str = "end_turn",
+    input_tokens: int = 10,
+    output_tokens: int = 5,
+) -> Mock:
+    return Mock(
+        content=[
+            Mock(type="thinking", thinking=""),
+            Mock(type="text", text=text),
+        ],
+        stop_reason=stop_reason,
+        usage=Mock(input_tokens=input_tokens, output_tokens=output_tokens),
+    )
+
+
+def test_factory_resolves_claude_engine() -> None:
+    with patch.dict(os.environ, {"ANTHROPIC_API_KEY": "test-key"}):
+        client = AIFactory.get_ai_completions_client(
+            completions_engine="claude", model_name="claude-opus-4-8"
+        )
+    assert isinstance(client, AiAnthropicCompletions)
+
+
+def test_missing_api_key_raises() -> None:
+    with patch.dict(os.environ, {"ANTHROPIC_API_KEY": ""}):
+        with pytest.raises(ValueError, match="ANTHROPIC_API_KEY"):
+            AiAnthropicCompletions(model="claude-opus-4-8")
+
+
+class TestCapabilities:
+    def test_opus_capabilities(self) -> None:
+        capabilities = AICompletionsCapabilitiesAnthropic.for_model("claude-opus-4-8")
+        assert capabilities.context_window_length == 1_000_000
+        assert capabilities.reasoning is True
+        assert capabilities.supports_streaming is True
+        assert capabilities.supports_token_counting is True
+        assert capabilities.supported_data_types == [
+            SupportedDataType.TEXT,
+            SupportedDataType.IMAGE,
+        ]
+        assert capabilities.pricing is not None
+        assert capabilities.pricing.token_rates.input_per_1m == Decimal("5.00")
+
+    def test_haiku_context_window(self) -> None:
+        capabilities = AICompletionsCapabilitiesAnthropic.for_model("claude-haiku-4-5")
+        assert capabilities.context_window_length == 200_000
+
+    def test_unknown_model_gets_conservative_default(self) -> None:
+        capabilities = AICompletionsCapabilitiesAnthropic.for_model("claude-unknown")
+        assert (
+            capabilities.context_window_length
+            == AICompletionsCapabilitiesAnthropic.DEFAULT_CONTEXT_WINDOW_LENGTH
+        )
+        assert capabilities.pricing is None
+
+
+class TestSendPrompt:
+    def test_send_prompt_uses_messages_create(self) -> None:
+        client = _build_client()
+        client.client.messages.create.return_value = _text_response("Hello there")
+
+        result: str = client.send_prompt("Greet me")
+
+        assert result == "Hello there"
+        create_kwargs = client.client.messages.create.call_args.kwargs
+        assert create_kwargs["model"] == "claude-opus-4-8"
+        assert (
+            create_kwargs["max_tokens"] == AiAnthropicCompletions.SEND_PROMPT_MAX_TOKENS
+        )
+        assert create_kwargs["system"]
+        assert create_kwargs["messages"] == [{"role": "user", "content": "Greet me"}]
+
+    def test_send_prompt_joins_only_text_blocks(self) -> None:
+        client = _build_client()
+        client.client.messages.create.return_value = Mock(
+            content=[
+                Mock(type="thinking", thinking="internal"),
+                Mock(type="text", text="Part one. "),
+                Mock(type="text", text="Part two."),
+            ],
+            stop_reason="end_turn",
+            usage=Mock(input_tokens=1, output_tokens=2),
+        )
+
+        assert client.send_prompt("Go") == "Part one. Part two."
+
+    def test_send_prompt_builds_image_content(self) -> None:
+        client = _build_client()
+        client.client.messages.create.return_value = _text_response("A red square")
+        params = AICompletionsPromptParamsOpenAI(
+            included_types=[SupportedDataType.IMAGE],
+            included_data=[b"fake-image-bytes"],
+            included_mime_types=["image/png"],
+        )
+
+        client.send_prompt("Describe this image", other_params=params)
+
+        content = client.client.messages.create.call_args.kwargs["messages"][0][
+            "content"
+        ]
+        assert content[0]["type"] == "image"
+        assert content[0]["source"]["type"] == "base64"
+        assert content[0]["source"]["media_type"] == "image/png"
+        assert content[1] == {"type": "text", "text": "Describe this image"}
+
+
+class TestStreaming:
+    def test_streaming_yields_text_deltas(self) -> None:
+        client = _build_client()
+        client.client.messages.create.return_value = iter(
+            [
+                Mock(type="message_start", message=Mock(usage=Mock(input_tokens=7))),
+                Mock(
+                    type="content_block_delta",
+                    delta=Mock(type="text_delta", text="Hel"),
+                ),
+                Mock(
+                    type="content_block_delta",
+                    delta=Mock(type="text_delta", text="lo"),
+                ),
+                Mock(
+                    type="message_delta",
+                    delta=Mock(stop_reason="end_turn"),
+                    usage=Mock(output_tokens=2),
+                ),
+            ]
+        )
+
+        list_chunks: list[str] = list(client.send_prompt_streaming("Greet me"))
+
+        assert list_chunks == ["Hel", "lo"]
+        create_kwargs = client.client.messages.create.call_args.kwargs
+        assert create_kwargs["stream"] is True
+        assert (
+            create_kwargs["max_tokens"] == AiAnthropicCompletions.STREAMING_MAX_TOKENS
+        )
+
+
+class _Person(AIStructuredPrompt):
+    name: str | None = None
+    age: int | None = None
+
+    @staticmethod
+    def get_prompt(input_text: str = "") -> str:
+        return f"Extract name and age from: {input_text}"
+
+
+class TestStrictSchemaPrompt:
+    def test_strict_schema_prompt_parses_json_output(self) -> None:
+        client = _build_client()
+        client.client.messages.create.return_value = _text_response(
+            '{"name": "Alice", "age": 30}'
+        )
+
+        result: Any = client.strict_schema_prompt("Extract", _Person)
+
+        assert result.name == "Alice"
+        assert result.age == 30
+        create_kwargs = client.client.messages.create.call_args.kwargs
+        dict_format = create_kwargs["output_config"]["format"]
+        assert dict_format["type"] == "json_schema"
+        assert dict_format["schema"]["additionalProperties"] is False
+
+    def test_strict_schema_prompt_raises_on_invalid_json(self) -> None:
+        client = _build_client()
+        client.client.messages.create.return_value = _text_response("not json")
+
+        with pytest.raises(ValueError, match="Invalid JSON response"):
+            client.strict_schema_prompt("Extract", _Person)
+
+
+class TestCountTokens:
+    def test_count_tokens_uses_provider_endpoint(self) -> None:
+        client = _build_client()
+        client.client.messages.count_tokens.return_value = Mock(input_tokens=42)
+
+        assert client.count_tokens("How many tokens?") == 42
+        count_kwargs = client.client.messages.count_tokens.call_args.kwargs
+        assert count_kwargs["model"] == "claude-opus-4-8"
+        assert count_kwargs["messages"][0]["role"] == "user"
+
+
+class TestObservabilityIdentity:
+    def test_vendor_and_engine_resolution(self) -> None:
+        # provider_vendor must match the pricing-registry provider label so
+        # finops cost enrichment can price claude-engine calls.
+        client = _build_client()
+        assert client._resolve_observability_provider_vendor() == PROVIDER_ANTHROPIC
+        assert client._resolve_observability_provider_engine() == "claude"
+
+
+class TestPricingAndLifecycle:
+    def test_compute_completion_cost(self) -> None:
+        client = _build_client()
+        # 1M in * 5.00/1M + 1M out * 25.00/1M = 30.00
+        assert client.compute_completion_cost(
+            input_tokens=1_000_000, output_tokens=1_000_000
+        ) == Decimal("30.00")
+
+    def test_registry_prices_current_models(self) -> None:
+        pricing = get_model_pricing(PROVIDER_ANTHROPIC, "claude-opus-4-8")
+        assert pricing is not None
+        assert pricing.token_rates.input_per_1m == Decimal("5.00")
+        assert pricing.token_rates.output_per_1m == Decimal("25.00")
+        assert pricing.token_rates.cached_input_per_1m == Decimal("0.50")
+
+        haiku = get_model_pricing(PROVIDER_ANTHROPIC, "claude-haiku-4-5")
+        assert haiku is not None
+        assert haiku.token_rates.input_per_1m == Decimal("1.00")
+
+    def test_retired_model_fails_fast(self) -> None:
+        with patch.dict(os.environ, {"ANTHROPIC_API_KEY": "test-key"}):
+            with pytest.raises(AiProviderConfigurationError, match="retired"):
+                AiAnthropicCompletions(model="claude-3-opus-20240229")
+
+    def test_deprecated_model_warns_once(self) -> None:
+        pricing_registry._SET_WARNED_MODELS.discard(
+            (PROVIDER_ANTHROPIC, "claude-opus-4-1")
+        )
+        with patch.dict(os.environ, {"ANTHROPIC_API_KEY": "test-key"}):
+            with pytest.warns(DeprecationWarning, match="claude-opus-4-8"):
+                AiAnthropicCompletions(model="claude-opus-4-1")

--- a/tests/test_anthropic_completions.py
+++ b/tests/test_anthropic_completions.py
@@ -94,6 +94,11 @@ class TestCapabilities:
         capabilities = AICompletionsCapabilitiesAnthropic.for_model("claude-haiku-4-5")
         assert capabilities.context_window_length == 200_000
 
+    def test_model_name_is_normalized_at_construction(self) -> None:
+        client = _build_client(model="  Claude-Opus-4-8  ")
+        assert client.completions_model == "claude-opus-4-8"
+        assert client.max_context_tokens == 1_000_000
+
     def test_unknown_model_gets_conservative_default(self) -> None:
         capabilities = AICompletionsCapabilitiesAnthropic.for_model("claude-unknown")
         assert (
@@ -132,6 +137,31 @@ class TestSendPrompt:
         )
 
         assert client.send_prompt("Go") == "Part one. Part two."
+
+    def test_send_prompt_raises_on_refusal(self) -> None:
+        client = _build_client()
+        client.client.messages.create.return_value = Mock(
+            content=[],
+            stop_reason="refusal",
+            usage=Mock(input_tokens=5, output_tokens=0),
+        )
+
+        with pytest.raises(RuntimeError, match="refusal"):
+            client.send_prompt("Do something declined")
+
+    def test_send_prompt_rejects_oversized_image(self) -> None:
+        client = _build_client()
+        params = AICompletionsPromptParamsOpenAI(
+            included_types=[SupportedDataType.IMAGE],
+            included_data=[
+                b"x" * (AiAnthropicCompletions.MAX_IMAGE_BYTES_ANTHROPIC + 1)
+            ],
+            included_mime_types=["image/png"],
+        )
+
+        with pytest.raises(ValueError, match="per-image"):
+            client.send_prompt("Describe", other_params=params)
+        client.client.messages.create.assert_not_called()
 
     def test_send_prompt_builds_image_content(self) -> None:
         client = _build_client()
@@ -217,6 +247,20 @@ class TestStrictSchemaPrompt:
         with pytest.raises(ValueError, match="Invalid JSON response"):
             client.strict_schema_prompt("Extract", _Person)
 
+    def test_schema_walker_ignores_field_named_properties(self) -> None:
+        class _Cfg(AIStructuredPrompt):
+            properties: dict[str, str] | None = None
+
+            @staticmethod
+            def get_prompt(input_text: str = "") -> str:
+                return input_text
+
+        dict_schema = AiAnthropicCompletions._build_output_config_schema(_Cfg)
+
+        assert dict_schema["additionalProperties"] is False
+        # The name->schema mapping must not gain a phantom property.
+        assert "additionalProperties" not in dict_schema["properties"]
+
 
 class TestCountTokens:
     def test_count_tokens_uses_provider_endpoint(self) -> None:
@@ -256,6 +300,13 @@ class TestPricingAndLifecycle:
         haiku = get_model_pricing(PROVIDER_ANTHROPIC, "claude-haiku-4-5")
         assert haiku is not None
         assert haiku.token_rates.input_per_1m == Decimal("1.00")
+
+    def test_deprecated_model_is_still_priced(self) -> None:
+        # Deprecated models keep billing until retirement, so finops cost
+        # enrichment must still find rates for them.
+        pricing = get_model_pricing(PROVIDER_ANTHROPIC, "claude-opus-4-1")
+        assert pricing is not None
+        assert pricing.token_rates.input_per_1m == Decimal("15.00")
 
     def test_retired_model_fails_fast(self) -> None:
         with patch.dict(os.environ, {"ANTHROPIC_API_KEY": "test-key"}):


### PR DESCRIPTION
Adds first-class support for Claude via the native Anthropic API (api.anthropic.com) as a new `claude` completions engine, alongside the existing Bedrock-routed `anthropic` engine (unchanged). Closes the gap where Claude was reachable only through Bedrock with a single catalogued model.

## What's in here

- **New engine `claude`** (`AiAnthropicCompletions` + `AIAnthropicBase`), behind a new `anthropic` optional extra (`anthropic>=0.116.0,<1.0.0`), authenticating with `ANTHROPIC_API_KEY`
- **Capabilities model** (`AICompletionsCapabilitiesAnthropic.for_model`): per-model context windows (1M tokens; `claude-haiku-4-5` at 200K), streaming, provider-side token counting, TEXT+IMAGE inputs, reasoning, registry pricing
- **Full surface**: `send_prompt` (text + vision), `strict_schema_prompt` via the Messages API JSON-schema response format (works on every catalogued model, including always-on-thinking models where forced tool choice would fail), `send_prompt_streaming` (raw stream events), `count_tokens` (native endpoint)
- **Pricing registry**: `PROVIDER_ANTHROPIC` entries for `claude-fable-5`, `claude-opus-4-8` (engine default), `claude-opus-4-7`, `claude-opus-4-6`, `claude-sonnet-4-6`, `claude-haiku-4-5` with input/output/cached rates and provenance; lifecycle entries for deprecated `claude-opus-4-1` and retired claude-3-x snapshots
- **Finops-ready observability**: `PROVIDER_VENDOR_ANTHROPIC` / `PROVIDER_ENGINE_CLAUDE` resolution so `emit_cost` prices claude-engine calls
- **Bug fix**: `ANTHROPIC_API_KEY` declared on `EnvSettings` — undeclared dotenv extras are stored lowercased by pydantic-settings and were invisible to `get_setting`
- **Docs**: README engines/extras/auth sections, `env_template` placeholders, `docs/pricing_research.md` Anthropic rows and source
- **Version**: 2.10.0 → 2.11.0 (all three locations)

## Test plan

- 19 new mocked tests (`tests/test_anthropic_completions.py`): factory resolution, capabilities, send_prompt, image content assembly, streaming, strict schema, count_tokens, observability vendor/engine resolution, pricing, cost computation, lifecycle (retired fails fast, deprecated warns)
- Full mocked suite: 378 passed (includes version-sync test)
- Live-verified against api.anthropic.com on `claude-opus-4-8`: send_prompt, streaming, structured output, count_tokens, and vision (base64 image → correct answer)
- `ruff` and `black` clean on all changed files

<!-- pr-review-prep:start -->
## PR Composition

Composition percentages are based on changed lines (added + deleted) vs the base branch `main`.

| Change Type | Lines Changed | Percentage |
|---|---:|---:|
| Core logic changes | 792 | 63% |
| Tests | 322 | 25% |
| Documentation | 85 | 7% |
| Data | 56 | 4% |
| Other | 13 | 1% |
| Total | 1268 | 100% |
<!-- pr-review-prep:end -->

<!-- pr-content-attribution:start -->
## Content Attribution Summary

Based on changed lines across counted PR commits in this PR. Pure data files are excluded — their content is deterministic process output, not authored work.

| Attribution Type | Commits | Lines Changed | Percentage |
|---|---:|---:|---:|
| AI-attributed | 2 | 1212 | 100% |
| Human-attributed | 0 | 0 | 0% |
| Bot-attributed | 0 | 0 | 0% |
| Total | 2 | 1212 | 100% |

Excluded from attribution:
- 56 data-file lines (`poetry.lock`)
<!-- pr-content-attribution:end -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

