### PR TITLE
feat: conversation, structured output, async, retries on openai/responses/gemini/bedrock (2.15.0)

### DIFF
--- a/.agents/memory/daily/2026-07-18/events/2026-07-18T00-43-55Z--2355287-davecthomas--thread_4d5b72e2-795b-45f4-9ce9-29b3baabc94a--turn_blte0adwb.md
+++ b/.agents/memory/daily/2026-07-18/events/2026-07-18T00-43-55Z--2355287-davecthomas--thread_4d5b72e2-795b-45f4-9ce9-29b3baabc94a--turn_blte0adwb.md
@@ -1,0 +1,60 @@
+---
+agentmemory_version: "0.4.4"
+timestamp: "2026-07-18T00:43:55Z"
+author: "2355287-davecthomas"
+branch: "feat/multi-engine-agent-features"
+thread_id: "4d5b72e2-795b-45f4-9ce9-29b3baabc94a"
+turn_id: "blte0adwb"
+workstream_id: "thread-4d5b72e2-795b-45f4-9ce9-29b3baabc94a"
+workstream_scope: "thread"
+episode_id: "episode-main-b34c818a56"
+episode_scope: "mixed"
+checkpoint_goal: "Bring the capability-gated agent-feature surface introduced in 2.14.0 (tool loops, structured output, async variants, retry policy, typed errors) to full parity across every supported engine."
+checkpoint_surface: "The completions layer across all provider engines \u2014 ai_base plus the Anthropic, OpenAI (Chat Completions and Responses), Google Gemini, and Bedrock completion classes and their shared capability-gating contract."
+checkpoint_outcome: "Shipped release 2.15.0 implementing the gated surface on every engine whose underlying API supports it, leaving unsupported gaps raising the typed capability error."
+decision_candidate: false
+enriched: true
+ai_generated: true
+ai_model: "claude-fable-5[1m]"
+ai_tool: "claude"
+ai_surface: "claude-code"
+ai_executor: "local-agent"
+related_adrs:
+files_touched:
+  - "CHANGELOG.md"
+  - "README.md"
+  - "pyproject.toml"
+  - "src/ai_api_unified/__version__.py"
+  - "src/ai_api_unified/ai_anthropic_base.py"
+  - "src/ai_api_unified/ai_base.py"
+  - "src/ai_api_unified/ai_openai_base.py"
+  - "src/ai_api_unified/completions/ai_anthropic_completions.py"
+  - "src/ai_api_unified/completions/ai_bedrock_completions.py"
+  - "src/ai_api_unified/completions/ai_google_gemini_capabilities.py"
+  - "src/ai_api_unified/completions/ai_google_gemini_completions.py"
+  - "src/ai_api_unified/completions/ai_openai_completions.py"
+  - "src/ai_api_unified/completions/ai_openai_responses_completions.py"
+  - "tests/test_google_gemini.py"
+  - "tests/test_multi_engine_conversation_api.py"
+design_docs_touched:
+verification:
+  - "git diff:  14 files changed, 3149 insertions(+), 133 deletions(-); ## 2.15.0; The 2.14.0 capability-gated surface lands on every engine whose underlying; API supports it; the remaining gaps stay unimplemented and raise the typed"
+source_pending_shards:
+  - ".agents/memory/pending/2026-07-18/2026-07-18T00-43-55Z--2355287-davecthomas--thread_4d5b72e2-795b-45f4-9ce9-29b3baabc94a--turn_blte0adwb.md"
+---
+
+## Why
+
+- The library's value is one agent-feature contract that behaves identically across engines. 2.14.0 defined that capability-gated surface; this release makes it real everywhere, so callers can rely on either a working feature or a typed capability error instead of silent per-engine divergence. The remaining gaps are deliberate: they track missing underlying provider support (e.g. boto3 has no official async client), not unfinished work.
+
+## What changed
+
+- OpenAI Chat Completions and Responses engines gained full support: send_conversation tool loops with forced tool_choice and strict functions, json_schema structured output, async variants on a lazy AsyncOpenAI, extended send_prompt parameters, retry_policy, and status-coded AiProviderRequestError. Google Gemini gained the same full surface via function-declaration tools, response_json_schema, and client.aio async (tool-call ids are the function name since the API carries none). Bedrock-routed engines gained partial support per underlying API: Converse toolConfig on Nova/Claude, outputConfig structured output only on AWS-listed models, retry_policy collapsing the engine schedule; async and per-call timeouts stay unimplemented for lack of provider support. A new engine-agnostic extend_messages_with_turn helper lets one tool loop replay a model turn in each engine's wire shape. Version bumped to 2.15.0 across all three version locations per the three-file policy.
+
+## Evidence
+
+- The CHANGELOG 2.15.0 entry states the release contract explicitly: the 2.14.0 capability-gated surface lands on every engine whose underlying API supports it, and remaining gaps raise the typed capability error. The README now carries a feature-support-by-engine matrix that makes each engine's support level a documented public commitment. The multi-engine conversation API test suite exercises the same tool loop across engines via the new replay helper, and the Gemini test suite covers the function-declaration tool and structured-output paths, validating parity rather than per-engine one-offs.
+
+## Next
+
+- Bedrock async variants and per-call timeouts remain open, blocked on upstream boto3/Converse support; Gemini async is single-attempt and relies on caller backoff, worth watching in practice.

--- a/.agents/memory/daily/2026-07-18/summary.md
+++ b/.agents/memory/daily/2026-07-18/summary.md
@@ -1,0 +1,39 @@
+# 2026-07-18 summary
+
+## Snapshot
+
+- Captured 1 memory event.
+- Main work: OpenAI Chat Completions and Responses engines gained full support: send_conversation tool loops with forced tool_choice and strict functions, json_schema structured output, async variants on a lazy AsyncOpenAI, extended send_prompt parameters, retry_policy, and status-coded AiProviderRequestError. Google Gemini gained the same full surface via function-declaration tools, response_json_schema, and client.aio async (tool-call ids are the function name since the API carries none). Bedrock-routed engines gained partial support per underlying API: Converse toolConfig on Nova/Claude, outputConfig structured output only on AWS-listed models, retry_policy collapsing the engine schedule; async and per-call timeouts stay unimplemented for lack of provider support. A new engine-agnostic extend_messages_with_turn helper lets one tool loop replay a model turn in each engine's wire shape. Version bumped to 2.15.0 across all three version locations per the three-file policy.
+- Top decision: None.
+- Blockers: Bedrock async variants and per-call timeouts remain open, blocked on upstream boto3/Converse support; Gemini async is single-attempt and relies on caller backoff, worth watching in practice.
+
+| Metric | Value |
+|---|---|
+| Memory events captured | 1 |
+| Repo files changed | 1 |
+| Decision candidates | 0 |
+| Active blockers | 1 |
+
+## Major work completed
+
+- OpenAI Chat Completions and Responses engines gained full support: send_conversation tool loops with forced tool_choice and strict functions, json_schema structured output, async variants on a lazy AsyncOpenAI, extended send_prompt parameters, retry_policy, and status-coded AiProviderRequestError. Google Gemini gained the same full surface via function-declaration tools, response_json_schema, and client.aio async (tool-call ids are the function name since the API carries none). Bedrock-routed engines gained partial support per underlying API: Converse toolConfig on Nova/Claude, outputConfig structured output only on AWS-listed models, retry_policy collapsing the engine schedule; async and per-call timeouts stay unimplemented for lack of provider support. A new engine-agnostic extend_messages_with_turn helper lets one tool loop replay a model turn in each engine's wire shape. Version bumped to 2.15.0 across all three version locations per the three-file policy.
+
+## Why this mattered
+
+- The library's value is one agent-feature contract that behaves identically across engines. 2.14.0 defined that capability-gated surface; this release makes it real everywhere, so callers can rely on either a working feature or a typed capability error instead of silent per-engine divergence. The remaining gaps are deliberate: they track missing underlying provider support (e.g. boto3 has no official async client), not unfinished work.
+
+## Active blockers
+
+- Bedrock async variants and per-call timeouts remain open, blocked on upstream boto3/Converse support; Gemini async is single-attempt and relies on caller backoff, worth watching in practice.
+
+## Decision candidates
+
+- None
+
+## Next likely steps
+
+- Bedrock async variants and per-call timeouts remain open, blocked on upstream boto3/Converse support; Gemini async is single-attempt and relies on caller backoff, worth watching in practice.
+
+## Relevant event shards
+
+- [2026-07-18 00:43:55 UTC by 2355287-davecthomas](events/2026-07-18T00-43-55Z--2355287-davecthomas--thread_4d5b72e2-795b-45f4-9ce9-29b3baabc94a--turn_blte0adwb.md)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,36 @@ Notable changes per release, so consumers can gate on the package version.
 Versions follow [semantic versioning](https://semver.org/); the authoritative
 version lives in `pyproject.toml` (see the README release section).
 
+## 2.15.0
+
+The 2.14.0 capability-gated surface lands on every engine whose underlying
+API supports it; the remaining gaps stay unimplemented and raise the typed
+capability error.
+
+- `openai` (Chat Completions) and `openai-responses`: full support —
+  `send_conversation` tool loops (tools, forced `tool_choice`, strict
+  functions), `send_structured_output` via the `json_schema` response format
+  (schema-guided mode), async variants on a lazy `AsyncOpenAI`, extended
+  `send_prompt` parameters, `retry_policy` (SDK `max_retries=0`), and
+  status-coded `AiProviderRequestError`.
+- `google-gemini`: full support — function-declaration tools with forced
+  calling, raw-JSON-schema structured output via `response_json_schema`,
+  async variants on `client.aio` (single attempt; pair with caller backoff),
+  extended `send_prompt` parameters (per-request `http_options` timeout),
+  `retry_policy` gating the engine backoff loop, and typed request errors.
+  Gemini tool-call ids are the function name (the API carries no call ids).
+- Bedrock-routed engines: partial per underlying API support —
+  `send_conversation` via Converse `toolConfig` on Nova and Claude families,
+  `send_structured_output` via Converse `outputConfig` only on models AWS
+  lists (Claude 4.5+), `max_response_tokens` mapping, `retry_policy`
+  collapsing the engine schedule, and status-coded errors from `ClientError`.
+  Unimplemented (no underlying support): async variants (boto3 has no
+  official async client) and per-call timeouts.
+- New engine-agnostic replay helper `extend_messages_with_turn(messages,
+  turn)` appends a model turn in each engine's wire shape, so one tool loop
+  runs unchanged across engines (implemented on claude too).
+- README gains a feature-support-by-engine matrix.
+
 ## 2.14.0
 
 Engine-agnostic completions features for workflow-service call shapes, fully

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# ai-api-unified 2.14.0
+# ai-api-unified 2.15.0
 
 `ai-api-unified` is a unified Python library for AI completions, embeddings, image generation, video generation, and voice. Application code targets stable base interfaces and factory entry points while concrete providers are selected at runtime from environment configuration.
 
@@ -214,12 +214,12 @@ Claude models are reachable through two completions engines:
   `bedrock` extra and AWS credentials.
 
 The two engines expose the same core caller-facing API (`send_prompt`,
-`strict_schema_prompt`, `send_prompt_streaming`, `count_tokens`); switching
-between them is a configuration change. The `claude` engine additionally
-implements the capability-gated surface added in 2.14.0 —
-`send_structured_output`, `send_conversation`, the async variants, and batch
-completions. Use `claude` for the current model lineup on Anthropic's own
-endpoint; use `anthropic` when your Claude access is provisioned through AWS.
+`strict_schema_prompt`, `send_prompt_streaming`, `count_tokens`) plus the
+capability-gated conversation/structured-output surface (see the support
+matrix above); switching between them is a configuration change. The `claude`
+engine additionally implements the async variants and batch completions. Use
+`claude` for the current model lineup on Anthropic's own endpoint; use
+`anthropic` when your Claude access is provisioned through AWS.
 
 ```dotenv
 COMPLETIONS_ENGINE=claude
@@ -256,11 +256,24 @@ text = client.send_prompt(
 )
 ```
 
-The `claude` engine maps these to the Messages API `system`, `max_tokens`, and
-SDK request-timeout fields. Engines that have not yet mapped
-`max_response_tokens` or `request_timeout_seconds` raise
-`AiProviderCapabilityUnsupportedError` when those are supplied;
-`system_prompt` works on every engine.
+All three parameters map to native provider fields on the `claude`,
+`openai`, `openai-responses`, and `google-gemini` engines. Bedrock-routed
+engines map `system_prompt` and `max_response_tokens` but raise
+`AiProviderCapabilityUnsupportedError` for `request_timeout_seconds` (boto3
+has no per-call timeout). See the support matrix below.
+
+#### Feature support by engine
+
+| Feature | `claude` | `openai` | `openai-responses` | `google-gemini` | Bedrock-routed |
+|---|---|---|---|---|---|
+| `send_prompt` extended params | yes | yes | yes | yes | partial (no per-call timeout) |
+| `send_structured_output` | yes | yes | yes | yes | per-model (AWS structured-outputs list: Claude 4.5+) |
+| `send_conversation` tool loop | yes | yes | yes | yes | Nova + Claude families |
+| Async variants (`asend_*`) | yes | yes | yes | yes | no (boto3 has no official async client) |
+| `retry_policy` / `AiProviderRequestError` | yes | yes | yes | yes | yes (engine loop; SDK retries via `AWS_MAX_ATTEMPTS`) |
+
+Unsupported combinations raise the typed `AiProviderCapabilityUnsupportedError`
+and each engine's `client.capabilities` flags report support at runtime.
 
 ### Structured output extraction (send_structured_output)
 
@@ -268,8 +281,12 @@ SDK request-timeout fields. Engines that have not yet mapped
 JSON object out. It accepts either an `AIStructuredPrompt` subclass
 (`response_model`) or a raw JSON Schema (`response_schema`) — for example a
 hand-written schema with `anyOf` variants per node type. Engines declare
-support via `capabilities.supports_structured_output`; the `claude` engine
-implements it via the Messages API JSON-schema response format.
+support via `capabilities.supports_structured_output`. Provider mappings:
+`claude` uses the Messages API JSON-schema response format (and streams and
+accumulates internally above its non-streaming budget); `openai` and
+`openai-responses` use the `json_schema` response format in schema-guided
+mode; `google-gemini` uses `response_json_schema`; Bedrock uses Converse
+`outputConfig` on the models AWS supports (Claude 4.5+).
 
 ```python
 result = client.send_structured_output(
@@ -346,7 +363,7 @@ for _ in range(MAX_ITERATIONS):
     )
     if turn.finish_reason != "tool_use":
         break
-    messages.append({"role": "assistant", "content": turn.raw_content})
+    client.extend_messages_with_turn(messages, turn)   # engine-shaped replay
     for tool_call in turn.tool_calls:
         output = execute_tool(tool_call.name, tool_call.input)   # caller-side (e.g. MCP)
         messages.append(
@@ -358,18 +375,25 @@ for _ in range(MAX_ITERATIONS):
 
 Each `AITurnResult` carries `text`, `tool_calls` (`id`, `name`, `input`), the
 normalized `finish_reason`, `usage` for that turn, and `raw_content` —
-engine-specific content blocks replayable verbatim as the next assistant
-message. `build_tool_result_message` produces the engine's tool-result wire
-shape, so callers never touch provider block formats except as the opaque
-`raw_content`.
+engine-specific content replayable as the next assistant turn. Because the
+assistant-turn wire shape differs per engine, `extend_messages_with_turn`
+appends it for you and `build_tool_result_message` produces the engine's
+tool-result shape, so the loop above runs unchanged on `claude`, `openai`,
+`openai-responses`, `google-gemini`, and tool-capable Bedrock models
+(Nova and Claude families). On Gemini, tool calls carry no provider ids, so
+`AIToolCall.id` is the function name.
 
 ### Async variants
 
 Engines whose SDK has an async client expose `a`-prefixed variants with the
 same signatures: `asend_prompt`, `asend_structured_output`, and
-`asend_conversation`. Support is declared via `capabilities.supports_async`;
-the `claude` engine implements all three on a lazily created `AsyncAnthropic`
-client. Sync methods are unchanged.
+`asend_conversation`. Support is declared via `capabilities.supports_async`:
+`claude` (lazy `AsyncAnthropic`), `openai` and `openai-responses` (lazy
+`AsyncOpenAI`), and `google-gemini` (`client.aio`) implement all three;
+Bedrock does not (boto3 has no official async client). Gemini async calls
+run a single attempt — the engine backoff loop is synchronous — so pair them
+with caller-owned backoff on `AiProviderRequestError`. Sync methods are
+unchanged.
 
 ```python
 turn = await client.asend_conversation("system", messages, tools=tools)
@@ -379,17 +403,20 @@ turn = await client.asend_conversation("system", messages, tools=tools)
 
 Engine retry behavior:
 
-- `claude` — the Anthropic SDK retries transient failures (408, 409, 429, 5xx)
-  twice by default with exponential backoff.
-- `openai` / `openai-responses` — the engine retries `send_prompt` and
-  `strict_schema_prompt` up to 3 attempts in-method.
-- `google-gemini` and Bedrock-routed engines — in-method retry loops with
-  backoff.
+- `claude` / `openai` / `openai-responses` — the provider SDK retries
+  transient failures (408, 409, 429, 5xx) twice by default with exponential
+  backoff; `retry_policy="none"` constructs the client with `max_retries=0`.
+- `google-gemini` — the engine's exponential-backoff loop (5 attempts);
+  `retry_policy="none"` collapses it to a single attempt.
+- Bedrock-routed engines — the engine's backoff schedule;
+  `retry_policy="none"` collapses it to a single attempt. botocore's own
+  client-level retries are configured separately via the standard
+  `AWS_MAX_ATTEMPTS` environment variable.
 
-Callers that run their own backoff can disable the `claude` engine's SDK
-retries at the constructor (`retry_policy="none"`), through configuration
+Every engine accepts `retry_policy` at the constructor, through configuration
 (`COMPLETIONS_RETRY_POLICY=none`), or per call
-(`provider_options={"retry_policy": "none"}`). HTTP-level failures raise
+(`provider_options={"retry_policy": "none"}`; on Bedrock the per-call
+override collapses that call's schedule). HTTP-level failures raise
 `AiProviderRequestError`, whose `status_code` attribute lets caller backoff
 classify 429/5xx/529 uniformly across engines; it is `None` when the failure
 happened before a status was available (connection error or client-side

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@
 [project]
 name = "ai_api_unified"
 
-version = "2.14.0" # keep in sync with src/ai_api_unified/__version__.py and the README.md title
+version = "2.15.0" # keep in sync with src/ai_api_unified/__version__.py and the README.md title
 description = "Unified access layer for AI completions (LLM), embedding (semantic), image, video, and voice services"
 authors = [{ name = "Dave Thomas", email = "davidcthomas@gmail.com" }]
 license = "MIT"

--- a/src/ai_api_unified/__version__.py
+++ b/src/ai_api_unified/__version__.py
@@ -9,4 +9,4 @@ from __future__ import annotations
 
 __all__: list[str] = ["__version__"]
 
-__version__: str = "2.14.0"
+__version__: str = "2.15.0"

--- a/src/ai_api_unified/ai_anthropic_base.py
+++ b/src/ai_api_unified/ai_anthropic_base.py
@@ -15,7 +15,11 @@ from typing import Any
 
 from anthropic import Anthropic, AsyncAnthropic
 
-from ai_api_unified.ai_base import RETRY_POLICY_DEFAULT, RETRY_POLICY_NONE
+from ai_api_unified.ai_base import (
+    RETRY_POLICY_DEFAULT,
+    RETRY_POLICY_NONE,
+    normalize_retry_policy,
+)
 from ai_api_unified.util.env_settings import EnvSettings
 
 _LOGGER: logging.Logger = logging.getLogger(__name__)
@@ -79,14 +83,8 @@ class AIAnthropicBase:
             if retry_policy is not None
             else str(self.env.get_setting(RETRY_POLICY_KEY, RETRY_POLICY_DEFAULT))
         )
-        str_normalized: str = str_candidate.strip().lower()
-        if str_normalized not in (RETRY_POLICY_DEFAULT, RETRY_POLICY_NONE):
-            raise ValueError(
-                f"Unsupported retry policy {str_candidate!r}; "
-                f"expected '{RETRY_POLICY_DEFAULT}' or '{RETRY_POLICY_NONE}'."
-            )
         # Normal return with the normalized retry policy token.
-        return str_normalized
+        return normalize_retry_policy(str_candidate)
 
     @property
     def async_client(self) -> AsyncAnthropic:

--- a/src/ai_api_unified/ai_base.py
+++ b/src/ai_api_unified/ai_base.py
@@ -307,6 +307,29 @@ RETRY_POLICY_DEFAULT: str = "default"
 RETRY_POLICY_NONE: str = "none"
 
 
+def normalize_retry_policy(retry_policy: str) -> str:
+    """
+    Normalizes and validates one retry-policy token shared by all engines.
+
+    Args:
+        retry_policy: Raw retry policy value from a constructor or environment.
+
+    Returns:
+        Normalized retry policy token ("default" or "none").
+
+    Raises:
+        ValueError: When an unrecognized retry policy value is supplied.
+    """
+    str_normalized: str = retry_policy.strip().lower()
+    if str_normalized not in (RETRY_POLICY_DEFAULT, RETRY_POLICY_NONE):
+        raise ValueError(
+            f"Unsupported retry policy {retry_policy!r}; "
+            f"expected '{RETRY_POLICY_DEFAULT}' or '{RETRY_POLICY_NONE}'."
+        )
+    # Normal return with the normalized retry policy token.
+    return str_normalized
+
+
 class AIFinishReason(str, Enum):
     """
     Normalized reason a completions turn stopped, uniform across engines.
@@ -2740,6 +2763,78 @@ class AIBaseCompletions(AIBase):
         tool-use support must implement this hook.
         """
         self._raise_completions_capability_unsupported("tool-use conversations")
+
+    def extend_messages_with_turn(
+        self,
+        messages: list[dict[str, Any]],
+        turn: AITurnResult,
+    ) -> list[dict[str, Any]]:
+        """
+        Appends one model turn to a caller-managed history in engine wire shape.
+
+        Engines shape assistant turns differently (a single message wrapping
+        content blocks, a message carrying tool_calls, or a list of output
+        items), so this helper keeps the caller's tool loop engine-agnostic:
+        append the turn, append tool results via build_tool_result_message,
+        and call send_conversation again.
+
+        Args:
+            messages: Caller-managed message history, mutated in place.
+            turn: The AITurnResult returned by send_conversation.
+
+        Returns:
+            The same messages list, for chaining.
+
+        Raises:
+            AiProviderCapabilityUnsupportedError: When the configured model
+                does not support tool-use conversations.
+        """
+        self._require_tool_use_capability()
+        self._extend_messages_with_turn_provider(messages=messages, turn=turn)
+        # Normal return with the extended caller-managed history.
+        return messages
+
+    def _extend_messages_with_turn_provider(
+        self,
+        *,
+        messages: list[dict[str, Any]],
+        turn: AITurnResult,
+    ) -> None:
+        """
+        Provider hook for appending one model turn in engine wire shape.
+
+        The base implementation raises: a provider whose capabilities declare
+        tool-use support must implement this hook.
+        """
+        self._raise_completions_capability_unsupported("tool-use conversations")
+
+    # Reserved provider_options key honored by engines that support per-call
+    # retry overrides; every other key merges into the provider request.
+    PROVIDER_OPTION_RETRY_POLICY: ClassVar[str] = "retry_policy"
+
+    def _split_provider_options(
+        self, provider_options: dict[str, Any] | None
+    ) -> tuple[dict[str, Any], str | None]:
+        """
+        Splits provider_options into request-merge keys and reserved keys.
+
+        Args:
+            provider_options: Optional engine-specific escape hatch supplied
+                per call.
+
+        Returns:
+            Tuple of (kwargs merged verbatim into the provider request,
+            optional per-call retry policy override).
+        """
+        if not provider_options:
+            # Early return because there is nothing to split.
+            return {}, None
+        dict_merge_options: dict[str, Any] = dict(provider_options)
+        str_retry_policy: str | None = dict_merge_options.pop(
+            self.PROVIDER_OPTION_RETRY_POLICY, None
+        )
+        # Normal return with merge options and the reserved retry override.
+        return dict_merge_options, str_retry_policy
 
     async def asend_prompt(
         self,

--- a/src/ai_api_unified/ai_openai_base.py
+++ b/src/ai_api_unified/ai_openai_base.py
@@ -3,23 +3,40 @@ from __future__ import annotations
 import logging
 from typing import Any
 
-from openai import OpenAI
+from openai import AsyncOpenAI, OpenAI
+from ai_api_unified.ai_base import (
+    RETRY_POLICY_DEFAULT,
+    RETRY_POLICY_NONE,
+    normalize_retry_policy,
+)
 from ai_api_unified.util.env_settings import EnvSettings
 
 _LOGGER: logging.Logger = logging.getLogger(__name__)
+
+RETRY_POLICY_KEY: str = "COMPLETIONS_RETRY_POLICY"
 
 
 class AIOpenAIBase:
     """
     Base class for OpenAI API interactions.
+
+    Retry behavior: the OpenAI SDK retries transient failures (408, 409, 429,
+    and 5xx) twice by default with exponential backoff. Pass
+    retry_policy="none" (or set COMPLETIONS_RETRY_POLICY=none) to disable SDK
+    retries so caller-owned backoff is the only retry layer.
     """
 
     DEFAULT_OPENAI_BASE_URL: str = "https://api.openai.com/v1"
     OPENAI_US_BASE_URL: str = "https://us.api.openai.com/v1"
 
-    def __init__(self, **kwargs: Any):
+    def __init__(self, *, retry_policy: str | None = None, **kwargs: Any):
         """
         Initialize the AIOpenAIBase class with environment settings and API credentials.
+
+        Args:
+            retry_policy: "default" keeps the OpenAI SDK's built-in retries;
+                "none" disables them (max_retries=0). Falls back to the
+                COMPLETIONS_RETRY_POLICY environment setting, then "default".
         """
         self.env = EnvSettings()
         self.api_key = self.env.get_setting("OPENAI_API_KEY")
@@ -28,8 +45,39 @@ class AIOpenAIBase:
             raise ValueError("OPENAI_API_KEY environment variable must be set.")
         self.base_url = self.get_api_base_url()
 
-        self.client = OpenAI(api_key=self.api_key, base_url=self.base_url)
+        str_candidate: str = (
+            retry_policy
+            if retry_policy is not None
+            else str(self.env.get_setting(RETRY_POLICY_KEY, RETRY_POLICY_DEFAULT))
+        )
+        self.retry_policy: str = normalize_retry_policy(str_candidate)
+        dict_client_kwargs: dict[str, Any] = {
+            "api_key": self.api_key,
+            "base_url": self.base_url,
+        }
+        if self.retry_policy == RETRY_POLICY_NONE:
+            dict_client_kwargs["max_retries"] = 0
+        self.client = OpenAI(**dict_client_kwargs)
+        # The async client is created lazily so purely synchronous consumers
+        # never pay for an unused event-loop-bound transport.
+        self._async_client: AsyncOpenAI | None = None
         self.backoff_delays = [1, 2, 4, 8, 16]
+
+    @property
+    def async_client(self) -> AsyncOpenAI:
+        """
+        Returns the lazily created AsyncOpenAI client for async variants.
+        """
+        if self._async_client is None:
+            dict_client_kwargs: dict[str, Any] = {
+                "api_key": self.api_key,
+                "base_url": self.base_url,
+            }
+            if self.retry_policy == RETRY_POLICY_NONE:
+                dict_client_kwargs["max_retries"] = 0
+            self._async_client = AsyncOpenAI(**dict_client_kwargs)
+        # Normal return with the shared async client instance.
+        return self._async_client
 
     def get_api_base_url(self) -> str:
         """Resolve the OpenAI base URL based on data residency constraints."""

--- a/src/ai_api_unified/completions/ai_anthropic_completions.py
+++ b/src/ai_api_unified/completions/ai_anthropic_completions.py
@@ -131,11 +131,6 @@ class AiAnthropicCompletions(AIAnthropicBase, AIBaseCompletions):
     # SDK's long-request guard, so structured calls stream and accumulate
     # internally; the caller still sees one blocking call.
     NONSTREAMING_MAX_TOKENS_THRESHOLD: ClassVar[int] = 16_000
-    # Reserved provider_options key honored by this engine: "retry_policy"
-    # ("none" disables SDK retries for that call). All other keys are merged
-    # verbatim into the Messages API request.
-    PROVIDER_OPTION_RETRY_POLICY: ClassVar[str] = "retry_policy"
-
     DICT_FINISH_REASON_MAP: ClassVar[dict[str, AIFinishReason]] = {
         "end_turn": AIFinishReason.COMPLETE,
         "stop_sequence": AIFinishReason.COMPLETE,
@@ -340,30 +335,8 @@ class AiAnthropicCompletions(AIAnthropicBase, AIBaseCompletions):
         return dict_schema
 
     # ── Shared helpers for conversation, structured output, and async ───────
-
-    def _split_provider_options(
-        self, provider_options: dict[str, Any] | None
-    ) -> tuple[dict[str, Any], str | None]:
-        """
-        Splits provider_options into request-merge keys and reserved keys.
-
-        Args:
-            provider_options: Optional engine-specific escape hatch supplied
-                per call.
-
-        Returns:
-            Tuple of (kwargs merged verbatim into the Messages request,
-            optional per-call retry policy override).
-        """
-        if not provider_options:
-            # Early return because there is nothing to split.
-            return {}, None
-        dict_merge_options: dict[str, Any] = dict(provider_options)
-        str_retry_policy: str | None = dict_merge_options.pop(
-            self.PROVIDER_OPTION_RETRY_POLICY, None
-        )
-        # Normal return with merge options and the reserved retry override.
-        return dict_merge_options, str_retry_policy
+    # provider_options splitting (reserved "retry_policy" key) lives on
+    # AIBaseCompletions._split_provider_options, shared across engines.
 
     def _client_for_call(
         self,
@@ -1034,6 +1007,19 @@ class AiAnthropicCompletions(AIAnthropicBase, AIBaseCompletions):
                 }
             ],
         }
+
+    def _extend_messages_with_turn_provider(
+        self,
+        *,
+        messages: list[dict[str, Any]],
+        turn: AITurnResult,
+    ) -> None:
+        """
+        Appends one Messages API assistant turn wrapping the raw content blocks.
+        """
+        messages.append({"role": "assistant", "content": turn.raw_content})
+        # Normal return after appending the assistant turn.
+        return None
 
     # ── Structured output (send_structured_output) ──────────────────────────
 

--- a/src/ai_api_unified/completions/ai_bedrock_completions.py
+++ b/src/ai_api_unified/completions/ai_bedrock_completions.py
@@ -3,7 +3,7 @@
 import json
 import logging
 from collections.abc import Iterator
-from typing import Any, Type
+from typing import Any, ClassVar, Type
 
 from pydantic import ValidationError
 
@@ -11,12 +11,25 @@ from ..ai_completions_exceptions import StructuredResponseTokenLimitError
 from ..ai_base import (
     AIBaseCompletions,
     AiApiObservedCompletionsResultModel,
+    AIFinishReason,
+    AIStructuredOutputResult,
     AIStructuredPrompt,
     AICompletionsCapabilitiesBase,
     AICompletionsPromptParamsBase,
+    AITokenUsage,
+    AITool,
+    AIToolCall,
+    AITurnResult,
+    RETRY_POLICY_DEFAULT,
+    RETRY_POLICY_NONE,
     SupportedDataType,
+    normalize_retry_policy,
 )
-from ..ai_bedrock_base import AIBedrockBase, ClientError
+from ..ai_bedrock_base import AIBedrockBase, BotoCoreError, ClientError
+from ..ai_provider_exceptions import (
+    AiProviderCapabilityUnsupportedError,
+    AiProviderRequestError,
+)
 from ..middleware.observability_runtime import (
     AiApiCallResultSummaryModel,
     ObservabilityMetadataValue,
@@ -38,6 +51,22 @@ class AICompletionsCapabilitiesBedrock(AICompletionsCapabilitiesBase):
     Based on https://docs.aws.amazon.com/bedrock/latest/userguide/conversation-inference.html
     """
 
+    # Model families with Converse toolConfig support that this engine maps
+    # (Amazon Nova and Anthropic Claude on Bedrock).
+    TUPLE_TOOL_USE_MODEL_MARKERS: ClassVar[tuple[str, ...]] = (
+        "nova",
+        "anthropic.claude",
+    )
+    # Models AWS lists as supporting native structured outputs
+    # (Converse outputConfig.textFormat); see
+    # https://docs.aws.amazon.com/bedrock/latest/userguide/structured-output.html
+    TUPLE_STRUCTURED_OUTPUT_MODEL_MARKERS: ClassVar[tuple[str, ...]] = (
+        "claude-haiku-4-5",
+        "claude-sonnet-4-5",
+        "claude-opus-4-5",
+        "claude-opus-4-6",
+    )
+
     @classmethod
     def for_model(
         cls,
@@ -46,6 +75,18 @@ class AICompletionsCapabilitiesBedrock(AICompletionsCapabilitiesBase):
         context_window_length: int,
     ) -> "AICompletionsCapabilitiesBedrock":
         """Create capabilities instance for the requested Bedrock model."""
+        normalized_name: str = model_name.strip().lower()
+        # Tool use and structured output are per-model on Bedrock: toolConfig
+        # is mapped for Nova and Claude families; outputConfig structured
+        # output only for the models AWS supports. Async stays False — boto3
+        # has no official async client.
+        bool_supports_tool_use: bool = any(
+            marker in normalized_name for marker in cls.TUPLE_TOOL_USE_MODEL_MARKERS
+        )
+        bool_supports_structured_output: bool = any(
+            marker in normalized_name
+            for marker in cls.TUPLE_STRUCTURED_OUTPUT_MODEL_MARKERS
+        )
         # Normal return with Bedrock capabilities; every chat model this client
         # targets streams via the ConverseStream API and supports the
         # provider-side CountTokens operation.
@@ -54,6 +95,8 @@ class AICompletionsCapabilitiesBedrock(AICompletionsCapabilitiesBase):
             supported_data_types=[SupportedDataType.TEXT, SupportedDataType.IMAGE],
             supports_streaming=True,
             supports_token_counting=True,
+            supports_tool_use=bool_supports_tool_use,
+            supports_structured_output=bool_supports_structured_output,
             pricing=get_model_pricing(PROVIDER_BEDROCK, model_name),
         )
 
@@ -64,7 +107,9 @@ class AiBedrockCompletions(AIBedrockBase, AIBaseCompletions):
     structured-output prompts.
     """
 
-    def __init__(self, model: str = "", **kwargs: Any):
+    def __init__(
+        self, model: str = "", *, retry_policy: str | None = None, **kwargs: Any
+    ):
         settings = EnvSettings()
         resolved_model: str = (
             model
@@ -73,12 +118,23 @@ class AiBedrockCompletions(AIBedrockBase, AIBaseCompletions):
         )
         self.completions_model: str = resolved_model
         enforce_model_lifecycle(PROVIDER_BEDROCK, resolved_model)
+        str_retry_candidate: str = (
+            retry_policy
+            if retry_policy is not None
+            else str(settings.get("COMPLETIONS_RETRY_POLICY", RETRY_POLICY_DEFAULT))
+        )
+        self.retry_policy: str = normalize_retry_policy(str_retry_candidate)
         AIBedrockBase.__init__(self, model=resolved_model, **kwargs)
         AIBaseCompletions.__init__(self, model=resolved_model, **kwargs)
         # Reuse the existing retry schedule from the base but allow overrides via kwargs
         custom_backoff: list[float] | None = kwargs.get("backoff_delays")
         if custom_backoff is not None:
             self.backoff_delays = custom_backoff
+        if self.retry_policy == RETRY_POLICY_NONE:
+            # A single-entry schedule collapses every engine retry loop to one
+            # attempt. botocore's own retry config is client-level; set the
+            # standard AWS_MAX_ATTEMPTS=1 environment variable to disable it.
+            self.backoff_delays = [0.0]
 
     @property
     def max_context_tokens(self) -> int:
@@ -361,10 +417,9 @@ class AiBedrockCompletions(AIBedrockBase, AIBaseCompletions):
         request_timeout_seconds: float | None = None,
         other_params: AICompletionsPromptParamsBase | None = None,
     ) -> str:
-        self._reject_unsupported_send_prompt_params(
-            max_response_tokens=max_response_tokens,
-            request_timeout_seconds=request_timeout_seconds,
-        )
+        # boto3 has no per-call timeout; that parameter stays unimplemented on
+        # this engine and raises the typed capability error when supplied.
+        self._reject_bedrock_timeout(request_timeout_seconds)
         prompt = self.pii_middleware.process_input(prompt)
         # AWS Bedrock expects messages in this format for the Converse API
         user_content: list[dict[str, Any]] = self._build_user_content(
@@ -378,13 +433,18 @@ class AiBedrockCompletions(AIBedrockBase, AIBaseCompletions):
             AICompletionsPromptParamsBase.DEFAULT_SYSTEM_PROMPT,
         )
 
-        inference_config = {"temperature": 0.2, "topP": 0.85, "maxTokens": 256}
+        inference_config = {
+            "temperature": 0.2,
+            "topP": 0.85,
+            "maxTokens": max_response_tokens or 256,
+        }
         dict_input_metadata: dict[str, ObservabilityMetadataValue] = (
             self._build_completions_observability_input_metadata(
                 prompt=prompt,
                 system_prompt=system_prompt,
                 other_params=other_params,
                 response_mode=self.RESPONSE_MODE_TEXT,
+                max_response_tokens=max_response_tokens,
             )
         )
 
@@ -781,3 +841,454 @@ class AiBedrockCompletions(AIBedrockBase, AIBaseCompletions):
         """
 
         return raw_json
+
+    # ── Conversation and structured output (Converse API, 2.15.0) ───────────
+    # Async variants and per-call timeouts stay unimplemented on this engine:
+    # boto3 has no official async client and no per-call timeout override.
+
+    DICT_FINISH_REASON_MAP: ClassVar[dict[str, AIFinishReason]] = {
+        "end_turn": AIFinishReason.COMPLETE,
+        "stop_sequence": AIFinishReason.COMPLETE,
+        "max_tokens": AIFinishReason.LENGTH,
+        "tool_use": AIFinishReason.TOOL_USE,
+        "guardrail_intervened": AIFinishReason.REFUSAL,
+        "content_filtered": AIFinishReason.REFUSAL,
+    }
+
+    PROVIDER_ENGINE_TOKEN: ClassVar[str] = "bedrock"
+
+    def _reject_bedrock_timeout(self, request_timeout_seconds: float | None) -> None:
+        """
+        Rejects per-call timeouts, which boto3 does not support.
+        """
+        if request_timeout_seconds is None:
+            # Normal return because no unsupported parameter was supplied.
+            return None
+        raise AiProviderCapabilityUnsupportedError(
+            f"{type(self).__name__} model '{self.model_name}' does not support "
+            "request_timeout_seconds: boto3 has no per-call timeout. Configure "
+            "botocore read_timeout at client construction instead."
+        )
+
+    def _raise_bedrock_request_error(self, exception: Exception) -> None:
+        """
+        Re-raises one botocore transport error as the typed request error.
+
+        Carries the HTTP status code from ClientError response metadata so
+        caller-owned backoff can classify 429/5xx uniformly across engines.
+        Non-transport exceptions propagate unchanged.
+        """
+        if isinstance(exception, ClientError):
+            dict_response: dict[str, Any] = getattr(exception, "response", None) or {}
+            raw_status = dict_response.get("ResponseMetadata", {}).get("HTTPStatusCode")
+            raise AiProviderRequestError(
+                f"Bedrock request failed: {exception}",
+                status_code=raw_status if isinstance(raw_status, int) else None,
+                provider_engine=self.PROVIDER_ENGINE_TOKEN,
+            ) from exception
+        if isinstance(exception, BotoCoreError):
+            raise AiProviderRequestError(
+                f"Bedrock request failed before a status was available: "
+                f"{exception}",
+                status_code=None,
+                provider_engine=self.PROVIDER_ENGINE_TOKEN,
+            ) from exception
+        # Normal return so non-transport exceptions propagate unchanged.
+        return None
+
+    def _is_retryable_client_error(self, exception: Exception) -> bool:
+        """
+        Classifies one exception as retryable per the base error-code policy.
+        """
+        if isinstance(exception, ClientError):
+            str_error_code: str = str(
+                (getattr(exception, "response", None) or {})
+                .get("Error", {})
+                .get("Code", "")
+            )
+            # Normal return based on the shared non-retryable code set.
+            return str_error_code not in self.NON_RETRYABLE_ERROR_CODES
+        # Normal return treating other transport errors as retryable.
+        return isinstance(exception, BotoCoreError)
+
+    def _execute_converse_with_retries(
+        self,
+        callable_converse: Any,
+        *,
+        retry_override: str | None = None,
+    ) -> dict[str, Any]:
+        """
+        Runs one Converse call through the engine retry schedule.
+
+        retry_override "none" (from provider_options) collapses the schedule
+        to a single attempt for that call. Exhausted or non-retryable
+        transport failures surface as typed AiProviderRequestError.
+        """
+        list_delays: list[float] = list(self.backoff_delays)
+        if retry_override is not None:
+            if normalize_retry_policy(retry_override) == RETRY_POLICY_NONE:
+                list_delays = [0.0]
+        # Loop through the retry schedule while preserving backoff behavior.
+        for attempt, delay in enumerate(list_delays, start=1):
+            try:
+                # Normal return with the raw Converse response dictionary.
+                return callable_converse()
+            except Exception as exception:
+                bool_last_attempt: bool = attempt == len(list_delays)
+                if bool_last_attempt or not self._is_retryable_client_error(exception):
+                    self._raise_bedrock_request_error(exception)
+                    raise
+                self._sleep_with_backoff(delay)
+        raise RuntimeError("Unreachable: converse retry schedule was empty.")
+
+    @staticmethod
+    def _build_converse_tool_config(
+        tools: list[AITool],
+        tool_choice: str | None,
+    ) -> dict[str, Any]:
+        """
+        Maps provider-neutral tools onto the Converse toolConfig shape.
+        """
+        list_provider_tools: list[dict[str, Any]] = []
+        # Loop over tool definitions so each maps to a Converse toolSpec.
+        for ai_tool in tools:
+            dict_tool_spec: dict[str, Any] = {
+                "name": ai_tool.name,
+                "description": ai_tool.description,
+                "inputSchema": {"json": ai_tool.input_schema},
+            }
+            if ai_tool.strict:
+                dict_tool_spec["strict"] = True
+            list_provider_tools.append({"toolSpec": dict_tool_spec})
+        dict_tool_config: dict[str, Any] = {"tools": list_provider_tools}
+        if tool_choice is not None:
+            dict_tool_config["toolChoice"] = {"tool": {"name": tool_choice}}
+        # Normal return with the Converse-shaped tool configuration.
+        return dict_tool_config
+
+    def _usage_from_converse(self, dict_response: dict[str, Any]) -> AITokenUsage:
+        """
+        Builds the provider-neutral usage model from one Converse response.
+        """
+        # Normal return with the provider-neutral token usage model.
+        return AITokenUsage(
+            input_tokens=self._extract_bedrock_prompt_tokens(dict_response),
+            output_tokens=self._extract_bedrock_completion_tokens(dict_response),
+            cached_input_tokens=self._extract_bedrock_cached_tokens(dict_response),
+            total_tokens=self._extract_bedrock_total_tokens(dict_response),
+        )
+
+    def _build_turn_result_from_converse(
+        self, dict_response: dict[str, Any]
+    ) -> AITurnResult:
+        """
+        Maps one Converse response onto the provider-neutral turn.
+
+        Converse content blocks are already plain dictionaries, so raw_content
+        is the output message content list, replayable verbatim inside the
+        next assistant message.
+        """
+        list_content: list[dict[str, Any]] = (
+            dict_response.get("output", {}).get("message", {}).get("content", []) or []
+        )
+        list_text_parts: list[str] = []
+        list_tool_calls: list[AIToolCall] = []
+        # Loop over content blocks so text and tool calls align with replay.
+        for dict_block in list_content:
+            if "text" in dict_block:
+                list_text_parts.append(str(dict_block.get("text") or ""))
+            elif "toolUse" in dict_block:
+                dict_tool_use: dict[str, Any] = dict_block.get("toolUse") or {}
+                list_tool_calls.append(
+                    AIToolCall(
+                        id=str(dict_tool_use.get("toolUseId") or ""),
+                        name=str(dict_tool_use.get("name") or ""),
+                        input=dict(dict_tool_use.get("input") or {}),
+                    )
+                )
+        str_stop_reason: str = str(dict_response.get("stopReason", "") or "").lower()
+        finish_reason: AIFinishReason = self._normalize_finish_reason(
+            str_stop_reason if str_stop_reason else None,
+            self.DICT_FINISH_REASON_MAP,
+        )
+        str_text: str = "".join(list_text_parts)
+        # Normal return with the provider-neutral turn result.
+        return AITurnResult(
+            text=str_text if str_text else None,
+            tool_calls=list_tool_calls,
+            finish_reason=finish_reason,
+            raw_content=list_content,
+            usage=self._usage_from_converse(dict_response),
+        )
+
+    def _observed_converse_turn_result(
+        self, dict_response: dict[str, Any]
+    ) -> AiApiObservedCompletionsResultModel[AITurnResult]:
+        """
+        Wraps one Converse response as an observed conversation-turn result.
+        """
+        turn_result: AITurnResult = self._build_turn_result_from_converse(dict_response)
+        # Normal return with the observed turn result and usage metadata.
+        return AiApiObservedCompletionsResultModel(
+            return_value=turn_result,
+            raw_output_text=turn_result.text or "",
+            finish_reason=str(dict_response.get("stopReason", "") or "") or None,
+            provider_prompt_tokens=turn_result.usage.input_tokens,
+            provider_completion_tokens=turn_result.usage.output_tokens,
+            provider_cached_input_tokens=turn_result.usage.cached_input_tokens,
+            provider_total_tokens=turn_result.usage.total_tokens,
+            dict_metadata={"tool_call_count": len(turn_result.tool_calls)},
+        )
+
+    def _build_conversation_observability_metadata(
+        self,
+        *,
+        system_prompt: str,
+        messages: list[dict[str, Any]],
+        tools: list[AITool],
+        tool_choice: str | None,
+        max_response_tokens: int | None,
+    ) -> dict[str, ObservabilityMetadataValue]:
+        """
+        Builds metadata-only observability fields for one conversation turn.
+        """
+        dict_metadata: dict[str, ObservabilityMetadataValue] = {
+            "response_mode": self.RESPONSE_MODE_TEXT,
+            "message_count": len(messages),
+            "tool_count": len(tools),
+            "system_prompt_char_count": len(system_prompt),
+        }
+        if tool_choice is not None:
+            dict_metadata["forced_tool"] = tool_choice
+        if max_response_tokens is not None:
+            dict_metadata["max_response_tokens"] = max_response_tokens
+        # Normal return with scalar conversation metadata.
+        return dict_metadata
+
+    def _send_conversation_provider(
+        self,
+        *,
+        system_prompt: str,
+        messages: list[dict[str, Any]],
+        tools: list[AITool],
+        tool_choice: str | None,
+        max_response_tokens: int | None,
+        request_timeout_seconds: float | None,
+        provider_options: dict[str, Any] | None,
+    ) -> AITurnResult:
+        """
+        Sends one conversation turn via the Converse API with toolConfig.
+        """
+        self._reject_bedrock_timeout(request_timeout_seconds)
+        dict_merge_options, str_retry_override = self._split_provider_options(
+            provider_options
+        )
+        dict_request_kwargs: dict[str, Any] = {
+            "modelId": self.model,
+            "messages": messages,
+            "system": [{"text": system_prompt}],
+            "inferenceConfig": {"maxTokens": max_response_tokens or 1024},
+        }
+        if tools:
+            dict_request_kwargs["toolConfig"] = self._build_converse_tool_config(
+                tools, tool_choice
+            )
+        dict_request_kwargs.update(dict_merge_options)
+        dict_input_metadata: dict[str, ObservabilityMetadataValue] = (
+            self._build_conversation_observability_metadata(
+                system_prompt=system_prompt,
+                messages=messages,
+                tools=tools,
+                tool_choice=tool_choice,
+                max_response_tokens=max_response_tokens,
+            )
+        )
+
+        def _execute_turn() -> AiApiObservedCompletionsResultModel[AITurnResult]:
+            dict_response: dict[str, Any] = self._execute_converse_with_retries(
+                lambda: self.client.converse(**dict_request_kwargs),
+                retry_override=str_retry_override,
+            )
+            # Normal return with the observed conversation turn.
+            return self._observed_converse_turn_result(dict_response)
+
+        observed_result: AiApiObservedCompletionsResultModel[AITurnResult] = (
+            self._execute_provider_call_with_observability(
+                capability=self.CLIENT_TYPE_COMPLETIONS,
+                operation="send_conversation",
+                dict_input_metadata=dict_input_metadata,
+                callable_execute=_execute_turn,
+                callable_build_result_summary=lambda result, provider_elapsed_ms: self._build_completions_observability_result_summary(
+                    observed_result=result,
+                    provider_elapsed_ms=provider_elapsed_ms,
+                ),
+            )
+        )
+        # Normal return with the caller-facing conversation turn.
+        return observed_result.return_value
+
+    def _build_tool_result_message_provider(
+        self,
+        *,
+        tool_call_id: str,
+        result: dict[str, Any],
+        is_error: bool,
+    ) -> dict[str, Any]:
+        """
+        Builds one Converse toolResult user message.
+        """
+        dict_tool_result: dict[str, Any] = {
+            "toolUseId": tool_call_id,
+            "content": [{"json": result}],
+        }
+        if is_error:
+            dict_tool_result["status"] = "error"
+        # Normal return with the Converse-shaped tool-result entry.
+        return {"role": "user", "content": [{"toolResult": dict_tool_result}]}
+
+    def _extend_messages_with_turn_provider(
+        self,
+        *,
+        messages: list[dict[str, Any]],
+        turn: AITurnResult,
+    ) -> None:
+        """
+        Appends one Converse assistant message wrapping the raw content blocks.
+        """
+        messages.append({"role": "assistant", "content": turn.raw_content})
+        # Normal return after appending the assistant turn.
+        return None
+
+    def _send_structured_output_provider(
+        self,
+        *,
+        response_schema: dict[str, Any],
+        system_prompt: str | None,
+        prompt: str | None,
+        messages: list[dict[str, Any]] | None,
+        max_response_tokens: int,
+        request_timeout_seconds: float | None,
+        provider_options: dict[str, Any] | None,
+    ) -> AIStructuredOutputResult:
+        """
+        Generates structured output via Converse outputConfig.textFormat.
+
+        Reachable only on models whose capabilities flag structured-output
+        support (AWS's supported-model list; see the capabilities class).
+        """
+        self._reject_bedrock_timeout(request_timeout_seconds)
+        dict_merge_options, str_retry_override = self._split_provider_options(
+            provider_options
+        )
+        str_system_prompt: str = self._resolve_system_prompt(
+            system_prompt,
+            None,
+            AICompletionsPromptParamsBase.DEFAULT_STRICT_SCHEMA_SYSTEM_PROMPT,
+        )
+        list_messages: list[dict[str, Any]] = list(messages or [])
+        if prompt is not None and prompt.strip():
+            str_redacted_prompt: str = self.pii_middleware.process_input(prompt)
+            list_messages.append(
+                {"role": "user", "content": [{"text": str_redacted_prompt}]}
+            )
+        dict_request_kwargs: dict[str, Any] = {
+            "modelId": self.model,
+            "messages": list_messages,
+            "system": [{"text": str_system_prompt}],
+            "inferenceConfig": {"maxTokens": max_response_tokens},
+            "outputConfig": {
+                "textFormat": {
+                    "type": "json_schema",
+                    "structure": {
+                        "jsonSchema": {
+                            "schema": response_schema,
+                            "name": "structured_output",
+                        }
+                    },
+                }
+            },
+        }
+        dict_request_kwargs.update(dict_merge_options)
+        dict_input_metadata: dict[str, ObservabilityMetadataValue] = {
+            "response_mode": self.RESPONSE_MODE_STRUCTURED,
+            "prompt_char_count": len(prompt) if prompt else 0,
+            "message_count": len(messages) if messages else 0,
+            "max_response_tokens": max_response_tokens,
+        }
+
+        def _execute_structured() -> (
+            AiApiObservedCompletionsResultModel[AIStructuredOutputResult]
+        ):
+            dict_response: dict[str, Any] = self._execute_converse_with_retries(
+                lambda: self.client.converse(**dict_request_kwargs),
+                retry_override=str_retry_override,
+            )
+            str_stop_reason: str = str(
+                dict_response.get("stopReason", "") or ""
+            ).lower()
+            finish_reason: AIFinishReason = self._normalize_finish_reason(
+                str_stop_reason if str_stop_reason else None,
+                self.DICT_FINISH_REASON_MAP,
+            )
+            usage: AITokenUsage = self._usage_from_converse(dict_response)
+            list_content: list[dict[str, Any]] = (
+                dict_response.get("output", {}).get("message", {}).get("content", [])
+                or []
+            )
+            str_raw_text: str = "".join(
+                str(dict_block.get("text") or "")
+                for dict_block in list_content
+                if "text" in dict_block
+            )
+            if finish_reason in (AIFinishReason.LENGTH, AIFinishReason.REFUSAL):
+                structured_result = AIStructuredOutputResult(
+                    data=None,
+                    finish_reason=finish_reason,
+                    usage=usage,
+                    raw_text=self.pii_middleware.process_output(str_raw_text),
+                )
+            else:
+                str_content: str = self.pii_middleware.process_output(str_raw_text)
+                if not str_content:
+                    raise ValueError("Empty response from Bedrock Converse API")
+                try:
+                    parsed_data: Any = json.loads(str_content)
+                except json.JSONDecodeError as json_error:
+                    raise ValueError(
+                        f"Invalid JSON response: {json_error}"
+                    ) from json_error
+                if not isinstance(parsed_data, dict):
+                    raise ValueError(
+                        "Structured response was valid JSON but not a JSON object."
+                    )
+                structured_result = AIStructuredOutputResult(
+                    data=parsed_data,
+                    finish_reason=finish_reason,
+                    usage=usage,
+                    raw_text=str_content,
+                )
+            # Normal return with the observed structured output result.
+            return AiApiObservedCompletionsResultModel(
+                return_value=structured_result,
+                raw_output_text=structured_result.raw_text,
+                finish_reason=str(dict_response.get("stopReason", "") or "") or None,
+                provider_prompt_tokens=usage.input_tokens,
+                provider_completion_tokens=usage.output_tokens,
+                provider_cached_input_tokens=usage.cached_input_tokens,
+                provider_total_tokens=usage.total_tokens,
+            )
+
+        observed_result: AiApiObservedCompletionsResultModel[
+            AIStructuredOutputResult
+        ] = self._execute_provider_call_with_observability(
+            capability=self.CLIENT_TYPE_COMPLETIONS,
+            operation="send_structured_output",
+            dict_input_metadata=dict_input_metadata,
+            callable_execute=_execute_structured,
+            callable_build_result_summary=lambda result, provider_elapsed_ms: self._build_completions_observability_result_summary(
+                observed_result=result,
+                provider_elapsed_ms=provider_elapsed_ms,
+            ),
+        )
+        # Normal return with the caller-facing structured output result.
+        return observed_result.return_value

--- a/src/ai_api_unified/completions/ai_google_gemini_capabilities.py
+++ b/src/ai_api_unified/completions/ai_google_gemini_capabilities.py
@@ -33,6 +33,12 @@ class AICompletionsCapabilitiesGoogle(AICompletionsCapabilitiesBase):
             ],
             # All Gemini chat models stream via generate_content_stream.
             "supports_streaming": True,
+            # All catalogued Gemini models accept function declarations with
+            # forced calling, raw-JSON-schema structured output
+            # (response_json_schema), and the SDK's client.aio async surface.
+            "supports_tool_use": True,
+            "supports_structured_output": True,
+            "supports_async": True,
         }
 
         # Model-specific capabilities

--- a/src/ai_api_unified/completions/ai_google_gemini_completions.py
+++ b/src/ai_api_unified/completions/ai_google_gemini_completions.py
@@ -48,10 +48,20 @@ from ai_api_unified.ai_google_base import AIGoogleBase
 from ..ai_base import (
     AIBaseCompletions,
     AiApiObservedCompletionsResultModel,
+    AIFinishReason,
+    AIStructuredOutputResult,
     AIStructuredPrompt,
     AICompletionsPromptParamsBase,
+    AITokenUsage,
+    AITool,
+    AIToolCall,
+    AITurnResult,
+    RETRY_POLICY_DEFAULT,
+    RETRY_POLICY_NONE,
     SupportedDataType,
+    normalize_retry_policy,
 )
+from ..ai_provider_exceptions import AiProviderRequestError
 from ..middleware.observability_runtime import (
     AiApiCallResultSummaryModel,
     ObservabilityMetadataValue,
@@ -117,16 +127,30 @@ class GoogleGeminiCompletions(AIBaseCompletions, AIGoogleBase):
     and schema-based generation.
     """
 
-    def __init__(self, model: str = "", **kwargs: Any) -> None:
+    def __init__(
+        self, model: str = "", *, retry_policy: str | None = None, **kwargs: Any
+    ) -> None:
         """
         Initialize Google Gemini completions client.
 
         Args:
             model: Completions model name, defaults to DEFAULT_COMPLETIONS_MODEL
+            retry_policy: "default" keeps the engine's exponential-backoff
+                retries; "none" disables them (single attempt). Falls back to
+                the COMPLETIONS_RETRY_POLICY environment setting, then
+                "default".
             dimensions: Not used for completions but kept for interface compatibility
         """
         AIGoogleBase.__init__(self, **kwargs)
         self.env: EnvSettings = EnvSettings()
+        str_retry_candidate: str = (
+            retry_policy
+            if retry_policy is not None
+            else str(
+                self.env.get_setting("COMPLETIONS_RETRY_POLICY", RETRY_POLICY_DEFAULT)
+            )
+        )
+        self.retry_policy: str = normalize_retry_policy(str_retry_candidate)
         self.geo_residency: str | None = self.env.get_geo_residency()
         if self.geo_residency:
             _LOGGER.warning(
@@ -207,10 +231,11 @@ class GoogleGeminiCompletions(AIBaseCompletions, AIGoogleBase):
             prompt: Text prompt to send
             system_prompt: Optional persistent instructions; overrides
                 other_params.system_prompt when both are supplied.
-            max_response_tokens: Not yet mapped on this engine; raises
-                AiProviderCapabilityUnsupportedError when supplied.
-            request_timeout_seconds: Not yet mapped on this engine; raises
-                AiProviderCapabilityUnsupportedError when supplied.
+            max_response_tokens: Optional response token budget; maps to the
+                GenerateContentConfig max_output_tokens field and overrides
+                params.max_output_tokens when both are supplied.
+            request_timeout_seconds: Optional per-call timeout; maps to
+                per-request http_options (SDK milliseconds).
             other_params: Optional Google-specific parameters (AICompletionsPromptParamsGoogle)
 
         Returns:
@@ -218,10 +243,6 @@ class GoogleGeminiCompletions(AIBaseCompletions, AIGoogleBase):
         """
         if not prompt or not prompt.strip():
             raise ValueError("Prompt cannot be empty or None")
-        self._reject_unsupported_send_prompt_params(
-            max_response_tokens=max_response_tokens,
-            request_timeout_seconds=request_timeout_seconds,
-        )
 
         prompt = self.pii_middleware.process_input(prompt)
 
@@ -231,12 +252,14 @@ class GoogleGeminiCompletions(AIBaseCompletions, AIGoogleBase):
             params.system_prompt = system_prompt
 
         system_prompt = params.system_prompt
+        int_max_output_tokens: int = max_response_tokens or params.max_output_tokens
         dict_input_metadata: dict[str, ObservabilityMetadataValue] = (
             self._build_completions_observability_input_metadata(
                 prompt=prompt,
                 system_prompt=system_prompt,
                 other_params=params,
                 response_mode=self.RESPONSE_MODE_TEXT,
+                max_response_tokens=max_response_tokens,
             )
         )
 
@@ -248,7 +271,8 @@ class GoogleGeminiCompletions(AIBaseCompletions, AIGoogleBase):
                 config: genai.types.GenerateContentConfig = self._build_config(
                     params=params,
                     system_prompt=system_prompt,
-                    max_output_tokens=params.max_output_tokens,
+                    max_output_tokens=int_max_output_tokens,
+                    request_timeout_seconds=request_timeout_seconds,
                 )
                 response: GenerateContentResponse = self.client.models.generate_content(
                     model=self.completions_model,
@@ -301,7 +325,8 @@ class GoogleGeminiCompletions(AIBaseCompletions, AIGoogleBase):
                 operation="send_prompt",
                 dict_input_metadata=dict_input_metadata,
                 callable_execute=lambda: self._retry_with_exponential_backoff(
-                    _generate_text
+                    _generate_text,
+                    max_retries=self._effective_max_retries(),
                 ),
                 callable_build_result_summary=lambda result, provider_elapsed_ms: self._build_completions_observability_result_summary(
                     observed_result=result,
@@ -581,7 +606,8 @@ class GoogleGeminiCompletions(AIBaseCompletions, AIGoogleBase):
                 operation="strict_schema_prompt",
                 dict_input_metadata=dict_input_metadata,
                 callable_execute=lambda: self._retry_with_exponential_backoff(
-                    _generate_structured
+                    _generate_structured,
+                    max_retries=self._effective_max_retries(),
                 ),
                 callable_build_result_summary=lambda result, provider_elapsed_ms: self._build_completions_observability_result_summary(
                     observed_result=result,
@@ -680,9 +706,17 @@ class GoogleGeminiCompletions(AIBaseCompletions, AIGoogleBase):
         system_prompt: str | None,
         max_output_tokens: int,
         response_schema: Type[AIStructuredPrompt] | None = None,
+        *,
+        response_json_schema: dict[str, Any] | None = None,
+        request_timeout_seconds: float | None = None,
     ) -> genai.types.GenerateContentConfig:
         """
         Construct GenerateContentConfig, including optional system instruction.
+
+        response_schema carries a pydantic class (legacy strict_schema_prompt
+        path); response_json_schema carries a raw JSON Schema for
+        send_structured_output. request_timeout_seconds maps to per-request
+        http_options (the SDK timeout unit is milliseconds).
         """
 
         config_kwargs: dict[str, Any] = {
@@ -695,9 +729,12 @@ class GoogleGeminiCompletions(AIBaseCompletions, AIGoogleBase):
         if system_prompt is not None:
             config_kwargs["system_instruction"] = system_prompt
 
-        if response_schema is not None:
+        if response_schema is not None or response_json_schema is not None:
             config_kwargs["response_mime_type"] = "application/json"
-            config_kwargs["response_schema"] = response_schema
+            if response_schema is not None:
+                config_kwargs["response_schema"] = response_schema
+            else:
+                config_kwargs["response_json_schema"] = response_json_schema
             default_temperature: float = AICompletionsPromptParamsGoogle.model_fields[
                 "temperature"
             ].default
@@ -708,6 +745,11 @@ class GoogleGeminiCompletions(AIBaseCompletions, AIGoogleBase):
             ].default
             if params.top_p == default_top_p:
                 config_kwargs["top_p"] = STRUCTURED_DEFAULT_TOP_P
+
+        if request_timeout_seconds is not None:
+            config_kwargs["http_options"] = genai.types.HttpOptions(
+                timeout=int(request_timeout_seconds * 1000)
+            )
 
         return genai.types.GenerateContentConfig(**config_kwargs)
 
@@ -819,3 +861,788 @@ class GoogleGeminiCompletions(AIBaseCompletions, AIGoogleBase):
         except AttributeError:
             # Early return because the SDK response did not expose usage metadata as expected.
             return None
+
+    # ── Conversation, structured output, async, retries (2.15.0) ────────────
+
+    PROVIDER_ENGINE_TOKEN = "google-gemini"
+
+    # Finish-reason markers matched as substrings of str(finish_reason), which
+    # renders as e.g. "FinishReason.MAX_TOKENS" on the real SDK.
+    TUPLE_LENGTH_FINISH_MARKERS = ("MAX_TOKENS",)
+    TUPLE_REFUSAL_FINISH_MARKERS = (
+        "SAFETY",
+        "RECITATION",
+        "BLOCKLIST",
+        "PROHIBITED_CONTENT",
+        "SPII",
+    )
+
+    def _effective_max_retries(self, retry_override: str | None = None) -> int | None:
+        """
+        Resolves the retry budget for one call from policy and override.
+
+        Returns:
+            0 when retries are disabled (single attempt), otherwise None so
+            the backoff helper uses the engine default.
+        """
+        # getattr with a default keeps init-bypassing test doubles working.
+        str_policy: str = getattr(self, "retry_policy", RETRY_POLICY_DEFAULT)
+        if retry_override is not None:
+            str_policy = normalize_retry_policy(retry_override)
+        if str_policy == RETRY_POLICY_NONE:
+            # Early return with a single-attempt budget.
+            return 0
+        # Normal return deferring to the engine default retry budget.
+        return None
+
+    def _raise_gemini_request_error(self, exception: Exception) -> None:
+        """
+        Re-raises one Google SDK transport error as the typed request error.
+
+        Probes the exception and its cause chain (the retry helper wraps
+        exhausted errors in RuntimeError "from" the original) for Google API
+        errors and their status codes. Non-Google exceptions propagate
+        unchanged.
+        """
+
+        def _probe_status_code(error: Any) -> int | None:
+            for str_attr in ("code", "status"):
+                raw_value = getattr(error, str_attr, None)
+                raw_value = getattr(raw_value, "value", raw_value)
+                if isinstance(raw_value, int):
+                    return raw_value
+                if isinstance(raw_value, str) and raw_value.isdigit():
+                    return int(raw_value)
+            response = getattr(error, "response", None)
+            raw_status = getattr(response, "status_code", None)
+            if isinstance(raw_status, int):
+                return raw_status
+            return None
+
+        # Loop over the exception and its cause so wrapped errors still map.
+        for candidate in (exception, getattr(exception, "__cause__", None)):
+            if candidate is None:
+                continue
+            str_module: str = type(candidate).__module__ or ""
+            if str_module.startswith("google"):
+                raise AiProviderRequestError(
+                    f"Google Gemini request failed: {candidate}",
+                    status_code=_probe_status_code(candidate),
+                    provider_engine=self.PROVIDER_ENGINE_TOKEN,
+                ) from exception
+        # Normal return so non-Google exceptions propagate unchanged.
+        return None
+
+    def _normalize_gemini_finish_reason(
+        self,
+        str_finish_reason: str | None,
+        *,
+        bool_has_tool_calls: bool,
+    ) -> AIFinishReason:
+        """
+        Maps one Gemini finish-reason string onto the normalized enum.
+        """
+        if bool_has_tool_calls:
+            # Early return because requested tool calls define the turn.
+            return AIFinishReason.TOOL_USE
+        str_upper: str = (str_finish_reason or "").upper()
+        if any(marker in str_upper for marker in self.TUPLE_LENGTH_FINISH_MARKERS):
+            # Early return because output was truncated at the budget.
+            return AIFinishReason.LENGTH
+        if any(marker in str_upper for marker in self.TUPLE_REFUSAL_FINISH_MARKERS):
+            # Early return because the response was blocked or declined.
+            return AIFinishReason.REFUSAL
+        # Normal return because the turn completed normally.
+        return AIFinishReason.COMPLETE
+
+    def _usage_from_gemini(self, response: Any) -> AITokenUsage:
+        """
+        Builds the provider-neutral usage model from one Gemini response.
+        """
+        # Normal return with the provider-neutral token usage model.
+        return AITokenUsage(
+            input_tokens=self._extract_gemini_prompt_tokens(response),
+            output_tokens=self._extract_gemini_completion_tokens(response),
+            cached_input_tokens=self._extract_gemini_cached_tokens(response),
+            total_tokens=self._extract_gemini_total_tokens(response),
+        )
+
+    @staticmethod
+    def _serialize_gemini_part(part: Any) -> dict[str, Any]:
+        """
+        Serializes one candidate content part into a replayable dictionary.
+        """
+        model_dump = getattr(part, "model_dump", None)
+        if callable(model_dump):
+            try:
+                dict_part: Any = model_dump(exclude_none=True)
+                if isinstance(dict_part, dict):
+                    # Early return with the SDK-serialized part.
+                    return dict_part
+            except TypeError:
+                # Fall through to attribute-based reconstruction (test doubles).
+                pass
+        function_call = getattr(part, "function_call", None)
+        if function_call is not None:
+            dict_function_call: dict[str, Any] = {
+                "name": str(getattr(function_call, "name", "") or ""),
+                "args": dict(getattr(function_call, "args", None) or {}),
+            }
+            return {"function_call": dict_function_call}
+        str_text: Any = getattr(part, "text", None)
+        if str_text:
+            return {"text": str_text}
+        # Normal return with an empty part placeholder for unknown shapes.
+        return {}
+
+    def _build_turn_result_from_gemini(self, response: Any) -> AITurnResult:
+        """
+        Maps one Gemini response onto the provider-neutral turn.
+
+        Gemini function calls carry no stable call id, so AIToolCall.id is
+        the function name; build_tool_result_message expects that name back.
+        """
+        list_text_parts: list[str] = []
+        list_tool_calls: list[AIToolCall] = []
+        list_raw_parts: list[dict[str, Any]] = []
+        candidates = getattr(response, "candidates", None) or []
+        content = getattr(candidates[0], "content", None) if candidates else None
+        # Loop over content parts so text, tool calls, and replay parts align.
+        for part in getattr(content, "parts", None) or []:
+            list_raw_parts.append(self._serialize_gemini_part(part))
+            function_call = getattr(part, "function_call", None)
+            if function_call is not None:
+                str_name: str = str(getattr(function_call, "name", "") or "")
+                list_tool_calls.append(
+                    AIToolCall(
+                        id=str_name,
+                        name=str_name,
+                        input=dict(getattr(function_call, "args", None) or {}),
+                    )
+                )
+                continue
+            str_part_text: Any = getattr(part, "text", None)
+            if str_part_text:
+                list_text_parts.append(str_part_text)
+        str_finish_reason: str | None = self._extract_gemini_finish_reason(response)
+        finish_reason: AIFinishReason = self._normalize_gemini_finish_reason(
+            str_finish_reason,
+            bool_has_tool_calls=bool(list_tool_calls),
+        )
+        str_text: str = "".join(list_text_parts)
+        # Normal return with the provider-neutral turn result.
+        return AITurnResult(
+            text=str_text if str_text else None,
+            tool_calls=list_tool_calls,
+            finish_reason=finish_reason,
+            raw_content=list_raw_parts,
+            usage=self._usage_from_gemini(response),
+        )
+
+    def _build_gemini_conversation_config_kwargs(
+        self,
+        *,
+        system_prompt: str,
+        tools: list[AITool],
+        tool_choice: str | None,
+        max_response_tokens: int | None,
+        request_timeout_seconds: float | None,
+        dict_merge_options: dict[str, Any],
+    ) -> dict[str, Any]:
+        """
+        Builds GenerateContentConfig kwargs for one conversation turn.
+
+        provider_options keys merge into the config kwargs, so callers can set
+        any GenerateContentConfig field the engine has not mapped.
+        """
+        dict_config_kwargs: dict[str, Any] = {"system_instruction": system_prompt}
+        if max_response_tokens is not None:
+            dict_config_kwargs["max_output_tokens"] = max_response_tokens
+        if tools:
+            list_declarations: list[Any] = []
+            # Loop over tool definitions so each maps to a function declaration.
+            for ai_tool in tools:
+                list_declarations.append(
+                    genai.types.FunctionDeclaration(
+                        name=ai_tool.name,
+                        description=ai_tool.description,
+                        parameters_json_schema=ai_tool.input_schema,
+                    )
+                )
+            dict_config_kwargs["tools"] = [
+                genai.types.Tool(function_declarations=list_declarations)
+            ]
+        if tool_choice is not None:
+            dict_config_kwargs["tool_config"] = genai.types.ToolConfig(
+                function_calling_config=genai.types.FunctionCallingConfig(
+                    mode="ANY",
+                    allowed_function_names=[tool_choice],
+                )
+            )
+        if request_timeout_seconds is not None:
+            dict_config_kwargs["http_options"] = genai.types.HttpOptions(
+                timeout=int(request_timeout_seconds * 1000)
+            )
+        dict_config_kwargs.update(dict_merge_options)
+        # Normal return with the conversation config kwargs.
+        return dict_config_kwargs
+
+    def _observed_gemini_turn_result(
+        self, response: Any
+    ) -> AiApiObservedCompletionsResultModel[AITurnResult]:
+        """
+        Wraps one Gemini response as an observed conversation-turn result.
+        """
+        turn_result: AITurnResult = self._build_turn_result_from_gemini(response)
+        # Normal return with the observed turn result and usage metadata.
+        return AiApiObservedCompletionsResultModel(
+            return_value=turn_result,
+            raw_output_text=turn_result.text or "",
+            finish_reason=self._extract_gemini_finish_reason(response),
+            provider_prompt_tokens=turn_result.usage.input_tokens,
+            provider_completion_tokens=turn_result.usage.output_tokens,
+            provider_cached_input_tokens=turn_result.usage.cached_input_tokens,
+            provider_total_tokens=turn_result.usage.total_tokens,
+            dict_metadata={"tool_call_count": len(turn_result.tool_calls)},
+        )
+
+    def _build_conversation_observability_metadata(
+        self,
+        *,
+        system_prompt: str,
+        messages: list[dict[str, Any]],
+        tools: list[AITool],
+        tool_choice: str | None,
+        max_response_tokens: int | None,
+    ) -> dict[str, ObservabilityMetadataValue]:
+        """
+        Builds metadata-only observability fields for one conversation turn.
+        """
+        dict_metadata: dict[str, ObservabilityMetadataValue] = {
+            "response_mode": self.RESPONSE_MODE_TEXT,
+            "message_count": len(messages),
+            "tool_count": len(tools),
+            "system_prompt_char_count": len(system_prompt),
+        }
+        if tool_choice is not None:
+            dict_metadata["forced_tool"] = tool_choice
+        if max_response_tokens is not None:
+            dict_metadata["max_response_tokens"] = max_response_tokens
+        # Normal return with scalar conversation metadata.
+        return dict_metadata
+
+    def _send_conversation_provider(
+        self,
+        *,
+        system_prompt: str,
+        messages: list[dict[str, Any]],
+        tools: list[AITool],
+        tool_choice: str | None,
+        max_response_tokens: int | None,
+        request_timeout_seconds: float | None,
+        provider_options: dict[str, Any] | None,
+    ) -> AITurnResult:
+        """
+        Sends one conversation turn via generate_content with function tools.
+        """
+        dict_merge_options, str_retry_override = self._split_provider_options(
+            provider_options
+        )
+        dict_config_kwargs: dict[str, Any] = (
+            self._build_gemini_conversation_config_kwargs(
+                system_prompt=system_prompt,
+                tools=tools,
+                tool_choice=tool_choice,
+                max_response_tokens=max_response_tokens,
+                request_timeout_seconds=request_timeout_seconds,
+                dict_merge_options=dict_merge_options,
+            )
+        )
+        dict_input_metadata: dict[str, ObservabilityMetadataValue] = (
+            self._build_conversation_observability_metadata(
+                system_prompt=system_prompt,
+                messages=messages,
+                tools=tools,
+                tool_choice=tool_choice,
+                max_response_tokens=max_response_tokens,
+            )
+        )
+
+        def _generate_turn() -> AiApiObservedCompletionsResultModel[AITurnResult]:
+            response = self.client.models.generate_content(
+                model=self.completions_model,
+                contents=messages,
+                config=genai.types.GenerateContentConfig(**dict_config_kwargs),
+            )
+            # Normal return with the observed conversation turn.
+            return self._observed_gemini_turn_result(response)
+
+        def _execute_with_policy() -> AiApiObservedCompletionsResultModel[AITurnResult]:
+            try:
+                return self._retry_with_exponential_backoff(
+                    _generate_turn,
+                    max_retries=self._effective_max_retries(str_retry_override),
+                )
+            except Exception as exception:
+                self._raise_gemini_request_error(exception)
+                raise
+
+        observed_result: AiApiObservedCompletionsResultModel[AITurnResult] = (
+            self._execute_provider_call_with_observability(
+                capability=self.CLIENT_TYPE_COMPLETIONS,
+                operation="send_conversation",
+                dict_input_metadata=dict_input_metadata,
+                callable_execute=_execute_with_policy,
+                callable_build_result_summary=lambda result, provider_elapsed_ms: self._build_completions_observability_result_summary(
+                    observed_result=result,
+                    provider_elapsed_ms=provider_elapsed_ms,
+                ),
+            )
+        )
+        # Normal return with the caller-facing conversation turn.
+        return observed_result.return_value
+
+    async def _asend_conversation_provider(
+        self,
+        *,
+        system_prompt: str,
+        messages: list[dict[str, Any]],
+        tools: list[AITool],
+        tool_choice: str | None,
+        max_response_tokens: int | None,
+        request_timeout_seconds: float | None,
+        provider_options: dict[str, Any] | None,
+    ) -> AITurnResult:
+        """
+        Async twin of _send_conversation_provider via client.aio.
+
+        Async variants perform a single attempt (the engine backoff helper is
+        synchronous); transport failures surface as typed request errors for
+        caller-owned backoff.
+        """
+        dict_merge_options, _ = self._split_provider_options(provider_options)
+        dict_config_kwargs: dict[str, Any] = (
+            self._build_gemini_conversation_config_kwargs(
+                system_prompt=system_prompt,
+                tools=tools,
+                tool_choice=tool_choice,
+                max_response_tokens=max_response_tokens,
+                request_timeout_seconds=request_timeout_seconds,
+                dict_merge_options=dict_merge_options,
+            )
+        )
+        dict_input_metadata: dict[str, ObservabilityMetadataValue] = (
+            self._build_conversation_observability_metadata(
+                system_prompt=system_prompt,
+                messages=messages,
+                tools=tools,
+                tool_choice=tool_choice,
+                max_response_tokens=max_response_tokens,
+            )
+        )
+
+        async def _generate_turn() -> AiApiObservedCompletionsResultModel[AITurnResult]:
+            try:
+                response = await self.client.aio.models.generate_content(
+                    model=self.completions_model,
+                    contents=messages,
+                    config=genai.types.GenerateContentConfig(**dict_config_kwargs),
+                )
+            except Exception as exception:
+                self._raise_gemini_request_error(exception)
+                raise
+            # Normal return with the observed conversation turn.
+            return self._observed_gemini_turn_result(response)
+
+        observed_result: AiApiObservedCompletionsResultModel[AITurnResult] = (
+            await self._execute_provider_acall_with_observability(
+                capability=self.CLIENT_TYPE_COMPLETIONS,
+                operation="asend_conversation",
+                dict_input_metadata=dict_input_metadata,
+                callable_execute=_generate_turn,
+                callable_build_result_summary=lambda result, provider_elapsed_ms: self._build_completions_observability_result_summary(
+                    observed_result=result,
+                    provider_elapsed_ms=provider_elapsed_ms,
+                ),
+            )
+        )
+        # Normal return with the caller-facing conversation turn.
+        return observed_result.return_value
+
+    def _build_tool_result_message_provider(
+        self,
+        *,
+        tool_call_id: str,
+        result: dict[str, Any],
+        is_error: bool,
+    ) -> dict[str, Any]:
+        """
+        Builds one Gemini function-response user message.
+
+        tool_call_id is the function name (Gemini function calls carry no
+        stable id; AIToolCall.id is set to the name). Errors are encoded in
+        the response payload under an "error" key.
+        """
+        dict_payload: dict[str, Any] = {"error": result} if is_error else result
+        # Normal return with the Gemini-shaped function response entry.
+        return {
+            "role": "user",
+            "parts": [
+                {
+                    "function_response": {
+                        "name": tool_call_id,
+                        "response": dict_payload,
+                    }
+                }
+            ],
+        }
+
+    def _extend_messages_with_turn_provider(
+        self,
+        *,
+        messages: list[dict[str, Any]],
+        turn: AITurnResult,
+    ) -> None:
+        """
+        Appends one Gemini model turn wrapping the raw content parts.
+        """
+        messages.append({"role": "model", "parts": turn.raw_content})
+        # Normal return after appending the model turn.
+        return None
+
+    def _build_gemini_structured_request(
+        self,
+        *,
+        response_schema: dict[str, Any],
+        system_prompt: str | None,
+        prompt: str | None,
+        messages: list[dict[str, Any]] | None,
+        max_response_tokens: int,
+        request_timeout_seconds: float | None,
+        dict_merge_options: dict[str, Any],
+    ) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+        """
+        Builds (contents, config kwargs) for one structured-output call.
+        """
+        str_system_prompt: str = self._resolve_system_prompt(
+            system_prompt,
+            None,
+            AICompletionsPromptParamsBase.DEFAULT_STRICT_SCHEMA_SYSTEM_PROMPT,
+        )
+        list_contents: list[dict[str, Any]] = list(messages or [])
+        if prompt is not None and prompt.strip():
+            str_redacted_prompt: str = self.pii_middleware.process_input(prompt)
+            list_contents.append(
+                {"role": "user", "parts": [{"text": str_redacted_prompt}]}
+            )
+        dict_config_kwargs: dict[str, Any] = {
+            "system_instruction": str_system_prompt,
+            "max_output_tokens": max_response_tokens,
+            "temperature": STRUCTURED_DEFAULT_TEMPERATURE,
+            "top_p": STRUCTURED_DEFAULT_TOP_P,
+            "response_mime_type": "application/json",
+            "response_json_schema": response_schema,
+        }
+        if request_timeout_seconds is not None:
+            dict_config_kwargs["http_options"] = genai.types.HttpOptions(
+                timeout=int(request_timeout_seconds * 1000)
+            )
+        dict_config_kwargs.update(dict_merge_options)
+        # Normal return with contents and config kwargs.
+        return list_contents, dict_config_kwargs
+
+    def _build_structured_output_result_from_gemini(
+        self, response: Any
+    ) -> AIStructuredOutputResult:
+        """
+        Maps one Gemini structured response onto the provider-neutral result.
+        """
+        str_finish_reason: str | None = self._extract_gemini_finish_reason(response)
+        finish_reason: AIFinishReason = self._normalize_gemini_finish_reason(
+            str_finish_reason,
+            bool_has_tool_calls=False,
+        )
+        usage: AITokenUsage = self._usage_from_gemini(response)
+        raw_output_text: str = str(getattr(response, "text", "") or "")
+        if finish_reason in (AIFinishReason.LENGTH, AIFinishReason.REFUSAL):
+            # Early return so callers branch on finish_reason instead of parsing.
+            return AIStructuredOutputResult(
+                data=None,
+                finish_reason=finish_reason,
+                usage=usage,
+                raw_text=self.pii_middleware.process_output(raw_output_text),
+            )
+        str_content: str = self.pii_middleware.process_output(raw_output_text)
+        if not str_content:
+            raise ValueError("Empty response from Gemini API")
+        try:
+            parsed_data: Any = json.loads(str_content)
+        except json.JSONDecodeError as json_error:
+            raise ValueError(f"Invalid JSON response: {json_error}") from json_error
+        if not isinstance(parsed_data, dict):
+            raise ValueError(
+                "Structured response was valid JSON but not a JSON object."
+            )
+        # Normal return with the parsed structured output result.
+        return AIStructuredOutputResult(
+            data=parsed_data,
+            finish_reason=finish_reason,
+            usage=usage,
+            raw_text=str_content,
+        )
+
+    def _observed_gemini_structured_result(
+        self, response: Any
+    ) -> AiApiObservedCompletionsResultModel[AIStructuredOutputResult]:
+        """
+        Wraps one Gemini structured response as an observed result.
+        """
+        structured_result: AIStructuredOutputResult = (
+            self._build_structured_output_result_from_gemini(response)
+        )
+        # Normal return with the observed structured output result.
+        return AiApiObservedCompletionsResultModel(
+            return_value=structured_result,
+            raw_output_text=structured_result.raw_text,
+            finish_reason=self._extract_gemini_finish_reason(response),
+            provider_prompt_tokens=structured_result.usage.input_tokens,
+            provider_completion_tokens=structured_result.usage.output_tokens,
+            provider_cached_input_tokens=structured_result.usage.cached_input_tokens,
+            provider_total_tokens=structured_result.usage.total_tokens,
+        )
+
+    def _build_structured_observability_metadata(
+        self,
+        *,
+        prompt: str | None,
+        messages: list[dict[str, Any]] | None,
+        max_response_tokens: int,
+    ) -> dict[str, ObservabilityMetadataValue]:
+        """
+        Builds metadata-only observability fields for one structured call.
+        """
+        # Normal return with scalar structured-call metadata.
+        return {
+            "response_mode": self.RESPONSE_MODE_STRUCTURED,
+            "prompt_char_count": len(prompt) if prompt else 0,
+            "message_count": len(messages) if messages else 0,
+            "max_response_tokens": max_response_tokens,
+        }
+
+    def _send_structured_output_provider(
+        self,
+        *,
+        response_schema: dict[str, Any],
+        system_prompt: str | None,
+        prompt: str | None,
+        messages: list[dict[str, Any]] | None,
+        max_response_tokens: int,
+        request_timeout_seconds: float | None,
+        provider_options: dict[str, Any] | None,
+    ) -> AIStructuredOutputResult:
+        """
+        Generates structured output via response_json_schema.
+        """
+        dict_merge_options, str_retry_override = self._split_provider_options(
+            provider_options
+        )
+        list_contents, dict_config_kwargs = self._build_gemini_structured_request(
+            response_schema=response_schema,
+            system_prompt=system_prompt,
+            prompt=prompt,
+            messages=messages,
+            max_response_tokens=max_response_tokens,
+            request_timeout_seconds=request_timeout_seconds,
+            dict_merge_options=dict_merge_options,
+        )
+        dict_input_metadata: dict[str, ObservabilityMetadataValue] = (
+            self._build_structured_observability_metadata(
+                prompt=prompt,
+                messages=messages,
+                max_response_tokens=max_response_tokens,
+            )
+        )
+
+        def _generate_structured() -> (
+            AiApiObservedCompletionsResultModel[AIStructuredOutputResult]
+        ):
+            response = self.client.models.generate_content(
+                model=self.completions_model,
+                contents=list_contents,
+                config=genai.types.GenerateContentConfig(**dict_config_kwargs),
+            )
+            # Normal return with the observed structured output result.
+            return self._observed_gemini_structured_result(response)
+
+        def _execute_with_policy() -> (
+            AiApiObservedCompletionsResultModel[AIStructuredOutputResult]
+        ):
+            try:
+                return self._retry_with_exponential_backoff(
+                    _generate_structured,
+                    max_retries=self._effective_max_retries(str_retry_override),
+                )
+            except (ValueError, ValidationError):
+                raise
+            except Exception as exception:
+                self._raise_gemini_request_error(exception)
+                raise
+
+        observed_result: AiApiObservedCompletionsResultModel[
+            AIStructuredOutputResult
+        ] = self._execute_provider_call_with_observability(
+            capability=self.CLIENT_TYPE_COMPLETIONS,
+            operation="send_structured_output",
+            dict_input_metadata=dict_input_metadata,
+            callable_execute=_execute_with_policy,
+            callable_build_result_summary=lambda result, provider_elapsed_ms: self._build_completions_observability_result_summary(
+                observed_result=result,
+                provider_elapsed_ms=provider_elapsed_ms,
+            ),
+        )
+        # Normal return with the caller-facing structured output result.
+        return observed_result.return_value
+
+    async def _asend_structured_output_provider(
+        self,
+        *,
+        response_schema: dict[str, Any],
+        system_prompt: str | None,
+        prompt: str | None,
+        messages: list[dict[str, Any]] | None,
+        max_response_tokens: int,
+        request_timeout_seconds: float | None,
+        provider_options: dict[str, Any] | None,
+    ) -> AIStructuredOutputResult:
+        """
+        Async twin of _send_structured_output_provider via client.aio.
+
+        Single attempt; see _asend_conversation_provider.
+        """
+        dict_merge_options, _ = self._split_provider_options(provider_options)
+        list_contents, dict_config_kwargs = self._build_gemini_structured_request(
+            response_schema=response_schema,
+            system_prompt=system_prompt,
+            prompt=prompt,
+            messages=messages,
+            max_response_tokens=max_response_tokens,
+            request_timeout_seconds=request_timeout_seconds,
+            dict_merge_options=dict_merge_options,
+        )
+        dict_input_metadata: dict[str, ObservabilityMetadataValue] = (
+            self._build_structured_observability_metadata(
+                prompt=prompt,
+                messages=messages,
+                max_response_tokens=max_response_tokens,
+            )
+        )
+
+        async def _generate_structured() -> (
+            AiApiObservedCompletionsResultModel[AIStructuredOutputResult]
+        ):
+            try:
+                response = await self.client.aio.models.generate_content(
+                    model=self.completions_model,
+                    contents=list_contents,
+                    config=genai.types.GenerateContentConfig(**dict_config_kwargs),
+                )
+            except Exception as exception:
+                self._raise_gemini_request_error(exception)
+                raise
+            # Normal return with the observed structured output result.
+            return self._observed_gemini_structured_result(response)
+
+        observed_result: AiApiObservedCompletionsResultModel[
+            AIStructuredOutputResult
+        ] = await self._execute_provider_acall_with_observability(
+            capability=self.CLIENT_TYPE_COMPLETIONS,
+            operation="asend_structured_output",
+            dict_input_metadata=dict_input_metadata,
+            callable_execute=_generate_structured,
+            callable_build_result_summary=lambda result, provider_elapsed_ms: self._build_completions_observability_result_summary(
+                observed_result=result,
+                provider_elapsed_ms=provider_elapsed_ms,
+            ),
+        )
+        # Normal return with the caller-facing structured output result.
+        return observed_result.return_value
+
+    async def _asend_prompt_provider(
+        self,
+        prompt: str,
+        *,
+        system_prompt: str | None,
+        max_response_tokens: int | None,
+        request_timeout_seconds: float | None,
+        other_params: AICompletionsPromptParamsBase | None,
+    ) -> str:
+        """
+        Async twin of send_prompt via client.aio.
+
+        Single attempt; see _asend_conversation_provider.
+        """
+        str_redacted_prompt: str = self.pii_middleware.process_input(prompt)
+        params = self._coerce_params(other_params)
+        if system_prompt is not None and system_prompt.strip():
+            params.system_prompt = system_prompt
+        str_system_prompt: str | None = params.system_prompt
+        int_max_output_tokens: int = max_response_tokens or params.max_output_tokens
+        list_contents: list[dict[str, Any]] = self._build_contents(
+            prompt=str_redacted_prompt, params=params
+        )
+        config: genai.types.GenerateContentConfig = self._build_config(
+            params=params,
+            system_prompt=str_system_prompt,
+            max_output_tokens=int_max_output_tokens,
+            request_timeout_seconds=request_timeout_seconds,
+        )
+        dict_input_metadata: dict[str, ObservabilityMetadataValue] = (
+            self._build_completions_observability_input_metadata(
+                prompt=str_redacted_prompt,
+                system_prompt=str_system_prompt,
+                other_params=params,
+                response_mode=self.RESPONSE_MODE_TEXT,
+                max_response_tokens=max_response_tokens,
+            )
+        )
+
+        async def _generate_text() -> AiApiObservedCompletionsResultModel[str]:
+            try:
+                response = await self.client.aio.models.generate_content(
+                    model=self.completions_model,
+                    contents=list_contents,
+                    config=config,
+                )
+            except Exception as exception:
+                self._raise_gemini_request_error(exception)
+                raise
+            raw_output_text: str = str(getattr(response, "text", "") or "")
+            # Normal return with the Gemini text output and usage metadata.
+            return AiApiObservedCompletionsResultModel(
+                return_value=raw_output_text,
+                raw_output_text=raw_output_text,
+                finish_reason=self._extract_gemini_finish_reason(response),
+                provider_prompt_tokens=self._extract_gemini_prompt_tokens(response),
+                provider_completion_tokens=self._extract_gemini_completion_tokens(
+                    response
+                ),
+                provider_cached_input_tokens=self._extract_gemini_cached_tokens(
+                    response
+                ),
+                provider_total_tokens=self._extract_gemini_total_tokens(response),
+            )
+
+        observed_result: AiApiObservedCompletionsResultModel[str] = (
+            await self._execute_provider_acall_with_observability(
+                capability=self.CLIENT_TYPE_COMPLETIONS,
+                operation="asend_prompt",
+                dict_input_metadata=dict_input_metadata,
+                callable_execute=_generate_text,
+                callable_build_result_summary=lambda result, provider_elapsed_ms: self._build_completions_observability_result_summary(
+                    observed_result=result,
+                    provider_elapsed_ms=provider_elapsed_ms,
+                ),
+            )
+        )
+        # Normal return with sanitized Gemini text after observability wrapping.
+        return self.pii_middleware.process_output(observed_result.return_value)

--- a/src/ai_api_unified/completions/ai_openai_completions.py
+++ b/src/ai_api_unified/completions/ai_openai_completions.py
@@ -8,6 +8,7 @@ from collections.abc import Iterator
 from datetime import date
 from typing import Any, ClassVar, Type
 
+from openai import APIConnectionError, APIStatusError, APITimeoutError
 from pydantic import ValidationError, model_validator
 
 from ai_api_unified.ai_completions_exceptions import (
@@ -18,11 +19,19 @@ from ai_api_unified.ai_openai_base import AIOpenAIBase
 from ..ai_base import (
     AIBaseCompletions,
     AiApiObservedCompletionsResultModel,
+    AIFinishReason,
+    AIStructuredOutputResult,
     AIStructuredPrompt,
     AICompletionsCapabilitiesBase,
     AICompletionsPromptParamsBase,
+    AITokenUsage,
+    AITool,
+    AIToolCall,
+    AITurnResult,
+    RETRY_POLICY_NONE,
     SupportedDataType,
 )
+from ..ai_provider_exceptions import AiProviderRequestError
 from ..middleware.observability_runtime import (
     AiApiCallResultSummaryModel,
     ObservabilityMetadataValue,
@@ -55,6 +64,11 @@ class AICompletionsCapabilitiesOpenAI(AICompletionsCapabilitiesBase):
         "supports_data_residency_constraint": True,
         # All supported chat models stream via chat.completions stream=True.
         "supports_streaming": True,
+        # All catalogued chat models accept tools/tool_choice and the
+        # json_schema response_format, and the SDK ships AsyncOpenAI.
+        "supports_tool_use": True,
+        "supports_structured_output": True,
+        "supports_async": True,
     }
 
     # Context window sizes (max tokens each model can handle)
@@ -262,6 +276,799 @@ class AiOpenAICompletions(AIOpenAIBase, AIBaseCompletions):
         return AICompletionsCapabilitiesOpenAI.DICT_OPENAI_CONTEXT_WINDOWS.get(
             self.completions_model, 0
         )
+
+    # ── Conversation, structured output, async, retries (2.15.0) ────────────
+
+    # Engine token carried on typed request errors.
+    PROVIDER_ENGINE_TOKEN: ClassVar[str] = "openai"
+
+    DICT_FINISH_REASON_MAP: ClassVar[dict[str, AIFinishReason]] = {
+        "stop": AIFinishReason.COMPLETE,
+        "length": AIFinishReason.LENGTH,
+        "tool_calls": AIFinishReason.TOOL_USE,
+        "function_call": AIFinishReason.TOOL_USE,
+        "content_filter": AIFinishReason.REFUSAL,
+    }
+
+    def _client_for_call(
+        self,
+        *,
+        request_timeout_seconds: float | None = None,
+        retry_policy_override: str | None = None,
+    ) -> Any:
+        """
+        Returns the sync client, applying per-call timeout and retry options.
+        """
+        dict_options: dict[str, Any] = {}
+        if request_timeout_seconds is not None:
+            dict_options["timeout"] = request_timeout_seconds
+        if retry_policy_override is not None:
+            if retry_policy_override.strip().lower() == RETRY_POLICY_NONE:
+                dict_options["max_retries"] = 0
+        if not dict_options:
+            # Early return with the shared client when no per-call options apply.
+            return self.client
+        # Normal return with a per-call options view of the shared client.
+        return self.client.with_options(**dict_options)
+
+    def _async_client_for_call(
+        self,
+        *,
+        request_timeout_seconds: float | None = None,
+        retry_policy_override: str | None = None,
+    ) -> Any:
+        """
+        Async twin of _client_for_call.
+        """
+        dict_options: dict[str, Any] = {}
+        if request_timeout_seconds is not None:
+            dict_options["timeout"] = request_timeout_seconds
+        if retry_policy_override is not None:
+            if retry_policy_override.strip().lower() == RETRY_POLICY_NONE:
+                dict_options["max_retries"] = 0
+        if not dict_options:
+            # Early return with the shared async client when no per-call options apply.
+            return self.async_client
+        # Normal return with a per-call options view of the shared async client.
+        return self.async_client.with_options(**dict_options)
+
+    def _raise_request_error(self, exception: Exception) -> None:
+        """
+        Re-raises one OpenAI SDK transport error as the typed request error.
+
+        Carries the HTTP status code (when available) so caller-owned backoff
+        can classify 429/5xx uniformly across engines. Non-transport
+        exceptions propagate unchanged.
+        """
+        if isinstance(exception, APIStatusError):
+            raise AiProviderRequestError(
+                f"OpenAI request failed with status "
+                f"{exception.status_code}: {exception.message}",
+                status_code=exception.status_code,
+                provider_engine=self.PROVIDER_ENGINE_TOKEN,
+            ) from exception
+        if isinstance(exception, (APITimeoutError, APIConnectionError)):
+            raise AiProviderRequestError(
+                f"OpenAI request failed before a status was available: " f"{exception}",
+                status_code=None,
+                provider_engine=self.PROVIDER_ENGINE_TOKEN,
+            ) from exception
+        # Normal return so non-transport exceptions propagate unchanged.
+        return None
+
+    @staticmethod
+    def _build_chat_provider_tools(list_tools: list[AITool]) -> list[dict[str, Any]]:
+        """
+        Maps provider-neutral AITool definitions onto Chat Completions tools.
+        """
+        list_provider_tools: list[dict[str, Any]] = []
+        # Loop over tool definitions so each maps to the chat function shape.
+        for ai_tool in list_tools:
+            dict_function: dict[str, Any] = {
+                "name": ai_tool.name,
+                "description": ai_tool.description,
+                "parameters": ai_tool.input_schema,
+            }
+            if ai_tool.strict:
+                dict_function["strict"] = True
+            list_provider_tools.append({"type": "function", "function": dict_function})
+        # Normal return with the chat-shaped tool list.
+        return list_provider_tools
+
+    def _usage_from_chat_response(self, response: Any) -> AITokenUsage:
+        """
+        Builds the provider-neutral usage model from one chat completion.
+        """
+        # Normal return with the provider-neutral token usage model.
+        return AITokenUsage(
+            input_tokens=self._extract_openai_prompt_tokens(response),
+            output_tokens=self._extract_openai_completion_tokens(response),
+            cached_input_tokens=self._extract_openai_cached_tokens(response),
+            total_tokens=self._extract_openai_total_tokens(response),
+        )
+
+    @staticmethod
+    def _serialize_chat_assistant_message(message: Any) -> dict[str, Any]:
+        """
+        Serializes one chat assistant message into a replayable dictionary.
+
+        Uses the SDK model_dump when available; otherwise reconstructs the
+        message from typed attributes so raw_content stays replayable as the
+        next assistant message.
+        """
+        model_dump = getattr(message, "model_dump", None)
+        if callable(model_dump):
+            try:
+                dict_message: Any = model_dump(exclude_none=True)
+                if isinstance(dict_message, dict):
+                    # Early return with the SDK-serialized assistant message.
+                    return dict_message
+            except TypeError:
+                # Fall through to attribute-based reconstruction (test doubles).
+                pass
+        dict_rebuilt: dict[str, Any] = {"role": "assistant"}
+        str_content: Any = getattr(message, "content", None)
+        if str_content is not None:
+            dict_rebuilt["content"] = str_content
+        list_tool_calls: list[dict[str, Any]] = []
+        # Loop over tool calls so replayed messages carry the full call shape.
+        for tool_call in getattr(message, "tool_calls", None) or []:
+            function = getattr(tool_call, "function", None)
+            list_tool_calls.append(
+                {
+                    "id": str(getattr(tool_call, "id", "") or ""),
+                    "type": "function",
+                    "function": {
+                        "name": str(getattr(function, "name", "") or ""),
+                        "arguments": str(getattr(function, "arguments", "") or "{}"),
+                    },
+                }
+            )
+        if list_tool_calls:
+            dict_rebuilt["tool_calls"] = list_tool_calls
+        # Normal return with the reconstructed assistant message.
+        return dict_rebuilt
+
+    def _build_turn_result_from_chat(self, response: Any) -> AITurnResult:
+        """
+        Maps one Chat Completions response onto the provider-neutral turn.
+        """
+        choice = response.choices[0]
+        message = choice.message
+        list_tool_calls: list[AIToolCall] = []
+        # Loop over tool calls so callers receive parsed inputs per call.
+        for tool_call in getattr(message, "tool_calls", None) or []:
+            function = getattr(tool_call, "function", None)
+            str_arguments: str = str(getattr(function, "arguments", "") or "{}")
+            try:
+                dict_input: dict[str, Any] = json.loads(str_arguments)
+            except json.JSONDecodeError as json_error:
+                raise ValueError(
+                    f"Tool call arguments were not valid JSON: {json_error}"
+                ) from json_error
+            list_tool_calls.append(
+                AIToolCall(
+                    id=str(getattr(tool_call, "id", "") or ""),
+                    name=str(getattr(function, "name", "") or ""),
+                    input=dict_input,
+                )
+            )
+        str_finish_reason: str | None = getattr(choice, "finish_reason", None)
+        finish_reason: AIFinishReason = self._normalize_finish_reason(
+            str(str_finish_reason) if str_finish_reason is not None else None,
+            self.DICT_FINISH_REASON_MAP,
+        )
+        # Present tool calls are authoritative: a forced tool_choice reports
+        # finish_reason "stop" even though the message carries tool_calls.
+        if list_tool_calls:
+            finish_reason = AIFinishReason.TOOL_USE
+        # The refusal field is authoritative even when finish_reason is stop.
+        if getattr(message, "refusal", None):
+            finish_reason = AIFinishReason.REFUSAL
+        str_text: str | None = getattr(message, "content", None) or None
+        # Normal return with the provider-neutral turn result.
+        return AITurnResult(
+            text=str_text,
+            tool_calls=list_tool_calls,
+            finish_reason=finish_reason,
+            raw_content=self._serialize_chat_assistant_message(message),
+            usage=self._usage_from_chat_response(response),
+        )
+
+    def _observed_chat_turn_result(
+        self, response: Any
+    ) -> AiApiObservedCompletionsResultModel[AITurnResult]:
+        """
+        Wraps one chat response as an observed conversation-turn result.
+        """
+        turn_result: AITurnResult = self._build_turn_result_from_chat(response)
+        str_finish_reason: Any = getattr(response.choices[0], "finish_reason", None)
+        # Normal return with the observed turn result and usage metadata.
+        return AiApiObservedCompletionsResultModel(
+            return_value=turn_result,
+            raw_output_text=turn_result.text or "",
+            finish_reason=str(str_finish_reason) if str_finish_reason else None,
+            provider_prompt_tokens=turn_result.usage.input_tokens,
+            provider_completion_tokens=turn_result.usage.output_tokens,
+            provider_cached_input_tokens=turn_result.usage.cached_input_tokens,
+            provider_total_tokens=turn_result.usage.total_tokens,
+            dict_metadata={"tool_call_count": len(turn_result.tool_calls)},
+        )
+
+    def _build_chat_conversation_request_kwargs(
+        self,
+        *,
+        system_prompt: str,
+        messages: list[dict[str, Any]],
+        tools: list[AITool],
+        tool_choice: str | None,
+        max_response_tokens: int | None,
+        dict_merge_options: dict[str, Any],
+    ) -> dict[str, Any]:
+        """
+        Builds the Chat Completions request kwargs for one conversation turn.
+        """
+        dict_request_kwargs: dict[str, Any] = {
+            "model": self.completions_model,
+            "messages": [{"role": "system", "content": system_prompt}, *messages],
+        }
+        if max_response_tokens is not None:
+            dict_request_kwargs["max_completion_tokens"] = max_response_tokens
+        if tools:
+            dict_request_kwargs["tools"] = self._build_chat_provider_tools(tools)
+        if tool_choice is not None:
+            dict_request_kwargs["tool_choice"] = {
+                "type": "function",
+                "function": {"name": tool_choice},
+            }
+        # provider_options merge last so callers can extend the raw request.
+        dict_request_kwargs.update(dict_merge_options)
+        # Normal return with the chat-shaped conversation request.
+        return dict_request_kwargs
+
+    def _build_conversation_observability_metadata(
+        self,
+        *,
+        system_prompt: str,
+        messages: list[dict[str, Any]],
+        tools: list[AITool],
+        tool_choice: str | None,
+        max_response_tokens: int | None,
+    ) -> dict[str, ObservabilityMetadataValue]:
+        """
+        Builds metadata-only observability fields for one conversation turn.
+        """
+        dict_metadata: dict[str, ObservabilityMetadataValue] = {
+            "response_mode": self.RESPONSE_MODE_TEXT,
+            "message_count": len(messages),
+            "tool_count": len(tools),
+            "system_prompt_char_count": len(system_prompt),
+        }
+        if tool_choice is not None:
+            dict_metadata["forced_tool"] = tool_choice
+        if max_response_tokens is not None:
+            dict_metadata["max_response_tokens"] = max_response_tokens
+        # Normal return with scalar conversation metadata.
+        return dict_metadata
+
+    def _send_conversation_provider(
+        self,
+        *,
+        system_prompt: str,
+        messages: list[dict[str, Any]],
+        tools: list[AITool],
+        tool_choice: str | None,
+        max_response_tokens: int | None,
+        request_timeout_seconds: float | None,
+        provider_options: dict[str, Any] | None,
+    ) -> AITurnResult:
+        """
+        Sends one conversation turn to the Chat Completions API.
+        """
+        dict_merge_options, str_retry_override = self._split_provider_options(
+            provider_options
+        )
+        call_client: Any = self._client_for_call(
+            request_timeout_seconds=request_timeout_seconds,
+            retry_policy_override=str_retry_override,
+        )
+        dict_request_kwargs: dict[str, Any] = (
+            self._build_chat_conversation_request_kwargs(
+                system_prompt=system_prompt,
+                messages=messages,
+                tools=tools,
+                tool_choice=tool_choice,
+                max_response_tokens=max_response_tokens,
+                dict_merge_options=dict_merge_options,
+            )
+        )
+        dict_input_metadata: dict[str, ObservabilityMetadataValue] = (
+            self._build_conversation_observability_metadata(
+                system_prompt=system_prompt,
+                messages=messages,
+                tools=tools,
+                tool_choice=tool_choice,
+                max_response_tokens=max_response_tokens,
+            )
+        )
+
+        def _execute_turn() -> AiApiObservedCompletionsResultModel[AITurnResult]:
+            try:
+                response = call_client.chat.completions.create(**dict_request_kwargs)
+            except Exception as exception:
+                self._raise_request_error(exception)
+                raise
+            # Normal return with the observed conversation turn.
+            return self._observed_chat_turn_result(response)
+
+        observed_result: AiApiObservedCompletionsResultModel[AITurnResult] = (
+            self._execute_provider_call_with_observability(
+                capability=self.CLIENT_TYPE_COMPLETIONS,
+                operation="send_conversation",
+                dict_input_metadata=dict_input_metadata,
+                callable_execute=_execute_turn,
+                callable_build_result_summary=lambda result, provider_elapsed_ms: self._build_completions_observability_result_summary(
+                    observed_result=result,
+                    provider_elapsed_ms=provider_elapsed_ms,
+                ),
+                legacy_caller_id=self.user,
+            )
+        )
+        # Normal return with the caller-facing conversation turn.
+        return observed_result.return_value
+
+    async def _asend_conversation_provider(
+        self,
+        *,
+        system_prompt: str,
+        messages: list[dict[str, Any]],
+        tools: list[AITool],
+        tool_choice: str | None,
+        max_response_tokens: int | None,
+        request_timeout_seconds: float | None,
+        provider_options: dict[str, Any] | None,
+    ) -> AITurnResult:
+        """
+        Async twin of _send_conversation_provider using AsyncOpenAI.
+        """
+        dict_merge_options, str_retry_override = self._split_provider_options(
+            provider_options
+        )
+        call_client: Any = self._async_client_for_call(
+            request_timeout_seconds=request_timeout_seconds,
+            retry_policy_override=str_retry_override,
+        )
+        dict_request_kwargs: dict[str, Any] = (
+            self._build_chat_conversation_request_kwargs(
+                system_prompt=system_prompt,
+                messages=messages,
+                tools=tools,
+                tool_choice=tool_choice,
+                max_response_tokens=max_response_tokens,
+                dict_merge_options=dict_merge_options,
+            )
+        )
+        dict_input_metadata: dict[str, ObservabilityMetadataValue] = (
+            self._build_conversation_observability_metadata(
+                system_prompt=system_prompt,
+                messages=messages,
+                tools=tools,
+                tool_choice=tool_choice,
+                max_response_tokens=max_response_tokens,
+            )
+        )
+
+        async def _execute_turn() -> AiApiObservedCompletionsResultModel[AITurnResult]:
+            try:
+                response = await call_client.chat.completions.create(
+                    **dict_request_kwargs
+                )
+            except Exception as exception:
+                self._raise_request_error(exception)
+                raise
+            # Normal return with the observed conversation turn.
+            return self._observed_chat_turn_result(response)
+
+        observed_result: AiApiObservedCompletionsResultModel[AITurnResult] = (
+            await self._execute_provider_acall_with_observability(
+                capability=self.CLIENT_TYPE_COMPLETIONS,
+                operation="asend_conversation",
+                dict_input_metadata=dict_input_metadata,
+                callable_execute=_execute_turn,
+                callable_build_result_summary=lambda result, provider_elapsed_ms: self._build_completions_observability_result_summary(
+                    observed_result=result,
+                    provider_elapsed_ms=provider_elapsed_ms,
+                ),
+                legacy_caller_id=self.user,
+            )
+        )
+        # Normal return with the caller-facing conversation turn.
+        return observed_result.return_value
+
+    def _build_tool_result_message_provider(
+        self,
+        *,
+        tool_call_id: str,
+        result: dict[str, Any],
+        is_error: bool,
+    ) -> dict[str, Any]:
+        """
+        Builds one Chat Completions tool-role result message.
+
+        The chat wire format has no error flag on tool messages, so failures
+        are encoded inside the JSON payload under an "error" key.
+        """
+        dict_payload: dict[str, Any] = {"error": result} if is_error else result
+        # Normal return with the chat-shaped tool-result entry.
+        return {
+            "role": "tool",
+            "tool_call_id": tool_call_id,
+            "content": json.dumps(dict_payload),
+        }
+
+    def _extend_messages_with_turn_provider(
+        self,
+        *,
+        messages: list[dict[str, Any]],
+        turn: AITurnResult,
+    ) -> None:
+        """
+        Appends one chat assistant message; raw_content is the full message.
+        """
+        messages.append(turn.raw_content)
+        # Normal return after appending the assistant turn.
+        return None
+
+    def _build_structured_observability_metadata(
+        self,
+        *,
+        prompt: str | None,
+        messages: list[dict[str, Any]] | None,
+        max_response_tokens: int,
+    ) -> dict[str, ObservabilityMetadataValue]:
+        """
+        Builds metadata-only observability fields for one structured call.
+        """
+        # Normal return with scalar structured-call metadata.
+        return {
+            "response_mode": self.RESPONSE_MODE_STRUCTURED,
+            "prompt_char_count": len(prompt) if prompt else 0,
+            "message_count": len(messages) if messages else 0,
+            "max_response_tokens": max_response_tokens,
+        }
+
+    def _build_structured_output_result_from_parts(
+        self,
+        *,
+        raw_output_text: str,
+        finish_reason: AIFinishReason,
+        usage: AITokenUsage,
+    ) -> AIStructuredOutputResult:
+        """
+        Maps structured response parts onto the provider-neutral result model.
+        """
+        if finish_reason in (AIFinishReason.LENGTH, AIFinishReason.REFUSAL):
+            # Early return so callers branch on finish_reason instead of parsing.
+            return AIStructuredOutputResult(
+                data=None,
+                finish_reason=finish_reason,
+                usage=usage,
+                raw_text=self.pii_middleware.process_output(raw_output_text),
+            )
+        str_content: str = self.pii_middleware.process_output(raw_output_text)
+        if not str_content:
+            raise ValueError("Empty response from OpenAI API")
+        try:
+            parsed_data: Any = json.loads(str_content)
+        except json.JSONDecodeError as json_error:
+            raise ValueError(f"Invalid JSON response: {json_error}") from json_error
+        if not isinstance(parsed_data, dict):
+            raise ValueError(
+                "Structured response was valid JSON but not a JSON object."
+            )
+        # Normal return with the parsed structured output result.
+        return AIStructuredOutputResult(
+            data=parsed_data,
+            finish_reason=finish_reason,
+            usage=usage,
+            raw_text=str_content,
+        )
+
+    def _send_structured_output_provider(
+        self,
+        *,
+        response_schema: dict[str, Any],
+        system_prompt: str | None,
+        prompt: str | None,
+        messages: list[dict[str, Any]] | None,
+        max_response_tokens: int,
+        request_timeout_seconds: float | None,
+        provider_options: dict[str, Any] | None,
+    ) -> AIStructuredOutputResult:
+        """
+        Generates structured output via the chat json_schema response format.
+
+        Runs in schema-guided mode (strict: false), matching the engine's
+        existing strict_schema_prompt behavior; parsed output is validated
+        client-side by the base template.
+        """
+        dict_merge_options, str_retry_override = self._split_provider_options(
+            provider_options
+        )
+        call_client: Any = self._client_for_call(
+            request_timeout_seconds=request_timeout_seconds,
+            retry_policy_override=str_retry_override,
+        )
+        dict_request_kwargs: dict[str, Any] = (
+            self._build_chat_structured_request_kwargs(
+                response_schema=response_schema,
+                system_prompt=system_prompt,
+                prompt=prompt,
+                messages=messages,
+                max_response_tokens=max_response_tokens,
+                dict_merge_options=dict_merge_options,
+            )
+        )
+        dict_input_metadata: dict[str, ObservabilityMetadataValue] = (
+            self._build_structured_observability_metadata(
+                prompt=prompt,
+                messages=messages,
+                max_response_tokens=max_response_tokens,
+            )
+        )
+
+        def _execute_structured() -> (
+            AiApiObservedCompletionsResultModel[AIStructuredOutputResult]
+        ):
+            try:
+                response = call_client.chat.completions.create(**dict_request_kwargs)
+            except Exception as exception:
+                self._raise_request_error(exception)
+                raise
+            # Normal return with the observed structured output result.
+            return self._observed_chat_structured_result(response)
+
+        observed_result: AiApiObservedCompletionsResultModel[
+            AIStructuredOutputResult
+        ] = self._execute_provider_call_with_observability(
+            capability=self.CLIENT_TYPE_COMPLETIONS,
+            operation="send_structured_output",
+            dict_input_metadata=dict_input_metadata,
+            callable_execute=_execute_structured,
+            callable_build_result_summary=lambda result, provider_elapsed_ms: self._build_completions_observability_result_summary(
+                observed_result=result,
+                provider_elapsed_ms=provider_elapsed_ms,
+            ),
+            legacy_caller_id=self.user,
+        )
+        # Normal return with the caller-facing structured output result.
+        return observed_result.return_value
+
+    async def _asend_structured_output_provider(
+        self,
+        *,
+        response_schema: dict[str, Any],
+        system_prompt: str | None,
+        prompt: str | None,
+        messages: list[dict[str, Any]] | None,
+        max_response_tokens: int,
+        request_timeout_seconds: float | None,
+        provider_options: dict[str, Any] | None,
+    ) -> AIStructuredOutputResult:
+        """
+        Async twin of _send_structured_output_provider.
+        """
+        dict_merge_options, str_retry_override = self._split_provider_options(
+            provider_options
+        )
+        call_client: Any = self._async_client_for_call(
+            request_timeout_seconds=request_timeout_seconds,
+            retry_policy_override=str_retry_override,
+        )
+        dict_request_kwargs: dict[str, Any] = (
+            self._build_chat_structured_request_kwargs(
+                response_schema=response_schema,
+                system_prompt=system_prompt,
+                prompt=prompt,
+                messages=messages,
+                max_response_tokens=max_response_tokens,
+                dict_merge_options=dict_merge_options,
+            )
+        )
+        dict_input_metadata: dict[str, ObservabilityMetadataValue] = (
+            self._build_structured_observability_metadata(
+                prompt=prompt,
+                messages=messages,
+                max_response_tokens=max_response_tokens,
+            )
+        )
+
+        async def _execute_structured() -> (
+            AiApiObservedCompletionsResultModel[AIStructuredOutputResult]
+        ):
+            try:
+                response = await call_client.chat.completions.create(
+                    **dict_request_kwargs
+                )
+            except Exception as exception:
+                self._raise_request_error(exception)
+                raise
+            # Normal return with the observed structured output result.
+            return self._observed_chat_structured_result(response)
+
+        observed_result: AiApiObservedCompletionsResultModel[
+            AIStructuredOutputResult
+        ] = await self._execute_provider_acall_with_observability(
+            capability=self.CLIENT_TYPE_COMPLETIONS,
+            operation="asend_structured_output",
+            dict_input_metadata=dict_input_metadata,
+            callable_execute=_execute_structured,
+            callable_build_result_summary=lambda result, provider_elapsed_ms: self._build_completions_observability_result_summary(
+                observed_result=result,
+                provider_elapsed_ms=provider_elapsed_ms,
+            ),
+            legacy_caller_id=self.user,
+        )
+        # Normal return with the caller-facing structured output result.
+        return observed_result.return_value
+
+    def _build_chat_structured_request_kwargs(
+        self,
+        *,
+        response_schema: dict[str, Any],
+        system_prompt: str | None,
+        prompt: str | None,
+        messages: list[dict[str, Any]] | None,
+        max_response_tokens: int,
+        dict_merge_options: dict[str, Any],
+    ) -> dict[str, Any]:
+        """
+        Builds the Chat Completions request kwargs for one structured call.
+        """
+        str_system_prompt: str = self._resolve_system_prompt(
+            system_prompt,
+            None,
+            AICompletionsPromptParamsBase.DEFAULT_STRICT_SCHEMA_SYSTEM_PROMPT,
+        )
+        list_messages: list[dict[str, Any]] = [
+            {"role": "system", "content": str_system_prompt},
+            *(messages or []),
+        ]
+        if prompt is not None and prompt.strip():
+            str_redacted_prompt: str = self.pii_middleware.process_input(prompt)
+            list_messages.append({"role": "user", "content": str_redacted_prompt})
+        dict_request_kwargs: dict[str, Any] = {
+            "model": self.completions_model,
+            "messages": list_messages,
+            "max_completion_tokens": max_response_tokens,
+            "response_format": {
+                "type": "json_schema",
+                "json_schema": {
+                    "name": "structured_output",
+                    "schema": response_schema,
+                    "strict": False,
+                },
+            },
+        }
+        dict_request_kwargs.update(dict_merge_options)
+        # Normal return with the chat-shaped structured request.
+        return dict_request_kwargs
+
+    def _observed_chat_structured_result(
+        self, response: Any
+    ) -> AiApiObservedCompletionsResultModel[AIStructuredOutputResult]:
+        """
+        Wraps one chat structured response as an observed result.
+        """
+        choice = response.choices[0]
+        str_finish_reason: Any = getattr(choice, "finish_reason", None)
+        finish_reason: AIFinishReason = self._normalize_finish_reason(
+            str(str_finish_reason) if str_finish_reason is not None else None,
+            self.DICT_FINISH_REASON_MAP,
+        )
+        if getattr(choice.message, "refusal", None):
+            finish_reason = AIFinishReason.REFUSAL
+        structured_result: AIStructuredOutputResult = (
+            self._build_structured_output_result_from_parts(
+                raw_output_text=getattr(choice.message, "content", None) or "",
+                finish_reason=finish_reason,
+                usage=self._usage_from_chat_response(response),
+            )
+        )
+        # Normal return with the observed structured output result.
+        return AiApiObservedCompletionsResultModel(
+            return_value=structured_result,
+            raw_output_text=structured_result.raw_text,
+            finish_reason=str(str_finish_reason) if str_finish_reason else None,
+            provider_prompt_tokens=structured_result.usage.input_tokens,
+            provider_completion_tokens=structured_result.usage.output_tokens,
+            provider_cached_input_tokens=structured_result.usage.cached_input_tokens,
+            provider_total_tokens=structured_result.usage.total_tokens,
+        )
+
+    async def _asend_prompt_provider(
+        self,
+        prompt: str,
+        *,
+        system_prompt: str | None,
+        max_response_tokens: int | None,
+        request_timeout_seconds: float | None,
+        other_params: AICompletionsPromptParamsBase | None,
+    ) -> str:
+        """
+        Async twin of send_prompt using AsyncOpenAI (single-shot, no
+        auto-continue loop).
+        """
+        str_redacted_prompt: str = self.pii_middleware.process_input(prompt)
+        str_system_prompt: str = self._resolve_system_prompt(
+            system_prompt,
+            other_params,
+            AICompletionsPromptParamsBase.DEFAULT_SYSTEM_PROMPT,
+        )
+        call_client: Any = self._async_client_for_call(
+            request_timeout_seconds=request_timeout_seconds
+        )
+        user_content = self._build_user_message_content(
+            str_redacted_prompt, other_params
+        )
+        dict_request_kwargs: dict[str, Any] = {
+            "model": self.completions_model,
+            "messages": [
+                {"role": "system", "content": str_system_prompt},
+                {"role": "user", "content": user_content},
+            ],
+        }
+        if max_response_tokens is not None:
+            dict_request_kwargs["max_completion_tokens"] = max_response_tokens
+        dict_input_metadata: dict[str, ObservabilityMetadataValue] = (
+            self._build_completions_observability_input_metadata(
+                prompt=str_redacted_prompt,
+                system_prompt=str_system_prompt,
+                other_params=other_params,
+                response_mode=self.RESPONSE_MODE_TEXT,
+                max_response_tokens=max_response_tokens,
+            )
+        )
+
+        async def _execute_text_prompt() -> AiApiObservedCompletionsResultModel[str]:
+            try:
+                response = await call_client.chat.completions.create(
+                    **dict_request_kwargs
+                )
+            except Exception as exception:
+                self._raise_request_error(exception)
+                raise
+            raw_output_text: str = response.choices[0].message.content or ""
+            # Normal return with the chat text output and usage metadata.
+            return AiApiObservedCompletionsResultModel(
+                return_value=raw_output_text,
+                raw_output_text=raw_output_text,
+                finish_reason=str(response.choices[0].finish_reason or ""),
+                provider_prompt_tokens=self._extract_openai_prompt_tokens(response),
+                provider_completion_tokens=self._extract_openai_completion_tokens(
+                    response
+                ),
+                provider_cached_input_tokens=self._extract_openai_cached_tokens(
+                    response
+                ),
+                provider_total_tokens=self._extract_openai_total_tokens(response),
+            )
+
+        observed_result: AiApiObservedCompletionsResultModel[str] = (
+            await self._execute_provider_acall_with_observability(
+                capability=self.CLIENT_TYPE_COMPLETIONS,
+                operation="asend_prompt",
+                dict_input_metadata=dict_input_metadata,
+                callable_execute=_execute_text_prompt,
+                callable_build_result_summary=lambda result, provider_elapsed_ms: self._build_completions_observability_result_summary(
+                    observed_result=result,
+                    provider_elapsed_ms=provider_elapsed_ms,
+                ),
+                legacy_caller_id=self.user,
+            )
+        )
+        # Normal return with sanitized chat text after observability wrapping.
+        return self.pii_middleware.process_output(observed_result.return_value)
 
     def _build_user_message_content(
         self,
@@ -496,18 +1303,23 @@ class AiOpenAICompletions(AIOpenAIBase, AIBaseCompletions):
             prompt (str): The prompt string to send.
             system_prompt: Optional persistent instructions; overrides
                 other_params.system_prompt when both are supplied.
-            max_response_tokens: Not yet mapped on this engine; raises
-                AiProviderCapabilityUnsupportedError when supplied.
-            request_timeout_seconds: Not yet mapped on this engine; raises
-                AiProviderCapabilityUnsupportedError when supplied.
+            max_response_tokens: Optional response token budget; maps to the
+                chat max_completion_tokens field. Supplying it also disables
+                the legacy auto-continue-on-length loop so the budget holds.
+            request_timeout_seconds: Optional per-call timeout; maps to the
+                OpenAI SDK request timeout.
             other_params: Optional provider-specific parameters (not used for OpenAI currently)
 
         Returns:
             str: The completion result as a string.
         """
-        self._reject_unsupported_send_prompt_params(
-            max_response_tokens=max_response_tokens,
-            request_timeout_seconds=request_timeout_seconds,
+        call_client: Any = self._client_for_call(
+            request_timeout_seconds=request_timeout_seconds
+        )
+        dict_token_kwargs: dict[str, Any] = (
+            {"max_completion_tokens": max_response_tokens}
+            if max_response_tokens is not None
+            else {}
         )
         try:
             prompt = self.pii_middleware.process_input(prompt)
@@ -525,20 +1337,26 @@ class AiOpenAICompletions(AIOpenAIBase, AIBaseCompletions):
                     system_prompt=system_prompt,
                     other_params=other_params,
                     response_mode=self.RESPONSE_MODE_TEXT,
+                    max_response_tokens=max_response_tokens,
                 )
             )
 
             def _execute_text_prompt() -> AiApiObservedCompletionsResultModel[str]:
-                response = self.client.chat.completions.create(
-                    model=self.completions_model,
-                    messages=[
-                        {
-                            "role": "system",
-                            "content": system_prompt,
-                        },
-                        {"role": "user", "content": user_content},
-                    ],
-                )
+                try:
+                    response = call_client.chat.completions.create(
+                        model=self.completions_model,
+                        messages=[
+                            {
+                                "role": "system",
+                                "content": system_prompt,
+                            },
+                            {"role": "user", "content": user_content},
+                        ],
+                        **dict_token_kwargs,
+                    )
+                except Exception as exception:
+                    self._raise_request_error(exception)
+                    raise
 
                 raw_output_text: str = response.choices[0].message.content or ""
                 int_provider_prompt_tokens: int | None = (
@@ -555,9 +1373,14 @@ class AiOpenAICompletions(AIOpenAIBase, AIBaseCompletions):
                 )
                 bool_continued_response: bool = False
 
-                while response.choices[0].finish_reason == "length":
+                # An explicit caller budget disables the legacy auto-continue
+                # loop; continuing past "length" would defeat the budget.
+                while (
+                    max_response_tokens is None
+                    and response.choices[0].finish_reason == "length"
+                ):
                     bool_continued_response = True
-                    response = self.client.chat.completions.create(
+                    response = call_client.chat.completions.create(
                         model=self.completions_model,
                         messages=[
                             {"role": "system", "content": "Continue."},

--- a/src/ai_api_unified/completions/ai_openai_responses_completions.py
+++ b/src/ai_api_unified/completions/ai_openai_responses_completions.py
@@ -18,16 +18,22 @@ from __future__ import annotations
 import json
 import logging
 from collections.abc import Iterator
-from typing import Any, Type
+from typing import Any, ClassVar, Type
 
 from pydantic import ValidationError
 
 from ..ai_base import (
     AIBaseCompletions,
     AiApiObservedCompletionsResultModel,
+    AIFinishReason,
+    AIStructuredOutputResult,
     AIStructuredPrompt,
     AICompletionsCapabilitiesBase,
     AICompletionsPromptParamsBase,
+    AITokenUsage,
+    AITool,
+    AIToolCall,
+    AITurnResult,
     SupportedDataType,
 )
 from ..middleware.observability_runtime import (
@@ -97,10 +103,10 @@ class AiOpenAIResponsesCompletions(AiOpenAICompletions):
             prompt: The text prompt to send.
             system_prompt: Optional persistent instructions; overrides
                 other_params.system_prompt when both are supplied.
-            max_response_tokens: Not yet mapped on this engine; raises
-                AiProviderCapabilityUnsupportedError when supplied.
-            request_timeout_seconds: Not yet mapped on this engine; raises
-                AiProviderCapabilityUnsupportedError when supplied.
+            max_response_tokens: Optional response token budget; maps to the
+                Responses max_output_tokens field.
+            request_timeout_seconds: Optional per-call timeout; maps to the
+                OpenAI SDK request timeout.
             other_params: Optional provider-specific parameters (system prompt only).
 
         Returns:
@@ -108,9 +114,13 @@ class AiOpenAIResponsesCompletions(AiOpenAICompletions):
         """
         if not prompt or not prompt.strip():
             raise ValueError("Prompt cannot be empty or None")
-        self._reject_unsupported_send_prompt_params(
-            max_response_tokens=max_response_tokens,
-            request_timeout_seconds=request_timeout_seconds,
+        call_client: Any = self._client_for_call(
+            request_timeout_seconds=request_timeout_seconds
+        )
+        dict_token_kwargs: dict[str, Any] = (
+            {"max_output_tokens": max_response_tokens}
+            if max_response_tokens is not None
+            else {}
         )
         prompt = self.pii_middleware.process_input(prompt)
         system_prompt = self._resolve_system_prompt(
@@ -124,15 +134,21 @@ class AiOpenAIResponsesCompletions(AiOpenAICompletions):
                 system_prompt=system_prompt,
                 other_params=other_params,
                 response_mode=self.RESPONSE_MODE_TEXT,
+                max_response_tokens=max_response_tokens,
             )
         )
 
         def _execute_text_prompt() -> AiApiObservedCompletionsResultModel[str]:
-            response = self.client.responses.create(
-                model=self.completions_model,
-                input=prompt,
-                instructions=system_prompt,
-            )
+            try:
+                response = call_client.responses.create(
+                    model=self.completions_model,
+                    input=prompt,
+                    instructions=system_prompt,
+                    **dict_token_kwargs,
+                )
+            except Exception as exception:
+                self._raise_request_error(exception)
+                raise
             raw_output_text: str = response.output_text or ""
             prompt_tokens, completion_tokens, total_tokens, cached_tokens = (
                 self._extract_responses_usage(response)
@@ -374,3 +390,652 @@ class AiOpenAIResponsesCompletions(AiOpenAICompletions):
             callable_build_result_summary=_build_summary,
             legacy_caller_id=self.user,
         )
+
+    # ── Conversation, structured output, async (Responses wire shapes) ──────
+
+    PROVIDER_ENGINE_TOKEN: ClassVar[str] = "openai-responses"
+
+    RESPONSES_STATUS_INCOMPLETE: ClassVar[str] = "incomplete"
+    RESPONSES_INCOMPLETE_MAX_TOKENS: ClassVar[str] = "max_output_tokens"
+
+    @staticmethod
+    def _build_responses_provider_tools(
+        list_tools: list[AITool],
+    ) -> list[dict[str, Any]]:
+        """
+        Maps provider-neutral AITool definitions onto Responses function tools.
+        """
+        list_provider_tools: list[dict[str, Any]] = []
+        # Loop over tool definitions so each maps to the Responses tool shape.
+        for ai_tool in list_tools:
+            dict_tool: dict[str, Any] = {
+                "type": "function",
+                "name": ai_tool.name,
+                "description": ai_tool.description,
+                "parameters": ai_tool.input_schema,
+            }
+            if ai_tool.strict:
+                dict_tool["strict"] = True
+            list_provider_tools.append(dict_tool)
+        # Normal return with the Responses-shaped tool list.
+        return list_provider_tools
+
+    @staticmethod
+    def _serialize_responses_output_item(item: Any) -> dict[str, Any]:
+        """
+        Serializes one Responses output item into a replayable dictionary.
+        """
+        model_dump = getattr(item, "model_dump", None)
+        if callable(model_dump):
+            try:
+                dict_item: Any = model_dump(exclude_none=True)
+                if isinstance(dict_item, dict):
+                    # Early return with the SDK-serialized output item.
+                    return dict_item
+            except TypeError:
+                # Fall through to attribute-based reconstruction (test doubles).
+                pass
+        str_item_type: str = str(getattr(item, "type", "") or "")
+        if str_item_type == "function_call":
+            return {
+                "type": "function_call",
+                "call_id": str(getattr(item, "call_id", "") or ""),
+                "name": str(getattr(item, "name", "") or ""),
+                "arguments": str(getattr(item, "arguments", "") or "{}"),
+            }
+        if str_item_type == "message":
+            return {
+                "type": "message",
+                "role": "assistant",
+                "content": getattr(item, "content", None) or [],
+            }
+        # Normal return with a minimal typed placeholder for unknown items.
+        return {"type": str_item_type}
+
+    def _usage_from_responses(self, response: Any) -> AITokenUsage:
+        """
+        Builds the provider-neutral usage model from one Responses result.
+        """
+        tuple_usage = self._extract_responses_usage(response)
+        # Normal return with the provider-neutral token usage model.
+        return AITokenUsage(
+            input_tokens=tuple_usage[0],
+            output_tokens=tuple_usage[1],
+            cached_input_tokens=tuple_usage[3],
+            total_tokens=tuple_usage[2],
+        )
+
+    def _responses_finish_reason(
+        self,
+        response: Any,
+        *,
+        bool_has_tool_calls: bool,
+        bool_has_refusal: bool,
+    ) -> AIFinishReason:
+        """
+        Derives the normalized finish reason from one Responses result.
+
+        The Responses API reports a run status rather than a chat-style finish
+        reason: tool calls surface as output items, truncation as
+        status="incomplete" with reason max_output_tokens, and refusals as
+        refusal content parts.
+        """
+        if bool_has_refusal:
+            # Early return because a refusal part is authoritative.
+            return AIFinishReason.REFUSAL
+        if bool_has_tool_calls:
+            # Early return because requested tool calls define the turn.
+            return AIFinishReason.TOOL_USE
+        str_status: str = str(getattr(response, "status", "") or "")
+        if str_status == self.RESPONSES_STATUS_INCOMPLETE:
+            incomplete_details = getattr(response, "incomplete_details", None)
+            str_reason: str = str(getattr(incomplete_details, "reason", "") or "")
+            if str_reason == self.RESPONSES_INCOMPLETE_MAX_TOKENS:
+                # Early return because output was truncated at the budget.
+                return AIFinishReason.LENGTH
+        # Normal return because the run completed normally.
+        return AIFinishReason.COMPLETE
+
+    def _build_turn_result_from_responses(self, response: Any) -> AITurnResult:
+        """
+        Maps one Responses result onto the provider-neutral turn.
+        """
+        list_tool_calls: list[AIToolCall] = []
+        list_raw_items: list[dict[str, Any]] = []
+        bool_has_refusal: bool = False
+        # Loop over output items so tool calls and replay content align.
+        for item in getattr(response, "output", None) or []:
+            list_raw_items.append(self._serialize_responses_output_item(item))
+            str_item_type: str = str(getattr(item, "type", "") or "")
+            if str_item_type == "function_call":
+                str_arguments: str = str(getattr(item, "arguments", "") or "{}")
+                try:
+                    dict_input: dict[str, Any] = json.loads(str_arguments)
+                except json.JSONDecodeError as json_error:
+                    raise ValueError(
+                        f"Tool call arguments were not valid JSON: {json_error}"
+                    ) from json_error
+                list_tool_calls.append(
+                    AIToolCall(
+                        id=str(getattr(item, "call_id", "") or ""),
+                        name=str(getattr(item, "name", "") or ""),
+                        input=dict_input,
+                    )
+                )
+            elif str_item_type == "message":
+                # Loop over content parts so refusal parts are detected.
+                for content_part in getattr(item, "content", None) or []:
+                    if str(getattr(content_part, "type", "") or "") == "refusal":
+                        bool_has_refusal = True
+        str_text: str = str(getattr(response, "output_text", "") or "")
+        finish_reason: AIFinishReason = self._responses_finish_reason(
+            response,
+            bool_has_tool_calls=bool(list_tool_calls),
+            bool_has_refusal=bool_has_refusal,
+        )
+        # Normal return with the provider-neutral turn result.
+        return AITurnResult(
+            text=str_text if str_text else None,
+            tool_calls=list_tool_calls,
+            finish_reason=finish_reason,
+            raw_content=list_raw_items,
+            usage=self._usage_from_responses(response),
+        )
+
+    def _observed_responses_turn_result(
+        self, response: Any
+    ) -> AiApiObservedCompletionsResultModel[AITurnResult]:
+        """
+        Wraps one Responses result as an observed conversation-turn result.
+        """
+        turn_result: AITurnResult = self._build_turn_result_from_responses(response)
+        # Normal return with the observed turn result and usage metadata.
+        return AiApiObservedCompletionsResultModel(
+            return_value=turn_result,
+            raw_output_text=turn_result.text or "",
+            finish_reason=str(getattr(response, "status", "") or "") or None,
+            provider_prompt_tokens=turn_result.usage.input_tokens,
+            provider_completion_tokens=turn_result.usage.output_tokens,
+            provider_cached_input_tokens=turn_result.usage.cached_input_tokens,
+            provider_total_tokens=turn_result.usage.total_tokens,
+            dict_metadata={"tool_call_count": len(turn_result.tool_calls)},
+        )
+
+    def _build_responses_conversation_request_kwargs(
+        self,
+        *,
+        system_prompt: str,
+        messages: list[dict[str, Any]],
+        tools: list[AITool],
+        tool_choice: str | None,
+        max_response_tokens: int | None,
+        dict_merge_options: dict[str, Any],
+    ) -> dict[str, Any]:
+        """
+        Builds the Responses API request kwargs for one conversation turn.
+        """
+        dict_request_kwargs: dict[str, Any] = {
+            "model": self.completions_model,
+            "instructions": system_prompt,
+            "input": messages,
+        }
+        if max_response_tokens is not None:
+            dict_request_kwargs["max_output_tokens"] = max_response_tokens
+        if tools:
+            dict_request_kwargs["tools"] = self._build_responses_provider_tools(tools)
+        if tool_choice is not None:
+            dict_request_kwargs["tool_choice"] = {
+                "type": "function",
+                "name": tool_choice,
+            }
+        # provider_options merge last so callers can extend the raw request.
+        dict_request_kwargs.update(dict_merge_options)
+        # Normal return with the Responses-shaped conversation request.
+        return dict_request_kwargs
+
+    def _send_conversation_provider(
+        self,
+        *,
+        system_prompt: str,
+        messages: list[dict[str, Any]],
+        tools: list[AITool],
+        tool_choice: str | None,
+        max_response_tokens: int | None,
+        request_timeout_seconds: float | None,
+        provider_options: dict[str, Any] | None,
+    ) -> AITurnResult:
+        """
+        Sends one conversation turn to the Responses API.
+        """
+        dict_merge_options, str_retry_override = self._split_provider_options(
+            provider_options
+        )
+        call_client: Any = self._client_for_call(
+            request_timeout_seconds=request_timeout_seconds,
+            retry_policy_override=str_retry_override,
+        )
+        dict_request_kwargs: dict[str, Any] = (
+            self._build_responses_conversation_request_kwargs(
+                system_prompt=system_prompt,
+                messages=messages,
+                tools=tools,
+                tool_choice=tool_choice,
+                max_response_tokens=max_response_tokens,
+                dict_merge_options=dict_merge_options,
+            )
+        )
+        dict_input_metadata: dict[str, ObservabilityMetadataValue] = (
+            self._build_conversation_observability_metadata(
+                system_prompt=system_prompt,
+                messages=messages,
+                tools=tools,
+                tool_choice=tool_choice,
+                max_response_tokens=max_response_tokens,
+            )
+        )
+
+        def _execute_turn() -> AiApiObservedCompletionsResultModel[AITurnResult]:
+            try:
+                response = call_client.responses.create(**dict_request_kwargs)
+            except Exception as exception:
+                self._raise_request_error(exception)
+                raise
+            # Normal return with the observed conversation turn.
+            return self._observed_responses_turn_result(response)
+
+        observed_result: AiApiObservedCompletionsResultModel[AITurnResult] = (
+            self._execute_provider_call_with_observability(
+                capability=self.CLIENT_TYPE_COMPLETIONS,
+                operation="send_conversation",
+                dict_input_metadata=dict_input_metadata,
+                callable_execute=_execute_turn,
+                callable_build_result_summary=lambda result, provider_elapsed_ms: self._build_completions_observability_result_summary(
+                    observed_result=result,
+                    provider_elapsed_ms=provider_elapsed_ms,
+                ),
+                legacy_caller_id=self.user,
+            )
+        )
+        # Normal return with the caller-facing conversation turn.
+        return observed_result.return_value
+
+    async def _asend_conversation_provider(
+        self,
+        *,
+        system_prompt: str,
+        messages: list[dict[str, Any]],
+        tools: list[AITool],
+        tool_choice: str | None,
+        max_response_tokens: int | None,
+        request_timeout_seconds: float | None,
+        provider_options: dict[str, Any] | None,
+    ) -> AITurnResult:
+        """
+        Async twin of _send_conversation_provider using AsyncOpenAI.
+        """
+        dict_merge_options, str_retry_override = self._split_provider_options(
+            provider_options
+        )
+        call_client: Any = self._async_client_for_call(
+            request_timeout_seconds=request_timeout_seconds,
+            retry_policy_override=str_retry_override,
+        )
+        dict_request_kwargs: dict[str, Any] = (
+            self._build_responses_conversation_request_kwargs(
+                system_prompt=system_prompt,
+                messages=messages,
+                tools=tools,
+                tool_choice=tool_choice,
+                max_response_tokens=max_response_tokens,
+                dict_merge_options=dict_merge_options,
+            )
+        )
+        dict_input_metadata: dict[str, ObservabilityMetadataValue] = (
+            self._build_conversation_observability_metadata(
+                system_prompt=system_prompt,
+                messages=messages,
+                tools=tools,
+                tool_choice=tool_choice,
+                max_response_tokens=max_response_tokens,
+            )
+        )
+
+        async def _execute_turn() -> AiApiObservedCompletionsResultModel[AITurnResult]:
+            try:
+                response = await call_client.responses.create(**dict_request_kwargs)
+            except Exception as exception:
+                self._raise_request_error(exception)
+                raise
+            # Normal return with the observed conversation turn.
+            return self._observed_responses_turn_result(response)
+
+        observed_result: AiApiObservedCompletionsResultModel[AITurnResult] = (
+            await self._execute_provider_acall_with_observability(
+                capability=self.CLIENT_TYPE_COMPLETIONS,
+                operation="asend_conversation",
+                dict_input_metadata=dict_input_metadata,
+                callable_execute=_execute_turn,
+                callable_build_result_summary=lambda result, provider_elapsed_ms: self._build_completions_observability_result_summary(
+                    observed_result=result,
+                    provider_elapsed_ms=provider_elapsed_ms,
+                ),
+                legacy_caller_id=self.user,
+            )
+        )
+        # Normal return with the caller-facing conversation turn.
+        return observed_result.return_value
+
+    def _build_tool_result_message_provider(
+        self,
+        *,
+        tool_call_id: str,
+        result: dict[str, Any],
+        is_error: bool,
+    ) -> dict[str, Any]:
+        """
+        Builds one Responses function_call_output input item.
+
+        The Responses wire format has no error flag on function outputs, so
+        failures are encoded inside the JSON payload under an "error" key.
+        """
+        dict_payload: dict[str, Any] = {"error": result} if is_error else result
+        # Normal return with the Responses-shaped tool-result entry.
+        return {
+            "type": "function_call_output",
+            "call_id": tool_call_id,
+            "output": json.dumps(dict_payload),
+        }
+
+    def _extend_messages_with_turn_provider(
+        self,
+        *,
+        messages: list[dict[str, Any]],
+        turn: AITurnResult,
+    ) -> None:
+        """
+        Extends the input item list with the turn's output items.
+        """
+        messages.extend(turn.raw_content or [])
+        # Normal return after extending the input item list.
+        return None
+
+    def _build_responses_structured_request_kwargs(
+        self,
+        *,
+        response_schema: dict[str, Any],
+        system_prompt: str | None,
+        prompt: str | None,
+        messages: list[dict[str, Any]] | None,
+        max_response_tokens: int,
+        dict_merge_options: dict[str, Any],
+    ) -> dict[str, Any]:
+        """
+        Builds the Responses API request kwargs for one structured call.
+        """
+        str_system_prompt: str = self._resolve_system_prompt(
+            system_prompt,
+            None,
+            AICompletionsPromptParamsBase.DEFAULT_STRICT_SCHEMA_SYSTEM_PROMPT,
+        )
+        list_input: list[dict[str, Any]] = list(messages or [])
+        if prompt is not None and prompt.strip():
+            str_redacted_prompt: str = self.pii_middleware.process_input(prompt)
+            list_input.append({"role": "user", "content": str_redacted_prompt})
+        dict_request_kwargs: dict[str, Any] = {
+            "model": self.completions_model,
+            "instructions": str_system_prompt,
+            "input": list_input,
+            "max_output_tokens": max_response_tokens,
+            "text": {
+                "format": {
+                    "type": "json_schema",
+                    "name": "structured_output",
+                    "schema": response_schema,
+                    "strict": False,
+                }
+            },
+        }
+        dict_request_kwargs.update(dict_merge_options)
+        # Normal return with the Responses-shaped structured request.
+        return dict_request_kwargs
+
+    def _observed_responses_structured_result(
+        self, response: Any
+    ) -> AiApiObservedCompletionsResultModel[AIStructuredOutputResult]:
+        """
+        Wraps one Responses structured result as an observed result.
+        """
+        bool_has_refusal: bool = False
+        # Loop over output message parts so refusal parts are detected.
+        for item in getattr(response, "output", None) or []:
+            if str(getattr(item, "type", "") or "") == "message":
+                for content_part in getattr(item, "content", None) or []:
+                    if str(getattr(content_part, "type", "") or "") == "refusal":
+                        bool_has_refusal = True
+        finish_reason: AIFinishReason = self._responses_finish_reason(
+            response,
+            bool_has_tool_calls=False,
+            bool_has_refusal=bool_has_refusal,
+        )
+        structured_result: AIStructuredOutputResult = (
+            self._build_structured_output_result_from_parts(
+                raw_output_text=str(getattr(response, "output_text", "") or ""),
+                finish_reason=finish_reason,
+                usage=self._usage_from_responses(response),
+            )
+        )
+        # Normal return with the observed structured output result.
+        return AiApiObservedCompletionsResultModel(
+            return_value=structured_result,
+            raw_output_text=structured_result.raw_text,
+            finish_reason=str(getattr(response, "status", "") or "") or None,
+            provider_prompt_tokens=structured_result.usage.input_tokens,
+            provider_completion_tokens=structured_result.usage.output_tokens,
+            provider_cached_input_tokens=structured_result.usage.cached_input_tokens,
+            provider_total_tokens=structured_result.usage.total_tokens,
+        )
+
+    def _send_structured_output_provider(
+        self,
+        *,
+        response_schema: dict[str, Any],
+        system_prompt: str | None,
+        prompt: str | None,
+        messages: list[dict[str, Any]] | None,
+        max_response_tokens: int,
+        request_timeout_seconds: float | None,
+        provider_options: dict[str, Any] | None,
+    ) -> AIStructuredOutputResult:
+        """
+        Generates structured output via the Responses json_schema text format.
+        """
+        dict_merge_options, str_retry_override = self._split_provider_options(
+            provider_options
+        )
+        call_client: Any = self._client_for_call(
+            request_timeout_seconds=request_timeout_seconds,
+            retry_policy_override=str_retry_override,
+        )
+        dict_request_kwargs: dict[str, Any] = (
+            self._build_responses_structured_request_kwargs(
+                response_schema=response_schema,
+                system_prompt=system_prompt,
+                prompt=prompt,
+                messages=messages,
+                max_response_tokens=max_response_tokens,
+                dict_merge_options=dict_merge_options,
+            )
+        )
+        dict_input_metadata: dict[str, ObservabilityMetadataValue] = (
+            self._build_structured_observability_metadata(
+                prompt=prompt,
+                messages=messages,
+                max_response_tokens=max_response_tokens,
+            )
+        )
+
+        def _execute_structured() -> (
+            AiApiObservedCompletionsResultModel[AIStructuredOutputResult]
+        ):
+            try:
+                response = call_client.responses.create(**dict_request_kwargs)
+            except Exception as exception:
+                self._raise_request_error(exception)
+                raise
+            # Normal return with the observed structured output result.
+            return self._observed_responses_structured_result(response)
+
+        observed_result: AiApiObservedCompletionsResultModel[
+            AIStructuredOutputResult
+        ] = self._execute_provider_call_with_observability(
+            capability=self.CLIENT_TYPE_COMPLETIONS,
+            operation="send_structured_output",
+            dict_input_metadata=dict_input_metadata,
+            callable_execute=_execute_structured,
+            callable_build_result_summary=lambda result, provider_elapsed_ms: self._build_completions_observability_result_summary(
+                observed_result=result,
+                provider_elapsed_ms=provider_elapsed_ms,
+            ),
+            legacy_caller_id=self.user,
+        )
+        # Normal return with the caller-facing structured output result.
+        return observed_result.return_value
+
+    async def _asend_structured_output_provider(
+        self,
+        *,
+        response_schema: dict[str, Any],
+        system_prompt: str | None,
+        prompt: str | None,
+        messages: list[dict[str, Any]] | None,
+        max_response_tokens: int,
+        request_timeout_seconds: float | None,
+        provider_options: dict[str, Any] | None,
+    ) -> AIStructuredOutputResult:
+        """
+        Async twin of _send_structured_output_provider.
+        """
+        dict_merge_options, str_retry_override = self._split_provider_options(
+            provider_options
+        )
+        call_client: Any = self._async_client_for_call(
+            request_timeout_seconds=request_timeout_seconds,
+            retry_policy_override=str_retry_override,
+        )
+        dict_request_kwargs: dict[str, Any] = (
+            self._build_responses_structured_request_kwargs(
+                response_schema=response_schema,
+                system_prompt=system_prompt,
+                prompt=prompt,
+                messages=messages,
+                max_response_tokens=max_response_tokens,
+                dict_merge_options=dict_merge_options,
+            )
+        )
+        dict_input_metadata: dict[str, ObservabilityMetadataValue] = (
+            self._build_structured_observability_metadata(
+                prompt=prompt,
+                messages=messages,
+                max_response_tokens=max_response_tokens,
+            )
+        )
+
+        async def _execute_structured() -> (
+            AiApiObservedCompletionsResultModel[AIStructuredOutputResult]
+        ):
+            try:
+                response = await call_client.responses.create(**dict_request_kwargs)
+            except Exception as exception:
+                self._raise_request_error(exception)
+                raise
+            # Normal return with the observed structured output result.
+            return self._observed_responses_structured_result(response)
+
+        observed_result: AiApiObservedCompletionsResultModel[
+            AIStructuredOutputResult
+        ] = await self._execute_provider_acall_with_observability(
+            capability=self.CLIENT_TYPE_COMPLETIONS,
+            operation="asend_structured_output",
+            dict_input_metadata=dict_input_metadata,
+            callable_execute=_execute_structured,
+            callable_build_result_summary=lambda result, provider_elapsed_ms: self._build_completions_observability_result_summary(
+                observed_result=result,
+                provider_elapsed_ms=provider_elapsed_ms,
+            ),
+            legacy_caller_id=self.user,
+        )
+        # Normal return with the caller-facing structured output result.
+        return observed_result.return_value
+
+    async def _asend_prompt_provider(
+        self,
+        prompt: str,
+        *,
+        system_prompt: str | None,
+        max_response_tokens: int | None,
+        request_timeout_seconds: float | None,
+        other_params: AICompletionsPromptParamsBase | None,
+    ) -> str:
+        """
+        Async twin of send_prompt using AsyncOpenAI on the Responses API.
+        """
+        str_redacted_prompt: str = self.pii_middleware.process_input(prompt)
+        str_system_prompt: str = self._resolve_system_prompt(
+            system_prompt,
+            other_params,
+            AICompletionsPromptParamsBase.DEFAULT_SYSTEM_PROMPT,
+        )
+        call_client: Any = self._async_client_for_call(
+            request_timeout_seconds=request_timeout_seconds
+        )
+        dict_request_kwargs: dict[str, Any] = {
+            "model": self.completions_model,
+            "input": str_redacted_prompt,
+            "instructions": str_system_prompt,
+        }
+        if max_response_tokens is not None:
+            dict_request_kwargs["max_output_tokens"] = max_response_tokens
+        dict_input_metadata: dict[str, ObservabilityMetadataValue] = (
+            self._build_completions_observability_input_metadata(
+                prompt=str_redacted_prompt,
+                system_prompt=str_system_prompt,
+                other_params=other_params,
+                response_mode=self.RESPONSE_MODE_TEXT,
+                max_response_tokens=max_response_tokens,
+            )
+        )
+
+        async def _execute_text_prompt() -> AiApiObservedCompletionsResultModel[str]:
+            try:
+                response = await call_client.responses.create(**dict_request_kwargs)
+            except Exception as exception:
+                self._raise_request_error(exception)
+                raise
+            raw_output_text: str = str(getattr(response, "output_text", "") or "")
+            tuple_usage = self._extract_responses_usage(response)
+            # Normal return with the Responses text output and usage metadata.
+            return AiApiObservedCompletionsResultModel(
+                return_value=raw_output_text,
+                raw_output_text=raw_output_text,
+                finish_reason=str(getattr(response, "status", "") or ""),
+                provider_prompt_tokens=tuple_usage[0],
+                provider_completion_tokens=tuple_usage[1],
+                provider_cached_input_tokens=tuple_usage[3],
+                provider_total_tokens=tuple_usage[2],
+            )
+
+        observed_result: AiApiObservedCompletionsResultModel[str] = (
+            await self._execute_provider_acall_with_observability(
+                capability=self.CLIENT_TYPE_COMPLETIONS,
+                operation="asend_prompt",
+                dict_input_metadata=dict_input_metadata,
+                callable_execute=_execute_text_prompt,
+                callable_build_result_summary=lambda result, provider_elapsed_ms: self._build_completions_observability_result_summary(
+                    observed_result=result,
+                    provider_elapsed_ms=provider_elapsed_ms,
+                ),
+                legacy_caller_id=self.user,
+            )
+        )
+        # Normal return with sanitized Responses text after observability wrapping.
+        return self.pii_middleware.process_output(observed_result.return_value)

--- a/tests/test_google_gemini.py
+++ b/tests/test_google_gemini.py
@@ -378,7 +378,7 @@ class TestGoogleGeminiModules:
                     with patch.object(
                         client,
                         "_retry_with_exponential_backoff",
-                        side_effect=lambda func: func(),
+                        side_effect=lambda func, **kwargs: func(),
                     ):
                         result = client.generate_embeddings("test text")
 
@@ -420,7 +420,7 @@ class TestGoogleGeminiModules:
                     with patch.object(
                         client,
                         "_retry_with_exponential_backoff",
-                        side_effect=lambda func: func(),
+                        side_effect=lambda func, **kwargs: func(),
                     ):
                         result = client.send_prompt("What is the capital of France?")
                         assert result == "This is a test response"
@@ -528,7 +528,7 @@ class TestGoogleGeminiModules:
                     with patch.object(
                         client,
                         "_retry_with_exponential_backoff",
-                        side_effect=lambda func: func(),
+                        side_effect=lambda func, **kwargs: func(),
                     ):
                         result = client.send_prompt(
                             "What is the capital of France?", other_params=custom_params
@@ -576,7 +576,7 @@ class TestGoogleGeminiModules:
                     with patch.object(
                         client,
                         "_retry_with_exponential_backoff",
-                        side_effect=lambda func: func(),
+                        side_effect=lambda func, **kwargs: func(),
                     ):
                         result = client.strict_schema_prompt(
                             "Describe a person", ExampleStructuredPrompt
@@ -632,7 +632,7 @@ class TestGoogleGeminiModules:
                     with patch.object(
                         client,
                         "_retry_with_exponential_backoff",
-                        side_effect=lambda func: func(),
+                        side_effect=lambda func, **kwargs: func(),
                     ):
                         with pytest.raises(
                             completions_module.StructuredResponseTokenLimitError,

--- a/tests/test_multi_engine_conversation_api.py
+++ b/tests/test_multi_engine_conversation_api.py
@@ -1,0 +1,661 @@
+# test_multi_engine_conversation_api.py
+"""
+Mocked tests for the conversation, structured-output, async, and retry
+features on the openai, openai-responses, google-gemini, and bedrock engines
+(claude engine coverage lives in test_completions_conversation_api.py).
+
+Transport faking follows each engine's established repo pattern: construct
+the real client with stubbed credentials, then replace the SDK client
+attribute with Mock objects mimicking that SDK's object graph.
+"""
+
+import json
+import os
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+
+from ai_api_unified.ai_base import (
+    AIFinishReason,
+    AITool,
+)
+from ai_api_unified.ai_provider_exceptions import (
+    AiProviderCapabilityUnsupportedError,
+    AiProviderRequestError,
+)
+
+WEATHER_TOOL = AITool(
+    name="get_weather",
+    description="Get current weather for a city.",
+    input_schema={
+        "type": "object",
+        "properties": {"city": {"type": "string"}},
+        "required": ["city"],
+    },
+    strict=True,
+)
+
+GRAPH_SCHEMA: dict = {
+    "type": "object",
+    "properties": {"nodes": {"type": "array", "items": {"type": "object"}}},
+    "required": ["nodes"],
+}
+
+
+# ── OpenAI Chat Completions engine ──────────────────────────────────────────
+
+openai = pytest.importorskip("openai")
+
+from ai_api_unified.completions.ai_openai_completions import (  # noqa: E402
+    AiOpenAICompletions,
+)
+from ai_api_unified.completions.ai_openai_responses_completions import (  # noqa: E402
+    AiOpenAIResponsesCompletions,
+)
+
+
+def _build_openai_client(**kwargs) -> AiOpenAICompletions:
+    with patch.dict(os.environ, {"OPENAI_API_KEY": "test-key"}):
+        client = AiOpenAICompletions(model="gpt-4o-mini", **kwargs)
+    client.client = Mock()
+    return client
+
+
+def _chat_usage(input_tokens: int = 10, output_tokens: int = 5) -> Mock:
+    return Mock(
+        prompt_tokens=input_tokens,
+        completion_tokens=output_tokens,
+        total_tokens=input_tokens + output_tokens,
+        prompt_tokens_details=Mock(cached_tokens=None),
+    )
+
+
+def _chat_message(
+    content: str | None = None,
+    tool_calls: list | None = None,
+    refusal: str | None = None,
+) -> Mock:
+    message = Mock(spec=["content", "tool_calls", "refusal", "model_dump"])
+    message.content = content
+    message.tool_calls = tool_calls
+    message.refusal = refusal
+    message.model_dump = Mock(side_effect=TypeError("test double"))
+    return message
+
+
+def _chat_tool_call(call_id: str, name: str, arguments: str) -> Mock:
+    function = Mock(spec=["name", "arguments"])
+    function.name = name
+    function.arguments = arguments
+    tool_call = Mock(spec=["id", "function"])
+    tool_call.id = call_id
+    tool_call.function = function
+    return tool_call
+
+
+def _chat_response(message: Mock, finish_reason: str = "stop") -> Mock:
+    return Mock(
+        choices=[Mock(message=message, finish_reason=finish_reason)],
+        usage=_chat_usage(),
+    )
+
+
+class TestOpenAIChatConversation:
+    def test_full_tool_loop_cycle(self):
+        client = _build_openai_client()
+        turn1 = _chat_response(
+            _chat_message(
+                content=None,
+                tool_calls=[_chat_tool_call("call_1", "get_weather", '{"city": "SF"}')],
+            ),
+            finish_reason="tool_calls",
+        )
+        turn2 = _chat_response(_chat_message(content="Sunny."), finish_reason="stop")
+        client.client.chat.completions.create.side_effect = [turn1, turn2]
+
+        messages = [{"role": "user", "content": "Weather in SF?"}]
+        result1 = client.send_conversation("sys", messages, tools=[WEATHER_TOOL])
+        assert result1.finish_reason is AIFinishReason.TOOL_USE
+        assert result1.tool_calls[0].input == {"city": "SF"}
+        # raw_content is the full assistant message; extend appends it as-is.
+        client.extend_messages_with_turn(messages, result1)
+        assert messages[-1]["role"] == "assistant"
+        assert messages[-1]["tool_calls"][0]["id"] == "call_1"
+
+        messages.append(
+            client.build_tool_result_message(
+                tool_call_id="call_1", result={"temp_f": 65}, is_error=False
+            )
+        )
+        assert messages[-1]["role"] == "tool"
+        assert messages[-1]["tool_call_id"] == "call_1"
+
+        result2 = client.send_conversation("sys", messages, tools=[WEATHER_TOOL])
+        assert result2.finish_reason is AIFinishReason.COMPLETE
+        assert result2.text == "Sunny."
+        assert result2.usage.input_tokens == 10
+
+        first_kwargs = client.client.chat.completions.create.call_args_list[0].kwargs
+        assert first_kwargs["messages"][0] == {"role": "system", "content": "sys"}
+        assert first_kwargs["tools"][0]["function"]["name"] == "get_weather"
+        assert first_kwargs["tools"][0]["function"]["strict"] is True
+
+    def test_forced_tool_choice_shape(self):
+        client = _build_openai_client()
+        client.client.chat.completions.create.return_value = _chat_response(
+            _chat_message(tool_calls=[_chat_tool_call("call_2", "get_weather", "{}")]),
+            finish_reason="tool_calls",
+        )
+        client.send_conversation(
+            "sys",
+            [{"role": "user", "content": "hi"}],
+            tools=[WEATHER_TOOL],
+            tool_choice="get_weather",
+        )
+        kwargs = client.client.chat.completions.create.call_args.kwargs
+        assert kwargs["tool_choice"] == {
+            "type": "function",
+            "function": {"name": "get_weather"},
+        }
+
+    def test_forced_tool_reports_tool_use_despite_stop_finish(self):
+        # A forced tool_choice returns finish_reason "stop" on the live API
+        # even though the message carries tool_calls; present tool calls win.
+        client = _build_openai_client()
+        client.client.chat.completions.create.return_value = _chat_response(
+            _chat_message(
+                tool_calls=[_chat_tool_call("call_3", "get_weather", '{"city": "SF"}')]
+            ),
+            finish_reason="stop",
+        )
+        turn = client.send_conversation(
+            "sys",
+            [{"role": "user", "content": "weather"}],
+            tools=[WEATHER_TOOL],
+            tool_choice="get_weather",
+        )
+        assert turn.finish_reason is AIFinishReason.TOOL_USE
+
+    def test_structured_output_raw_schema(self):
+        client = _build_openai_client()
+        payload = {"nodes": [{"kind": "task"}]}
+        client.client.chat.completions.create.return_value = _chat_response(
+            _chat_message(content=json.dumps(payload))
+        )
+        result = client.send_structured_output("Compile.", response_schema=GRAPH_SCHEMA)
+        assert result.data == payload
+        assert result.finish_reason is AIFinishReason.COMPLETE
+        kwargs = client.client.chat.completions.create.call_args.kwargs
+        assert kwargs["response_format"]["type"] == "json_schema"
+        assert kwargs["response_format"]["json_schema"]["schema"] == GRAPH_SCHEMA
+
+    def test_structured_length_and_refusal(self):
+        client = _build_openai_client()
+        client.client.chat.completions.create.return_value = _chat_response(
+            _chat_message(content='{"nodes": ['), finish_reason="length"
+        )
+        result = client.send_structured_output("Compile.", response_schema=GRAPH_SCHEMA)
+        assert result.finish_reason is AIFinishReason.LENGTH
+        assert result.data is None
+
+        client.client.chat.completions.create.return_value = _chat_response(
+            _chat_message(content=None, refusal="cannot help"), finish_reason="stop"
+        )
+        result = client.send_structured_output("Compile.", response_schema=GRAPH_SCHEMA)
+        assert result.finish_reason is AIFinishReason.REFUSAL
+        assert result.data is None
+
+    def test_send_prompt_budget_and_timeout(self):
+        client = _build_openai_client()
+        client.client.with_options.return_value = client.client
+        client.client.chat.completions.create.return_value = _chat_response(
+            _chat_message(content="ok"), finish_reason="length"
+        )
+        text = client.send_prompt(
+            "hi", max_response_tokens=500, request_timeout_seconds=15.0
+        )
+        # With an explicit budget the auto-continue-on-length loop is off.
+        assert text == "ok"
+        client.client.with_options.assert_called_once_with(timeout=15.0)
+        kwargs = client.client.chat.completions.create.call_args.kwargs
+        assert kwargs["max_completion_tokens"] == 500
+
+    @pytest.mark.asyncio
+    async def test_async_variants(self):
+        client = _build_openai_client()
+        async_client = Mock()
+        async_client.chat.completions.create = AsyncMock(
+            return_value=_chat_response(_chat_message(content="async ok"))
+        )
+        async_client.with_options.return_value = async_client
+        client._async_client = async_client
+
+        text = await client.asend_prompt("hi", max_response_tokens=64)
+        assert text == "async ok"
+        turn = await client.asend_conversation(
+            "sys", [{"role": "user", "content": "hi"}]
+        )
+        assert turn.text == "async ok"
+
+    def test_constructor_retry_policy_none(self):
+        with patch.dict(os.environ, {"OPENAI_API_KEY": "test-key"}):
+            with patch("ai_api_unified.ai_openai_base.OpenAI") as mock_openai_cls:
+                AiOpenAICompletions(model="gpt-4o-mini", retry_policy="none")
+        assert mock_openai_cls.call_args.kwargs["max_retries"] == 0
+
+    def test_status_error_wrapped(self):
+        import httpx
+
+        client = _build_openai_client()
+        request = httpx.Request("POST", "https://api.openai.com/v1/chat/completions")
+        response = httpx.Response(429, request=request)
+        client.client.chat.completions.create.side_effect = openai.APIStatusError(
+            "rate limited", response=response, body=None
+        )
+        with pytest.raises(AiProviderRequestError) as exc_info:
+            client.send_conversation("sys", [{"role": "user", "content": "hi"}])
+        assert exc_info.value.status_code == 429
+        assert exc_info.value.provider_engine == "openai"
+
+
+# ── OpenAI Responses engine ─────────────────────────────────────────────────
+
+
+def _build_responses_client() -> AiOpenAIResponsesCompletions:
+    with patch.dict(os.environ, {"OPENAI_API_KEY": "test-key"}):
+        client = AiOpenAIResponsesCompletions(model="gpt-4o-mini")
+    client.client = Mock()
+    return client
+
+
+def _responses_usage() -> Mock:
+    return Mock(
+        input_tokens=20,
+        output_tokens=8,
+        total_tokens=28,
+        input_tokens_details=Mock(cached_tokens=None),
+    )
+
+
+def _function_call_item(call_id: str, name: str, arguments: str) -> Mock:
+    item = Mock(spec=["type", "call_id", "name", "arguments"])
+    item.type = "function_call"
+    item.call_id = call_id
+    item.name = name
+    item.arguments = arguments
+    return item
+
+
+class TestResponsesConversation:
+    def test_tool_turn_and_replay(self):
+        client = _build_responses_client()
+        response = Mock(
+            output=[_function_call_item("fc_1", "get_weather", '{"city": "LA"}')],
+            output_text="",
+            status="completed",
+            usage=_responses_usage(),
+        )
+        client.client.responses.create.return_value = response
+
+        messages = [{"role": "user", "content": "Weather in LA?"}]
+        turn = client.send_conversation(
+            "sys", messages, tools=[WEATHER_TOOL], tool_choice="get_weather"
+        )
+        assert turn.finish_reason is AIFinishReason.TOOL_USE
+        assert turn.tool_calls[0].id == "fc_1"
+        assert turn.usage.input_tokens == 20
+
+        kwargs = client.client.responses.create.call_args.kwargs
+        assert kwargs["tools"][0] == {
+            "type": "function",
+            "name": "get_weather",
+            "description": WEATHER_TOOL.description,
+            "parameters": WEATHER_TOOL.input_schema,
+            "strict": True,
+        }
+        assert kwargs["tool_choice"] == {"type": "function", "name": "get_weather"}
+
+        # Replay extends the input item list, then appends the tool output.
+        client.extend_messages_with_turn(messages, turn)
+        assert messages[-1]["type"] == "function_call"
+        tool_result = client.build_tool_result_message(
+            tool_call_id="fc_1", result={"temp_f": 70}, is_error=False
+        )
+        assert tool_result == {
+            "type": "function_call_output",
+            "call_id": "fc_1",
+            "output": json.dumps({"temp_f": 70}),
+        }
+
+    def test_structured_output_format_and_length(self):
+        client = _build_responses_client()
+        payload = {"nodes": []}
+        client.client.responses.create.return_value = Mock(
+            output=[],
+            output_text=json.dumps(payload),
+            status="completed",
+            usage=_responses_usage(),
+        )
+        result = client.send_structured_output("Compile.", response_schema=GRAPH_SCHEMA)
+        assert result.data == payload
+        kwargs = client.client.responses.create.call_args.kwargs
+        assert kwargs["text"]["format"]["type"] == "json_schema"
+        assert kwargs["text"]["format"]["schema"] == GRAPH_SCHEMA
+
+        client.client.responses.create.return_value = Mock(
+            output=[],
+            output_text='{"nodes"',
+            status="incomplete",
+            incomplete_details=Mock(reason="max_output_tokens"),
+            usage=_responses_usage(),
+        )
+        result = client.send_structured_output("Compile.", response_schema=GRAPH_SCHEMA)
+        assert result.finish_reason is AIFinishReason.LENGTH
+        assert result.data is None
+
+    @pytest.mark.asyncio
+    async def test_async_conversation(self):
+        client = _build_responses_client()
+        async_client = Mock()
+        async_client.responses.create = AsyncMock(
+            return_value=Mock(
+                output=[],
+                output_text="done",
+                status="completed",
+                usage=_responses_usage(),
+            )
+        )
+        async_client.with_options.return_value = async_client
+        client._async_client = async_client
+        turn = await client.asend_conversation(
+            "sys", [{"role": "user", "content": "hi"}]
+        )
+        assert turn.finish_reason is AIFinishReason.COMPLETE
+        assert turn.text == "done"
+
+
+# ── Google Gemini engine ────────────────────────────────────────────────────
+
+genai_module = pytest.importorskip("google.genai")
+
+from ai_api_unified.completions.ai_google_gemini_completions import (  # noqa: E402
+    GoogleGeminiCompletions,
+)
+
+
+def _build_gemini_client(mock_client: Mock, **kwargs) -> GoogleGeminiCompletions:
+    with patch.object(
+        GoogleGeminiCompletions,
+        "_initialize_client",
+        lambda self: setattr(self, "client", mock_client),
+    ):
+        return GoogleGeminiCompletions(model="gemini-2.5-flash", **kwargs)
+
+
+def _gemini_usage() -> Mock:
+    return Mock(
+        prompt_token_count=30,
+        candidates_token_count=12,
+        total_token_count=42,
+        cached_content_token_count=None,
+    )
+
+
+def _gemini_function_call_part(name: str, args: dict) -> Mock:
+    function_call = Mock(spec=["name", "args"])
+    function_call.name = name
+    function_call.args = args
+    part = Mock(spec=["function_call", "text", "model_dump"])
+    part.function_call = function_call
+    part.text = None
+    part.model_dump = Mock(side_effect=TypeError("test double"))
+    return part
+
+
+def _gemini_text_part(text: str) -> Mock:
+    part = Mock(spec=["function_call", "text", "model_dump"])
+    part.function_call = None
+    part.text = text
+    part.model_dump = Mock(side_effect=TypeError("test double"))
+    return part
+
+
+def _gemini_response(parts: list, finish_reason: str = "FinishReason.STOP") -> Mock:
+    return Mock(
+        candidates=[Mock(content=Mock(parts=parts), finish_reason=finish_reason)],
+        usage_metadata=_gemini_usage(),
+        text="".join(getattr(p, "text", None) or "" for p in parts),
+    )
+
+
+class TestGeminiConversation:
+    def test_tool_turn_forced_and_replay(self):
+        mock_client = Mock()
+        client = _build_gemini_client(mock_client)
+        mock_client.models.generate_content.return_value = _gemini_response(
+            [_gemini_function_call_part("get_weather", {"city": "NYC"})],
+            finish_reason="FinishReason.STOP",
+        )
+        messages = [{"role": "user", "parts": [{"text": "Weather in NYC?"}]}]
+        turn = client.send_conversation(
+            "sys", messages, tools=[WEATHER_TOOL], tool_choice="get_weather"
+        )
+        assert turn.finish_reason is AIFinishReason.TOOL_USE
+        # Gemini tool-call ids are the function name.
+        assert turn.tool_calls[0].id == "get_weather"
+        assert turn.tool_calls[0].input == {"city": "NYC"}
+        assert turn.usage.input_tokens == 30
+
+        config = mock_client.models.generate_content.call_args.kwargs["config"]
+        declaration = config.tools[0].function_declarations[0]
+        assert declaration.name == "get_weather"
+        assert declaration.parameters_json_schema == WEATHER_TOOL.input_schema
+        assert config.tool_config.function_calling_config.allowed_function_names == [
+            "get_weather"
+        ]
+
+        client.extend_messages_with_turn(messages, turn)
+        assert messages[-1]["role"] == "model"
+        assert messages[-1]["parts"][0]["function_call"]["name"] == "get_weather"
+        tool_result = client.build_tool_result_message(
+            tool_call_id="get_weather", result={"temp_f": 55}, is_error=False
+        )
+        assert tool_result["parts"][0]["function_response"]["name"] == "get_weather"
+
+    def test_structured_output_json_schema_and_length(self):
+        mock_client = Mock()
+        client = _build_gemini_client(mock_client)
+        payload = {"nodes": []}
+        mock_client.models.generate_content.return_value = _gemini_response(
+            [_gemini_text_part(json.dumps(payload))]
+        )
+        result = client.send_structured_output("Compile.", response_schema=GRAPH_SCHEMA)
+        assert result.data == payload
+        config = mock_client.models.generate_content.call_args.kwargs["config"]
+        assert config.response_json_schema == GRAPH_SCHEMA
+        assert config.response_mime_type == "application/json"
+
+        mock_client.models.generate_content.return_value = _gemini_response(
+            [_gemini_text_part('{"nodes"')],
+            finish_reason="FinishReason.MAX_TOKENS",
+        )
+        result = client.send_structured_output("Compile.", response_schema=GRAPH_SCHEMA)
+        assert result.finish_reason is AIFinishReason.LENGTH
+        assert result.data is None
+
+    @pytest.mark.asyncio
+    async def test_async_prompt(self):
+        mock_client = Mock()
+        mock_client.aio.models.generate_content = AsyncMock(
+            return_value=_gemini_response([_gemini_text_part("async ok")])
+        )
+        client = _build_gemini_client(mock_client)
+        text = await client.asend_prompt("hi", max_response_tokens=128)
+        assert text == "async ok"
+
+    def test_retry_policy_none_single_attempt(self):
+        mock_client = Mock()
+        client = _build_gemini_client(mock_client, retry_policy="none")
+        assert client._effective_max_retries() == 0
+        assert client._effective_max_retries("none") == 0
+        client_default = _build_gemini_client(Mock())
+        assert client_default._effective_max_retries() is None
+        assert client_default._effective_max_retries("none") == 0
+
+    def test_capability_flags(self):
+        client = _build_gemini_client(Mock())
+        assert client.capabilities.supports_tool_use is True
+        assert client.capabilities.supports_structured_output is True
+        assert client.capabilities.supports_async is True
+
+
+# ── Bedrock engine ──────────────────────────────────────────────────────────
+
+pytest.importorskip("boto3")
+
+from ai_api_unified.completions.ai_bedrock_completions import (  # noqa: E402
+    AiBedrockCompletions,
+)
+
+
+def _build_bedrock_client(model: str = "amazon.nova-lite-v1:0", **kwargs):
+    with patch("ai_api_unified.ai_bedrock_base.boto3"):
+        client = AiBedrockCompletions(model=model, **kwargs)
+    client.client = Mock()
+    client.backoff_delays = [0.0]
+    client._sleep_with_backoff = lambda base_delay: None
+    return client
+
+
+def _converse_response(content: list, stop_reason: str = "end_turn") -> dict:
+    return {
+        "output": {"message": {"role": "assistant", "content": content}},
+        "stopReason": stop_reason,
+        "usage": {"inputTokens": 15, "outputTokens": 6, "totalTokens": 21},
+    }
+
+
+class TestBedrockConversation:
+    def test_tool_turn_forced_and_replay(self):
+        client = _build_bedrock_client()
+        client.client.converse.return_value = _converse_response(
+            [
+                {
+                    "toolUse": {
+                        "toolUseId": "tu_1",
+                        "name": "get_weather",
+                        "input": {"city": "Denver"},
+                    }
+                }
+            ],
+            stop_reason="tool_use",
+        )
+        messages = [{"role": "user", "content": [{"text": "Weather in Denver?"}]}]
+        turn = client.send_conversation(
+            "sys", messages, tools=[WEATHER_TOOL], tool_choice="get_weather"
+        )
+        assert turn.finish_reason is AIFinishReason.TOOL_USE
+        assert turn.tool_calls[0].id == "tu_1"
+        assert turn.usage.input_tokens == 15
+
+        kwargs = client.client.converse.call_args.kwargs
+        tool_spec = kwargs["toolConfig"]["tools"][0]["toolSpec"]
+        assert tool_spec["name"] == "get_weather"
+        assert tool_spec["inputSchema"] == {"json": WEATHER_TOOL.input_schema}
+        assert kwargs["toolConfig"]["toolChoice"] == {"tool": {"name": "get_weather"}}
+
+        client.extend_messages_with_turn(messages, turn)
+        assert messages[-1]["role"] == "assistant"
+        assert messages[-1]["content"][0]["toolUse"]["toolUseId"] == "tu_1"
+        tool_result = client.build_tool_result_message(
+            tool_call_id="tu_1", result={"temp_f": 40}, is_error=True
+        )
+        assert tool_result["content"][0]["toolResult"]["status"] == "error"
+        assert tool_result["content"][0]["toolResult"]["content"] == [
+            {"json": {"temp_f": 40}}
+        ]
+
+    def test_finish_reason_mapping(self):
+        client = _build_bedrock_client()
+        for stop_reason, expected in (
+            ("end_turn", AIFinishReason.COMPLETE),
+            ("max_tokens", AIFinishReason.LENGTH),
+            ("guardrail_intervened", AIFinishReason.REFUSAL),
+        ):
+            client.client.converse.return_value = _converse_response(
+                [{"text": "x"}], stop_reason=stop_reason
+            )
+            turn = client.send_conversation(
+                "sys", [{"role": "user", "content": [{"text": "hi"}]}]
+            )
+            assert turn.finish_reason is expected
+
+    def test_structured_output_gated_per_model(self):
+        # Nova is not in AWS's structured-outputs supported list.
+        nova_client = _build_bedrock_client()
+        with pytest.raises(AiProviderCapabilityUnsupportedError):
+            nova_client.send_structured_output("Compile.", response_schema=GRAPH_SCHEMA)
+
+        claude_client = _build_bedrock_client(model="us.anthropic.claude-opus-4-6-v1:0")
+        payload = {"nodes": []}
+        claude_client.client.converse.return_value = _converse_response(
+            [{"text": json.dumps(payload)}]
+        )
+        result = claude_client.send_structured_output(
+            "Compile.", response_schema=GRAPH_SCHEMA
+        )
+        assert result.data == payload
+        kwargs = claude_client.client.converse.call_args.kwargs
+        text_format = kwargs["outputConfig"]["textFormat"]
+        assert text_format["type"] == "json_schema"
+        assert text_format["structure"]["jsonSchema"]["schema"] == GRAPH_SCHEMA
+
+    def test_timeout_and_async_stay_unimplemented(self):
+        client = _build_bedrock_client()
+        with pytest.raises(
+            AiProviderCapabilityUnsupportedError, match="request_timeout_seconds"
+        ):
+            client.send_conversation(
+                "sys",
+                [{"role": "user", "content": [{"text": "hi"}]}],
+                request_timeout_seconds=5.0,
+            )
+        assert client.capabilities.supports_async is False
+
+    @pytest.mark.asyncio
+    async def test_async_gate_raises(self):
+        client = _build_bedrock_client()
+        with pytest.raises(AiProviderCapabilityUnsupportedError):
+            await client.asend_prompt("hi")
+
+    def test_client_error_wrapped_with_status(self):
+        from botocore.exceptions import ClientError as BotoClientError
+
+        client = _build_bedrock_client()
+        client.client.converse.side_effect = BotoClientError(
+            {
+                "Error": {"Code": "ThrottlingException", "Message": "slow down"},
+                "ResponseMetadata": {"HTTPStatusCode": 429},
+            },
+            "Converse",
+        )
+        with pytest.raises(AiProviderRequestError) as exc_info:
+            client.send_conversation(
+                "sys", [{"role": "user", "content": [{"text": "hi"}]}]
+            )
+        assert exc_info.value.status_code == 429
+        assert exc_info.value.provider_engine == "bedrock"
+
+    def test_retry_policy_none_collapses_schedule(self):
+        with patch("ai_api_unified.ai_bedrock_base.boto3"):
+            client = AiBedrockCompletions(
+                model="amazon.nova-lite-v1:0", retry_policy="none"
+            )
+        assert client.backoff_delays == [0.0]
+
+    def test_send_prompt_maps_max_tokens(self):
+        client = _build_bedrock_client()
+        client.client.converse.return_value = _converse_response([{"text": "ok"}])
+        client.send_prompt("hi", max_response_tokens=2048)
+        kwargs = client.client.converse.call_args.kwargs
+        assert kwargs["inferenceConfig"]["maxTokens"] == 2048


### PR DESCRIPTION
## What this PR does

Implements the 2.14.0 capability-gated completions surface (tool-loop conversations, structured extraction, async variants, retry policy, typed status-coded errors, extended `send_prompt` parameters) on every engine whose underlying provider API supports it. Anything the underlying API does not cover stays unimplemented and raises the typed `AiProviderCapabilityUnsupportedError`.

### Per-engine support landed

| Feature | `openai` | `openai-responses` | `google-gemini` | Bedrock-routed |
|---|---|---|---|---|
| Tool-loop conversations (`send_conversation`, forced `tool_choice`, strict tools) | yes | yes | yes (function declarations; ids are function names) | Nova + Claude families via Converse `toolConfig` |
| `send_structured_output` (raw JSON Schema) | yes (`json_schema` response format) | yes (`text.format`) | yes (`response_json_schema`) | per-model: AWS structured-outputs list (Claude 4.5+) |
| Async variants | yes (`AsyncOpenAI`) | yes | yes (`client.aio`, single attempt) | no — boto3 has no official async client |
| `send_prompt` `max_response_tokens` / `request_timeout_seconds` | yes / yes | yes / yes | yes / yes (`http_options`) | yes / no (boto3 has no per-call timeout) |
| `retry_policy` + `AiProviderRequestError.status_code` | yes | yes | yes | yes (engine schedule; SDK retries via `AWS_MAX_ATTEMPTS`) |

New engine-agnostic replay helper `extend_messages_with_turn` keeps one tool loop working unchanged across engines despite differing assistant-turn wire shapes (also implemented on `claude`).

### Verification

- 25 new mocked-transport tests (`tests/test_multi_engine_conversation_api.py`); full mocked suite 483 passed. Bedrock request shapes were validated against the pinned botocore service model (`toolConfig`, `outputConfig` members).
- Live smoke against real APIs on `openai`, `openai-responses`, and `google-gemini`: forced-tool turn → tool result → complete, structured `anyOf` extraction, and async prompt all passed. The live run caught and fixed a real defect: OpenAI reports `finish_reason: "stop"` on forced tool calls, so present `tool_calls` now take precedence (regression test added). Bedrock live was unavailable (expired AWS SSO session) — the failure surfaced as the new typed `AiProviderRequestError`, as designed.
- Existing public API unchanged; version bumped to 2.15.0 with a changelog entry; README gains a feature-support-by-engine matrix.

<!-- pr-review-prep:start -->
## PR Composition

Composition percentages are based on changed lines (added + deleted) versus the base branch `main`.

| Change Type | Lines Changed | Percentage |
|---|---:|---:|
| Core logic changes | 3149 | 78% |
| Documentation | 220 | 5% |
| Tests | 671 | 17% |
| Other | 2 | 0% |
| Total | 4042 | 100% |
<!-- pr-review-prep:end -->

<!-- pr-content-attribution:start -->
## Content Attribution Summary

Based on changed lines across counted PR commits in this PR. Pure data files are excluded — their content is deterministic process output, not authored work.

| Attribution Type | Commits | Lines Changed | Percentage |
|---|---:|---:|---:|
| AI-attributed | 2 | 4042 | 100% |
| Human-attributed | 0 | 0 | 0% |
| Bot-attributed | 0 | 0 | 0% |
| Total | 2 | 4042 | 100% |

Excluded from attribution:
- none (no merge/sync commits, no data-file lines)
<!-- pr-content-attribution:end -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

