### PR TITLE
chore: impact-based test selection with area markers and a full-regression release gate

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,11 @@
 # Repository guidelines
 
-- Run `pytest` before committing changes to ensure the test suite passes.
+- TEST SELECTION POLICY: during development run only impacted tests via
+  `poetry run python scripts/run_impacted_tests.py` (areas map in
+  `tests/area_map.py`; new test files must be added there). Run the FULL
+  mocked regression suite (`poetry run pytest -q -m "not nonmock"`) before
+  committing load-bearing changes and always before a release — `publish.sh`
+  enforces the release gate.
 - Keep code formatted with `black` using the default settings.
 - Use US English for all documentation and comments.
 - When adding examples or new modules, place them under `src/ai_api_unified/`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,11 +45,27 @@ README release section.
 - Releases are cut on `main` after merge: tag `v<version>` and push the tag.
   Publishing to PyPI is a separate, explicit step via `./publish.sh`.
 
+## Test selection policy (AI agents: follow this)
+
+The suite is large (483+ tests). Do not run all of it on every edit.
+
+- **During development**, run only the impacted areas:
+  `poetry run python scripts/run_impacted_tests.py` (maps your git diff to
+  `area_*` pytest markers via `tests/area_map.py`), or select by hand, e.g.
+  `poetry run pytest -m "area_engine_openai and not nonmock"`.
+- **Every new test file must be mapped** in `tests/area_map.py`; collection
+  fails with instructions if it is not.
+- **Full mocked regression** (`poetry run pytest -q -m "not nonmock"`) is
+  REQUIRED before tagging or publishing any release. `publish.sh` runs it and
+  will not publish on failure. Load-bearing changes (`ai_base.py`, factory,
+  registry, `conftest.py`, `pyproject.toml`) also escalate to the full suite
+  automatically.
+
 ## Working conventions
 
 - Never commit directly to `main`; create a branch from the updated remote
   primary branch first.
-- Run the mocked suite before any commit: `poetry run pytest -q -m "not nonmock"`
-  (tests in `*_nonmock.py` files call live provider APIs when credentials are
-  present in `.env`).
+- Run impacted tests before any commit (see the test selection policy above);
+  run the full mocked suite before a release. Tests in `*_nonmock.py` files
+  call live provider APIs when credentials are present in `.env`.
 - Lint and format: `poetry run ruff check .` and `poetry run black .`.

--- a/publish.sh
+++ b/publish.sh
@@ -42,6 +42,17 @@ if [[ ! "$confirm" =~ ^[Yy]$ ]]; then
     exit 0
 fi
 
+# ============================================================================
+# AI AGENT REMINDER — TEST SELECTION POLICY
+# Impact-based test runs (scripts/run_impacted_tests.py) are for development
+# only. Publishing REQUIRES the FULL mocked regression suite; this gate is
+# mandatory and must not be bypassed or weakened.
+# ============================================================================
+echo ""
+echo "🧪 Running the FULL mocked regression suite (required before publish)..."
+poetry run pytest -q -m "not nonmock"
+echo "✅ Full regression suite passed."
+
 echo ""
 echo "🧹 Cleaning up previous builds..."
 rm -rf dist/ build/ *.egg-info/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -122,6 +122,11 @@ video_frames = [
 [tool.pytest.ini_options]
 minversion = "6.0"
 addopts = "-ra"
+# AI AGENT REMINDER — TEST SELECTION POLICY: area_* markers (auto-applied
+# from tests/area_map.py by conftest.py) enable impact-based selection during
+# development via scripts/run_impacted_tests.py. The FULL mocked regression
+# suite (pytest -m "not nonmock") is REQUIRED before any release; publish.sh
+# enforces it.
 markers = [
   "nonmock: tests that call live provider APIs and require credentials",
   "integration: broader integration-style tests that may require optional extras or external services",

--- a/scripts/run_impacted_tests.py
+++ b/scripts/run_impacted_tests.py
@@ -1,0 +1,198 @@
+#!/usr/bin/env python3
+# ============================================================================
+# AI AGENT REMINDER — TEST SELECTION POLICY
+#
+# This is the development-loop test runner: it maps your git diff onto test
+# areas (tests/area_map.py) and runs only the impacted tests. Use it instead
+# of the full suite while iterating:
+#
+#     poetry run python scripts/run_impacted_tests.py              # diff vs main
+#     poetry run python scripts/run_impacted_tests.py --dry-run    # show plan
+#     poetry run python scripts/run_impacted_tests.py --base HEAD~1
+#
+# The FULL mocked regression suite is REQUIRED before tagging or publishing
+# a release (publish.sh enforces it):
+#
+#     poetry run pytest -q -m "not nonmock"
+# ============================================================================
+"""
+Impact-based test selection: git diff -> areas -> pytest marker expression.
+
+Load-bearing changes (ai_base.py, the factory/registry, conftest, pyproject)
+escalate to the full suite. Changed test files always run directly. Paths
+with no test impact (docs, scripts, ADRs, memory shards) trigger nothing.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "tests"))
+
+from area_map import (  # noqa: E402
+    ALL_AREAS,
+    AREA_MARKER_PREFIX,
+    areas_for_test_file,
+    classify_changed_path,
+)
+
+
+def _resolve_default_base() -> str:
+    """
+    Resolves the default diff base: the first remote's primary branch.
+    """
+    str_remote: str = (
+        subprocess.run(["git", "remote"], capture_output=True, text=True, check=True)
+        .stdout.split("\n")[0]
+        .strip()
+    )
+    if not str_remote:
+        # Early return with a local fallback when the repo has no remote.
+        return "main"
+    completed = subprocess.run(
+        ["git", "symbolic-ref", "--short", f"refs/remotes/{str_remote}/HEAD"],
+        capture_output=True,
+        text=True,
+    )
+    if completed.returncode != 0:
+        # Early return with the conventional primary branch name.
+        return f"{str_remote}/main"
+    # Normal return with the remote primary branch ref.
+    return completed.stdout.strip()
+
+
+def _changed_paths(str_base: str) -> list[str]:
+    """
+    Returns changed paths versus the base, including uncommitted changes.
+    """
+    set_paths: set[str] = set()
+    for list_command in (
+        ["git", "diff", "--name-only", f"{str_base}...HEAD"],
+        ["git", "diff", "--name-only", "HEAD"],
+        ["git", "diff", "--name-only", "--cached"],
+    ):
+        completed = subprocess.run(
+            list_command, capture_output=True, text=True, check=True
+        )
+        set_paths.update(
+            str_line.strip()
+            for str_line in completed.stdout.split("\n")
+            if str_line.strip()
+        )
+    # Normal return with the sorted union of committed and working-tree changes.
+    return sorted(set_paths)
+
+
+def build_plan(
+    list_changed_paths: list[str],
+) -> tuple[bool, set[str], list[str], list[str]]:
+    """
+    Classifies changed paths into a test plan.
+
+    Returns:
+        Tuple of (run_full_suite, impacted areas, changed test files,
+        paths with no test impact).
+    """
+    bool_full_suite: bool = False
+    set_areas: set[str] = set()
+    list_test_files: list[str] = []
+    list_no_impact: list[str] = []
+    # Loop over changed paths so each contributes its mapped impact.
+    for str_path in list_changed_paths:
+        impact = classify_changed_path(str_path)
+        if impact is None:
+            list_no_impact.append(str_path)
+        elif impact == ALL_AREAS:
+            bool_full_suite = True
+        elif isinstance(impact, str):
+            # A changed test file: fold its own areas into the marker
+            # expression (positional paths would restrict collection and
+            # silently drop area selection). An unmapped file runs directly
+            # so collection surfaces the map-this-file error.
+            str_basename: str = impact.rsplit("/", 1)[-1]
+            tuple_file_areas = areas_for_test_file(str_basename)
+            if tuple_file_areas is not None:
+                set_areas.update(tuple_file_areas)
+            else:
+                list_test_files.append(impact)
+        else:
+            set_areas.update(impact)
+    # Normal return with the classified plan.
+    return bool_full_suite, set_areas, list_test_files, list_no_impact
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Run only the tests impacted by the current git diff."
+    )
+    parser.add_argument(
+        "--base",
+        default=None,
+        help="Diff base (default: the remote primary branch).",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print the selection plan without running pytest.",
+    )
+    args = parser.parse_args()
+
+    str_base: str = args.base or _resolve_default_base()
+    list_changed_paths: list[str] = _changed_paths(str_base)
+    if not list_changed_paths:
+        print(f"No changes versus {str_base}; nothing to run.")
+        return 0
+
+    bool_full_suite, set_areas, list_test_files, list_no_impact = build_plan(
+        list_changed_paths
+    )
+
+    print(f"Diff base: {str_base}")
+    print(f"Changed paths: {len(list_changed_paths)}")
+    if list_no_impact:
+        print(f"No test impact ({len(list_no_impact)}): {', '.join(list_no_impact)}")
+
+    list_pytest_args: list[str]
+    if bool_full_suite:
+        print(
+            "Load-bearing change detected -> FULL mocked regression suite. "
+            "(Also required before any release; see publish.sh.)"
+        )
+        list_pytest_args = ["-m", "not nonmock"]
+    elif not set_areas and not list_test_files:
+        print("No impacted test areas; nothing to run.")
+        return 0
+    elif list_test_files and set_areas:
+        # Unmapped test files alongside area impacts: escalate to the full
+        # suite so the map-this-file collection error is not lost.
+        print(
+            "Unmapped test files changed alongside source areas "
+            f"({', '.join(list_test_files)}) -> FULL mocked regression suite."
+        )
+        list_pytest_args = ["-m", "not nonmock"]
+    elif list_test_files:
+        # Unmapped changed test files run directly; collection will raise the
+        # add-to-area-map error for them.
+        list_pytest_args = ["-m", "not nonmock", *list_test_files]
+        print(f"Selection -> unmapped test files: {', '.join(list_test_files)}")
+    else:
+        str_marker_expression: str = " or ".join(
+            f"{AREA_MARKER_PREFIX}{str_area}" for str_area in sorted(set_areas)
+        )
+        list_pytest_args = ["-m", f"({str_marker_expression}) and not nonmock"]
+        print(f"Selection -> areas: {', '.join(sorted(set_areas))}")
+
+    list_command: list[str] = ["pytest", "-q", *list_pytest_args]
+    print("Running:", " ".join(list_command))
+    if args.dry_run:
+        return 0
+    completed = subprocess.run(["poetry", "run", *list_command])
+    # Normal return with pytest's exit status.
+    return completed.returncode
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/area_map.py
+++ b/tests/area_map.py
@@ -1,0 +1,242 @@
+# area_map.py
+# ============================================================================
+# AI AGENT REMINDER — TEST SELECTION POLICY (read before running tests)
+#
+# During development, run only the test areas impacted by your change:
+#
+#     poetry run python scripts/run_impacted_tests.py
+#
+# The FULL mocked regression suite is REQUIRED (and enforced by publish.sh)
+# before tagging or publishing a release:
+#
+#     poetry run pytest -q -m "not nonmock"
+#
+# This module is the single source of truth for both sides of that policy:
+# which areas each test file belongs to, and which areas each source path
+# impacts. Every new test file MUST be added to DICT_TEST_FILE_AREAS —
+# conftest.py fails collection for unmapped files so the map stays complete.
+# ============================================================================
+"""
+Test-area registry mapping test files to areas and source paths to areas.
+
+Areas become pytest markers with the `area_` prefix (for example
+`area_engine_openai`), applied automatically by conftest.py, so any subset
+can be run directly:
+
+    poetry run pytest -m "area_middleware and not nonmock"
+"""
+
+from __future__ import annotations
+
+AREA_MARKER_PREFIX: str = "area_"
+
+# Sentinel meaning "this change impacts everything; run the full suite".
+ALL_AREAS: str = "__all__"
+
+AREAS: tuple[str, ...] = (
+    "core",
+    "completions",
+    "engine_anthropic",
+    "engine_openai",
+    "engine_gemini",
+    "engine_bedrock",
+    "middleware",
+    "pricing",
+    "embeddings",
+    "images",
+    "videos",
+    "voice",
+)
+
+# Test file basename -> areas it exercises. A file may carry several areas;
+# it runs when any of them is impacted.
+DICT_TEST_FILE_AREAS: dict[str, tuple[str, ...]] = {
+    # Core factory/registry/config surface
+    "test_ai_api.py": ("core",),
+    "test_ai_factory_provider_loading.py": ("core",),
+    "test_ai_provider_loader.py": ("core",),
+    "test_ai_provider_registry.py": ("core",),
+    "test_env_settings.py": ("core",),
+    "test_package_metadata_validation.py": ("core",),
+    "test_package_optional_import_safety.py": ("core",),
+    "test_version_sync.py": ("core",),
+    # Anthropic (native claude engine)
+    "test_anthropic_batches.py": ("completions", "engine_anthropic"),
+    "test_anthropic_completions.py": ("completions", "engine_anthropic"),
+    "test_completions_conversation_api.py": ("completions", "engine_anthropic"),
+    # OpenAI engines
+    "test_openai_responses_completions.py": ("completions", "engine_openai"),
+    "test_openai_us_endpoint.py": ("completions", "engine_openai"),
+    # Google Gemini engine
+    "test_google_gemini.py": ("completions", "engine_gemini", "embeddings"),
+    "test_google_gemini_nonmock.py": ("completions", "engine_gemini", "embeddings"),
+    # Multi-engine completions surfaces
+    "test_cached_token_capture.py": (
+        "completions",
+        "engine_anthropic",
+        "engine_openai",
+        "engine_gemini",
+        "engine_bedrock",
+    ),
+    "test_completions_streaming.py": (
+        "completions",
+        "engine_openai",
+        "engine_gemini",
+        "engine_bedrock",
+    ),
+    "test_image_input_completions.py": (
+        "completions",
+        "engine_openai",
+        "engine_gemini",
+    ),
+    "test_model_switch_nonmock.py": (
+        "completions",
+        "engine_openai",
+        "engine_gemini",
+        "engine_bedrock",
+    ),
+    "test_multi_engine_conversation_api.py": (
+        "completions",
+        "engine_openai",
+        "engine_gemini",
+        "engine_bedrock",
+    ),
+    # Pricing registry
+    "test_model_pricing.py": ("pricing",),
+    # Middleware: observability, finops, PII
+    "test_custom_recognizer_registration.py": ("middleware",),
+    "test_finops_cost_observability.py": ("middleware", "pricing"),
+    "test_middleware_config.py": ("middleware",),
+    "test_middleware_extensibility_poc.py": ("middleware",),
+    "test_observability_docs_release_phase_h.py": ("middleware",),
+    "test_observability_log_cleanup_phase_g.py": ("middleware",),
+    "test_observability_middleware_phase_a.py": ("middleware",),
+    "test_observability_shared_runtime.py": ("middleware",),
+    "test_pii_middleware_observability.py": ("middleware",),
+    "test_pii_redactor_nonmock.py": ("middleware",),
+    "test_presidio_log_control.py": ("middleware",),
+    # Middleware phases that construct real capability clients
+    "test_observability_completions_phase_c.py": ("middleware", "completions"),
+    "test_observability_embeddings_phase_d.py": ("middleware", "embeddings"),
+    "test_observability_images_phase_e.py": ("middleware", "images"),
+    "test_observability_tts_phase_f.py": ("middleware", "voice"),
+    # Embeddings
+    "test_embeddings_capabilities.py": ("embeddings",),
+    # Images
+    "test_image_generation_files.py": ("images",),
+    "test_nova_canvas_image.py": ("images", "engine_bedrock"),
+    # Videos
+    "test_ai_base_videos.py": ("videos",),
+    "test_frame_helpers.py": ("videos",),
+    "test_google_gemini_videos.py": ("videos", "engine_gemini"),
+    "test_nova_reel_videos.py": ("videos", "engine_bedrock"),
+    "test_openai_videos.py": ("videos", "engine_openai"),
+    "test_video_generation_nonmock.py": ("videos",),
+    # Voice
+    "test_ai_voice_factory_provider_loading.py": ("voice",),
+    "test_voice_env_settings.py": ("voice",),
+    "test_voice_nonmock.py": ("voice",),
+}
+
+# Source path prefixes -> areas impacted by a change under that prefix.
+# Rules are matched in order; the FIRST matching prefix wins, so more
+# specific prefixes must come before broader ones. ALL_AREAS means the
+# change is load-bearing for everything and the full suite runs.
+LIST_SOURCE_AREA_RULES: list[tuple[str, tuple[str, ...] | str]] = [
+    # Engine-specific completions
+    (
+        "src/ai_api_unified/completions/ai_anthropic_completions.py",
+        ("completions", "engine_anthropic"),
+    ),
+    (
+        "src/ai_api_unified/completions/ai_openai_completions.py",
+        ("completions", "engine_openai"),
+    ),
+    (
+        "src/ai_api_unified/completions/ai_openai_responses_completions.py",
+        ("completions", "engine_openai"),
+    ),
+    (
+        "src/ai_api_unified/completions/ai_google_gemini_completions.py",
+        ("completions", "engine_gemini"),
+    ),
+    (
+        "src/ai_api_unified/completions/ai_google_gemini_capabilities.py",
+        ("completions", "engine_gemini"),
+    ),
+    (
+        "src/ai_api_unified/completions/ai_bedrock_completions.py",
+        ("completions", "engine_bedrock"),
+    ),
+    # Provider bases are shared across that vendor's capabilities
+    (
+        "src/ai_api_unified/ai_anthropic_base.py",
+        ("completions", "engine_anthropic"),
+    ),
+    (
+        "src/ai_api_unified/ai_openai_base.py",
+        ("completions", "engine_openai", "images", "videos", "voice"),
+    ),
+    (
+        "src/ai_api_unified/ai_google_base.py",
+        ("completions", "engine_gemini", "embeddings", "images", "videos", "voice"),
+    ),
+    (
+        "src/ai_api_unified/ai_bedrock_base.py",
+        ("completions", "engine_bedrock", "embeddings", "images", "videos"),
+    ),
+    # Capability packages
+    ("src/ai_api_unified/embeddings/", ("embeddings",)),
+    ("src/ai_api_unified/images/", ("images",)),
+    ("src/ai_api_unified/videos/", ("videos",)),
+    ("src/ai_api_unified/voice/", ("voice",)),
+    ("src/ai_api_unified/middleware/", ("middleware",)),
+    ("src/ai_api_unified/pricing/", ("pricing", "middleware", "completions")),
+    # Load-bearing shared modules: run everything.
+    ("src/ai_api_unified/ai_base.py", ALL_AREAS),
+    ("src/ai_api_unified/ai_factory.py", ALL_AREAS),
+    ("src/ai_api_unified/ai_provider_loader.py", ALL_AREAS),
+    ("src/ai_api_unified/ai_provider_registry.py", ALL_AREAS),
+    ("src/ai_api_unified/ai_provider_exceptions.py", ALL_AREAS),
+    ("src/ai_api_unified/ai_completions_exceptions.py", ALL_AREAS),
+    ("src/ai_api_unified/util/", ALL_AREAS),
+    ("src/ai_api_unified/__init__.py", ALL_AREAS),
+    ("src/ai_api_unified/__version__.py", ("core",)),
+    # Test infrastructure changes invalidate selection itself.
+    ("tests/conftest.py", ALL_AREAS),
+    ("tests/area_map.py", ALL_AREAS),
+    ("pyproject.toml", ALL_AREAS),
+    ("poetry.lock", ALL_AREAS),
+]
+
+
+def areas_for_test_file(str_basename: str) -> tuple[str, ...] | None:
+    """
+    Returns the areas mapped for one test file basename, or None if unmapped.
+    """
+    return DICT_TEST_FILE_AREAS.get(str_basename)
+
+
+def classify_changed_path(str_path: str) -> tuple[str, ...] | str | None:
+    """
+    Returns the impact of one changed repo path.
+
+    Returns a tuple of areas, ALL_AREAS for full-suite triggers, the literal
+    path for a changed test file (run it directly), or None when the path has
+    no test impact (docs, scripts, CI, ADRs).
+    """
+    if str_path.startswith("tests/") and str_path.endswith(".py"):
+        str_basename: str = str_path.rsplit("/", 1)[-1]
+        if str_basename in ("conftest.py", "area_map.py", "__init__.py"):
+            return ALL_AREAS
+        # A changed test file runs directly regardless of area mapping.
+        return str_path
+    # Loop over ordered rules so the most specific prefix wins.
+    for str_prefix, impact in LIST_SOURCE_AREA_RULES:
+        if str_path.startswith(str_prefix):
+            return impact
+    if str_path.startswith("src/"):
+        # Unknown source paths are load-bearing until mapped here.
+        return ALL_AREAS
+    # Docs, scripts, CI, and memory shards trigger no tests.
+    return None

--- a/tests/area_map.py
+++ b/tests/area_map.py
@@ -225,6 +225,10 @@ def classify_changed_path(str_path: str) -> tuple[str, ...] | str | None:
     path for a changed test file (run it directly), or None when the path has
     no test impact (docs, scripts, CI, ADRs).
     """
+    if str_path.startswith("tests/input/"):
+        # Shared test fixtures: no per-fixture consumer map exists, so run
+        # everything rather than silently skip the tests that read them.
+        return ALL_AREAS
     if str_path.startswith("tests/") and str_path.endswith(".py"):
         str_basename: str = str_path.rsplit("/", 1)[-1]
         if str_basename in ("conftest.py", "area_map.py", "__init__.py"):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -81,11 +81,71 @@ def configure_presidio_test_log_noise_filter() -> None:
 configure_presidio_test_log_noise_filter()
 
 
+# ============================================================================
+# AI AGENT REMINDER — TEST SELECTION POLICY
+#
+# 483+ tests is too many to run on every edit. During development, run only
+# the areas impacted by your change:
+#
+#     poetry run python scripts/run_impacted_tests.py        # auto from git diff
+#     poetry run pytest -m "area_engine_openai and not nonmock"   # by hand
+#
+# The FULL mocked regression suite (poetry run pytest -q -m "not nonmock")
+# is REQUIRED before tagging or publishing a release; publish.sh enforces it.
+# Area markers are applied automatically from tests/area_map.py — every new
+# test file MUST be mapped there or collection fails below.
+# ============================================================================
+tests_dir: str = os.path.dirname(__file__)
+if tests_dir not in sys.path:
+    sys.path.insert(0, tests_dir)
+
+from area_map import (  # noqa: E402
+    AREA_MARKER_PREFIX,
+    AREAS,
+    areas_for_test_file,
+)
+
+
 def pytest_configure(config: pytest.Config) -> None:
     config.addinivalue_line(
         "markers",
         "nonmock: tests that call live provider APIs and require credentials",
     )
+    # Loop over areas so every area marker is registered for strict marker use.
+    for str_area in AREAS:
+        config.addinivalue_line(
+            "markers",
+            f"{AREA_MARKER_PREFIX}{str_area}: tests exercising the "
+            f"'{str_area}' code area (auto-applied from tests/area_map.py)",
+        )
+
+
+def pytest_collection_modifyitems(
+    config: pytest.Config, items: list[pytest.Item]
+) -> None:
+    """
+    Auto-applies area markers from tests/area_map.py to every collected test.
+
+    Fails collection for unmapped test files so impact-based selection can
+    never silently skip a new test file.
+    """
+    list_unmapped_files: list[str] = []
+    # Loop over collected items so each carries its file's area markers.
+    for item in items:
+        str_basename: str = os.path.basename(str(item.fspath))
+        tuple_areas = areas_for_test_file(str_basename)
+        if tuple_areas is None:
+            if str_basename not in list_unmapped_files:
+                list_unmapped_files.append(str_basename)
+            continue
+        for str_area in tuple_areas:
+            item.add_marker(getattr(pytest.mark, f"{AREA_MARKER_PREFIX}{str_area}"))
+    if list_unmapped_files:
+        raise pytest.UsageError(
+            "Test files missing from tests/area_map.py DICT_TEST_FILE_AREAS: "
+            f"{', '.join(sorted(list_unmapped_files))}. Add each file to the "
+            "map (this keeps impact-based test selection complete)."
+        )
 
 
 def pytest_addoption(parser: pytest.Parser) -> None:


### PR DESCRIPTION
## What this PR does

Adds impact-based test selection so day-to-day development runs only the tests touched by a change, while the full 483-test mocked regression stays mandatory — and enforced — before any release.

### How it works

- **`tests/area_map.py`** — single source of truth: 12 areas (`core`, `completions`, four `engine_*`, `middleware`, `pricing`, `embeddings`, `images`, `videos`, `voice`); every test file maps to its areas, and ordered source-path rules map code changes to impacted areas. Load-bearing modules (`ai_base.py`, factory, registry, `conftest.py`, `pyproject.toml`) escalate to the full suite.
- **`tests/conftest.py`** — auto-applies `area_*` markers from the map and fails collection with instructions when a test file is unmapped, so selection can never silently skip new tests.
- **`scripts/run_impacted_tests.py`** — `git diff` → areas → `pytest -m` expression, with `--dry-run` and `--base`. Changed test files fold into their own areas (positional paths would restrict collection); docs/scripts/memory shards trigger nothing.
- **`publish.sh`** — now runs the full mocked regression before building; publishing cannot proceed on a red suite.
- **Prominent AI-reminder comments** stating the policy live in every file an agent touches when running tests: the map, conftest, the runner, `pyproject.toml`, `publish.sh`, plus `CLAUDE.md` and `AGENTS.md` sections.

### Measured effect

| Selection | Tests collected |
|---|---:|
| `area_engine_openai` | 78 / 494 |
| `area_middleware` | 181 / 494 |
| docs-only change | 0 (nothing runs) |
| load-bearing change | full suite |

Verification: full regression 483 passed with the collection hook active; the unmapped-file guard fires with a clear error; the runner dry-run classifies this branch's own docs edits as no-impact and its conftest edit as full-suite. Test/CI-only change — no version bump per the versioning policy.

<!-- pr-review-prep:start -->
## PR Composition

Composition percentages are based on changed lines (added + deleted) versus the base branch `main`.

| Change Type | Lines Changed | Percentage |
|---|---:|---:|
| Core logic changes | 0 | 0% |
| Documentation | 29 | 5% |
| Tests | 306 | 56% |
| Other | 214 | 39% |
| Total | 549 | 100% |
<!-- pr-review-prep:end -->

<!-- pr-content-attribution:start -->
## Content Attribution Summary

Based on changed lines across counted PR commits in this PR. Pure data files are excluded — their content is deterministic process output, not authored work.

| Attribution Type | Commits | Lines Changed | Percentage |
|---|---:|---:|---:|
| AI-attributed | 2 | 549 | 100% |
| Human-attributed | 0 | 0 | 0% |
| Bot-attributed | 0 | 0 | 0% |
| Total | 2 | 549 | 100% |

Excluded from attribution:
- none (no merge/sync commits, no data-file lines)
<!-- pr-content-attribution:end -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

