### PR TITLE
feat: per-engine API base-URL overrides for claude, openai, and gemini (2.20.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,27 @@ Notable changes per release, so consumers can gate on the package version.
 Versions follow [semantic versioning](https://semver.org/); the authoritative
 version lives in `pyproject.toml` (see the README release section).
 
+## 2.20.0
+
+- Per-engine API base-URL overrides for `claude`, `openai`,
+  `openai-responses`, and `google-gemini`, so provider traffic can route
+  through an LLM gateway, an egress proxy, a recording proxy, or any
+  OpenAI-compatible server: `ANTHROPIC_BASE_URL_OVERRIDE`,
+  `OPENAI_BASE_URL_OVERRIDE`, `GOOGLE_GEMINI_BASE_URL_OVERRIDE`, or a
+  `base_url` argument on the factory and engine constructors for per-client
+  routing.
+- Overrides must be https unless they target `localhost`, `127.0.0.1`, or
+  `::1`; anything else raises `AiProviderConfigurationError` before a
+  credential leaves the process. The resolved value is passed to each SDK
+  explicitly, so the SDKs' own `OPENAI_BASE_URL` / `ANTHROPIC_BASE_URL` /
+  `GOOGLE_GEMINI_BASE_URL` variables cannot take effect unvalidated.
+- Organization-identity lookups (2.18.0/2.19.0) now derive from the resolved
+  base URL, so finops attribution follows the gateway instead of calling the
+  vendor directly.
+- Engines whose SDK cannot honor an override (Bedrock-routed, `titan`,
+  `voyage`, voice) raise `AiProviderCapabilityUnsupportedError` when passed
+  `base_url` rather than ignoring it.
+
 ## 2.19.0
 
 - Organization identity for finops attribution now covers every provider to

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,12 @@ version lives in `pyproject.toml` (see the README release section).
   `GOOGLE_GEMINI_BASE_URL` variables cannot take effect unvalidated.
 - Organization-identity lookups (2.18.0/2.19.0) now derive from the resolved
   base URL, so finops attribution follows the gateway instead of calling the
-  vendor directly.
+  vendor directly. Exception: the Anthropic Admin API key grants org-wide
+  read/write, so it does not follow `ANTHROPIC_BASE_URL_OVERRIDE`; set
+  `ANTHROPIC_ADMIN_BASE_URL_OVERRIDE` to route that lookup too.
+- The deprecated `OPENAI_BASE_URL` is now validated by the same https rules,
+  closing a path where a process-wide value set by other tooling could send
+  the API key to a plaintext host.
 - Engines whose SDK cannot honor an override (Bedrock-routed, `titan`,
   `voyage`, voice) raise `AiProviderCapabilityUnsupportedError` when passed
   `base_url` rather than ignoring it.

--- a/README.md
+++ b/README.md
@@ -771,6 +771,7 @@ There is no implicit default provider. Set the selector for each capability you 
 | `ANTHROPIC_BASE_URL_OVERRIDE` | Optional API base-URL override for the `claude` engine (https required) |
 | `OPENAI_BASE_URL_OVERRIDE`  | Optional API base-URL override for the OpenAI engines (https required) |
 | `GOOGLE_GEMINI_BASE_URL_OVERRIDE` | Optional API base-URL override for `google-gemini` (https required) |
+| `ANTHROPIC_ADMIN_BASE_URL_OVERRIDE` | Optional separate override for the Anthropic Admin API lookup; the admin key does not follow the inference override |
 
 ### API Base URL Overrides
 
@@ -819,7 +820,13 @@ Rules and rationale:
   then (OpenAI only) the deprecated `OPENAI_BASE_URL` and geo-residency
   routing, then the provider default.
 - **Organization lookups follow the override**, so finops attribution does not
-  bypass your gateway.
+  bypass your gateway — with one deliberate exception: the Anthropic **Admin
+  API key** grants org-wide read/write, far beyond the inference key, so it
+  does not follow `ANTHROPIC_BASE_URL_OVERRIDE`. Routing inference through a
+  gateway never silently hands that gateway an administration credential. Set
+  `ANTHROPIC_ADMIN_BASE_URL_OVERRIDE` to opt the admin lookup in as well.
+- The deprecated `OPENAI_BASE_URL` is validated by the same rules, since other
+  tooling commonly sets that name process-wide.
 - Engines without SDK support (Bedrock-routed, `titan`, `voyage`, voice)
   raise `AiProviderCapabilityUnsupportedError` when passed `base_url`, rather
   than ignoring it silently.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# ai-api-unified 2.19.0
+# ai-api-unified 2.20.0
 
 `ai-api-unified` is a unified Python library for AI completions, embeddings, image generation, video generation, and voice. Application code targets stable base interfaces and factory entry points while concrete providers are selected at runtime from environment configuration.
 
@@ -768,6 +768,61 @@ There is no implicit default provider. Set the selector for each capability you 
 | `EMBEDDING_DIMENSIONS`      | Optional embeddings dimension override. Leave unset for provider defaults.                  |
 | `AI_API_GEO_RESIDENCY`      | Optional geo hint. `US`, `USA`, or `United States` normalize to US routing where supported. |
 | `AI_MIDDLEWARE_CONFIG_PATH` | Optional YAML config path for observability and PII middleware                              |
+| `ANTHROPIC_BASE_URL_OVERRIDE` | Optional API base-URL override for the `claude` engine (https required) |
+| `OPENAI_BASE_URL_OVERRIDE`  | Optional API base-URL override for the OpenAI engines (https required) |
+| `GOOGLE_GEMINI_BASE_URL_OVERRIDE` | Optional API base-URL override for `google-gemini` (https required) |
+
+### API Base URL Overrides
+
+The `claude`, `openai`, `openai-responses`, and `google-gemini` engines accept
+a base-URL override, so provider traffic can route through an LLM gateway,
+a corporate egress proxy, a recording proxy in tests, or any
+OpenAI-compatible server:
+
+| Engine | Setting |
+| --- | --- |
+| `claude` | `ANTHROPIC_BASE_URL_OVERRIDE` |
+| `openai`, `openai-responses` | `OPENAI_BASE_URL_OVERRIDE` |
+| `google-gemini` | `GOOGLE_GEMINI_BASE_URL_OVERRIDE` |
+
+```dotenv
+# Route Claude traffic through a gateway
+ANTHROPIC_BASE_URL_OVERRIDE=https://llm-gateway.internal/anthropic
+
+# Point the openai engine at a local OpenAI-compatible server
+OPENAI_BASE_URL_OVERRIDE=http://localhost:11434/v1
+```
+
+Per client, when one process needs several destinations:
+
+```python
+client = AIFactory.get_ai_completions_client(
+    completions_engine="claude",
+    base_url="https://llm-gateway.internal/anthropic",
+)
+```
+
+Rules and rationale:
+
+- **https is required.** An override redirects your API keys to that host, so
+  plain `http://` is rejected with `AiProviderConfigurationError` unless the
+  host is `localhost`, `127.0.0.1`, or `::1` (local gateways and test
+  servers).
+- **The `_OVERRIDE` suffix is deliberate.** The OpenAI, Anthropic, and Google
+  SDKs read their own `OPENAI_BASE_URL`, `ANTHROPIC_BASE_URL`, and
+  `GOOGLE_GEMINI_BASE_URL` variables. Using distinct names, and passing the
+  resolved value to the SDK explicitly, keeps a stray native variable from
+  taking effect without the https check. (On `google-gemini` with no override
+  set, the SDK still resolves its own default, including those native
+  variables, which this library does not validate.)
+- **Precedence:** the `base_url` argument, then `<ENGINE>_BASE_URL_OVERRIDE`,
+  then (OpenAI only) the deprecated `OPENAI_BASE_URL` and geo-residency
+  routing, then the provider default.
+- **Organization lookups follow the override**, so finops attribution does not
+  bypass your gateway.
+- Engines without SDK support (Bedrock-routed, `titan`, `voyage`, voice)
+  raise `AiProviderCapabilityUnsupportedError` when passed `base_url`, rather
+  than ignoring it silently.
 
 ### Provider Authentication
 

--- a/env_template
+++ b/env_template
@@ -28,6 +28,10 @@ ANTHROPIC_ADMIN_KEY=
 # https:// unless it targets localhost/127.0.0.1/::1. Deliberately named
 # _OVERRIDE so it does not collide with the SDK's own ANTHROPIC_BASE_URL.
 ANTHROPIC_BASE_URL_OVERRIDE=
+# The Admin API key grants org-wide read/write, so it does NOT follow the
+# override above. Set this only if the admin lookup should also route through
+# a gateway (egress-restricted networks).
+ANTHROPIC_ADMIN_BASE_URL_OVERRIDE=
 # Geo-residency constraint (optional: US | USA | United States)
 AI_API_GEO_RESIDENCY=
 # --- Voyage AI (embeddings; used by EMBEDDING_ENGINE=voyage) ---

--- a/env_template
+++ b/env_template
@@ -12,6 +12,9 @@ EMBEDDING_ENGINE=google-gemini
 ########################################################################
 # --- OpenAI ---
 OPENAI_API_KEY=
+# Optional API base-URL override; also points the openai engine at any
+# OpenAI-compatible server. Same https rule as above.
+OPENAI_BASE_URL_OVERRIDE=
 # --- Anthropic (native Claude API; used by COMPLETIONS_ENGINE=claude) ---
 ANTHROPIC_API_KEY=
 # Optional Admin API key (sk-ant-admin...) for organization-level finops
@@ -20,11 +23,18 @@ ANTHROPIC_API_KEY=
 # id only, captured from one free count_tokens response header. Fails open:
 # cost events omit org identity if resolution fails.
 ANTHROPIC_ADMIN_KEY=
+# Optional API base-URL override for gateways, proxies, or local test
+# servers (LiteLLM, Helicone, Cloudflare AI Gateway, vLLM, Ollama). Must be
+# https:// unless it targets localhost/127.0.0.1/::1. Deliberately named
+# _OVERRIDE so it does not collide with the SDK's own ANTHROPIC_BASE_URL.
+ANTHROPIC_BASE_URL_OVERRIDE=
 # Geo-residency constraint (optional: US | USA | United States)
 AI_API_GEO_RESIDENCY=
 # --- Voyage AI (embeddings; used by EMBEDDING_ENGINE=voyage) ---
 VOYAGE_API_KEY=
 GOOGLE_GEMINI_API_KEY=
+# Optional API base-URL override for Gemini. Same https rule as above.
+GOOGLE_GEMINI_BASE_URL_OVERRIDE=
 GOOGLE_AUTH_METHOD=api_key
 # Completions engine (openai | openai-responses | claude | google-gemini | nova | anthropic | ...)
 COMPLETIONS_ENGINE=google-gemini

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@
 [project]
 name = "ai_api_unified"
 
-version = "2.19.0" # keep in sync with src/ai_api_unified/__version__.py and the README.md title
+version = "2.20.0" # keep in sync with src/ai_api_unified/__version__.py and the README.md title
 description = "Unified access layer for AI completions (LLM), embedding (semantic), image, video, and voice services"
 authors = [{ name = "Dave Thomas", email = "davidcthomas@gmail.com" }]
 license = "MIT"

--- a/src/ai_api_unified/__version__.py
+++ b/src/ai_api_unified/__version__.py
@@ -9,4 +9,4 @@ from __future__ import annotations
 
 __all__: list[str] = ["__version__"]
 
-__version__: str = "2.19.0"
+__version__: str = "2.20.0"

--- a/src/ai_api_unified/ai_anthropic_base.py
+++ b/src/ai_api_unified/ai_anthropic_base.py
@@ -18,6 +18,7 @@ from anthropic import Anthropic, AsyncAnthropic
 
 from ai_api_unified.ai_base import (
     AIProviderOrgInfoBase,
+    resolve_base_url_override,
     AIProviderOrgInfoCapability,
     ORG_INFO_SOURCE_ADMIN_API,
     ORG_INFO_SOURCE_NONE,
@@ -33,7 +34,9 @@ _LOGGER: logging.Logger = logging.getLogger(__name__)
 
 RETRY_POLICY_KEY: str = "COMPLETIONS_RETRY_POLICY"
 ANTHROPIC_ADMIN_KEY_SETTING: str = "ANTHROPIC_ADMIN_KEY"
-ANTHROPIC_ADMIN_ORGANIZATION_URL: str = "https://api.anthropic.com/v1/organizations/me"
+ANTHROPIC_BASE_URL_OVERRIDE_SETTING: str = "ANTHROPIC_BASE_URL_OVERRIDE"
+ANTHROPIC_DEFAULT_BASE_URL: str = "https://api.anthropic.com"
+ANTHROPIC_ADMIN_ORGANIZATION_PATH: str = "/v1/organizations/me"
 ANTHROPIC_API_VERSION: str = "2023-06-01"
 ANTHROPIC_ORG_ID_RESPONSE_HEADER: str = "anthropic-organization-id"
 ORG_RESOLUTION_TIMEOUT_SECONDS: float = 10.0
@@ -58,7 +61,13 @@ class AIAnthropicBase:
     retries so caller-owned backoff is the only retry layer.
     """
 
-    def __init__(self, *, retry_policy: str | None = None, **kwargs: Any):
+    def __init__(
+        self,
+        *,
+        retry_policy: str | None = None,
+        base_url: str | None = None,
+        **kwargs: Any,
+    ):
         """
         Initialize the AIAnthropicBase class with environment settings and API credentials.
 
@@ -66,6 +75,10 @@ class AIAnthropicBase:
             retry_policy: "default" keeps the Anthropic SDK's built-in retries;
                 "none" disables them (max_retries=0). Falls back to the
                 COMPLETIONS_RETRY_POLICY environment setting, then "default".
+            base_url: Optional API base-URL override (gateways, proxies,
+                local test servers). Falls back to
+                ANTHROPIC_BASE_URL_OVERRIDE, then the Anthropic default.
+                Must be https:// unless it targets a loopback host.
         """
         self.env = EnvSettings()
         self.api_key = self.env.get_setting("ANTHROPIC_API_KEY")
@@ -74,13 +87,26 @@ class AIAnthropicBase:
             raise ValueError("ANTHROPIC_API_KEY environment variable must be set.")
 
         self.retry_policy: str = self._resolve_retry_policy(retry_policy)
+        # Always pass base_url explicitly so the SDK's own ANTHROPIC_BASE_URL
+        # variable cannot take effect without passing the https validation.
+        self.base_url: str = (
+            resolve_base_url_override(
+                self.env,
+                str_env_key=ANTHROPIC_BASE_URL_OVERRIDE_SETTING,
+                str_explicit=base_url,
+            )
+            or ANTHROPIC_DEFAULT_BASE_URL
+        )
         int_max_retries: int | None = (
             0 if self.retry_policy == RETRY_POLICY_NONE else None
         )
-        if int_max_retries is None:
-            self.client = Anthropic(api_key=self.api_key)
-        else:
-            self.client = Anthropic(api_key=self.api_key, max_retries=int_max_retries)
+        dict_client_kwargs: dict[str, Any] = {
+            "api_key": self.api_key,
+            "base_url": self.base_url,
+        }
+        if int_max_retries is not None:
+            dict_client_kwargs["max_retries"] = int_max_retries
+        self.client = Anthropic(**dict_client_kwargs)
         # The async client is created lazily so purely synchronous consumers
         # never pay for an unused event-loop-bound transport.
         self._async_client: AsyncAnthropic | None = None
@@ -122,12 +148,13 @@ class AIAnthropicBase:
             int_max_retries: int | None = (
                 0 if self.retry_policy == RETRY_POLICY_NONE else None
             )
-            if int_max_retries is None:
-                self._async_client = AsyncAnthropic(api_key=self.api_key)
-            else:
-                self._async_client = AsyncAnthropic(
-                    api_key=self.api_key, max_retries=int_max_retries
-                )
+            dict_client_kwargs: dict[str, Any] = {
+                "api_key": self.api_key,
+                "base_url": self.base_url,
+            }
+            if int_max_retries is not None:
+                dict_client_kwargs["max_retries"] = int_max_retries
+            self._async_client = AsyncAnthropic(**dict_client_kwargs)
         # Normal return with the shared async client instance.
         return self._async_client
 
@@ -176,7 +203,7 @@ class AIAnthropicBase:
         """
         try:
             response: httpx.Response = httpx.get(
-                ANTHROPIC_ADMIN_ORGANIZATION_URL,
+                f"{self.base_url.rstrip('/')}{ANTHROPIC_ADMIN_ORGANIZATION_PATH}",
                 headers={
                     "x-api-key": self.admin_key,
                     "anthropic-version": ANTHROPIC_API_VERSION,

--- a/src/ai_api_unified/ai_anthropic_base.py
+++ b/src/ai_api_unified/ai_anthropic_base.py
@@ -35,6 +35,7 @@ _LOGGER: logging.Logger = logging.getLogger(__name__)
 RETRY_POLICY_KEY: str = "COMPLETIONS_RETRY_POLICY"
 ANTHROPIC_ADMIN_KEY_SETTING: str = "ANTHROPIC_ADMIN_KEY"
 ANTHROPIC_BASE_URL_OVERRIDE_SETTING: str = "ANTHROPIC_BASE_URL_OVERRIDE"
+ANTHROPIC_ADMIN_BASE_URL_OVERRIDE_SETTING: str = "ANTHROPIC_ADMIN_BASE_URL_OVERRIDE"
 ANTHROPIC_DEFAULT_BASE_URL: str = "https://api.anthropic.com"
 ANTHROPIC_ADMIN_ORGANIZATION_PATH: str = "/v1/organizations/me"
 ANTHROPIC_API_VERSION: str = "2023-06-01"
@@ -114,6 +115,17 @@ class AIAnthropicBase:
         # Optional Admin API key for organization-level finops attribution.
         self.admin_key: str = str(
             self.env.get_setting(ANTHROPIC_ADMIN_KEY_SETTING, "") or ""
+        )
+        # The admin key grants org-wide read/write, far beyond the inference
+        # key, so it does NOT follow ANTHROPIC_BASE_URL_OVERRIDE: routing
+        # inference through a gateway must not silently hand that gateway an
+        # org-administration credential. Sending it elsewhere is opt-in.
+        self.admin_base_url: str = (
+            resolve_base_url_override(
+                self.env,
+                str_env_key=ANTHROPIC_ADMIN_BASE_URL_OVERRIDE_SETTING,
+            )
+            or ANTHROPIC_DEFAULT_BASE_URL
         )
         # Org-identity caching (success cache + enrichment negative cache)
         # lives on AIBase; this base only implements the fetch hooks.
@@ -203,7 +215,8 @@ class AIAnthropicBase:
         """
         try:
             response: httpx.Response = httpx.get(
-                f"{self.base_url.rstrip('/')}{ANTHROPIC_ADMIN_ORGANIZATION_PATH}",
+                f"{self.admin_base_url.rstrip('/')}"
+                f"{ANTHROPIC_ADMIN_ORGANIZATION_PATH}",
                 headers={
                     "x-api-key": self.admin_key,
                     "anthropic-version": ANTHROPIC_API_VERSION,

--- a/src/ai_api_unified/ai_base.py
+++ b/src/ai_api_unified/ai_base.py
@@ -9,6 +9,7 @@ import math
 import mimetypes
 import tempfile
 import time
+import urllib.parse
 import uuid
 from abc import ABC, abstractmethod
 from collections.abc import Callable
@@ -354,6 +355,78 @@ class AIProviderOrgInfoCapability(BaseModel):
     supports_org_id: bool = False
     supports_org_name: bool = False
     requirement: str | None = None
+
+
+BASE_URL_OVERRIDE_LOCAL_HOSTS: tuple[str, ...] = ("localhost", "127.0.0.1", "::1")
+
+
+def validate_base_url_override(str_base_url: str, *, str_env_key: str) -> str:
+    """
+    Validates one base-URL override before any credential is sent to it.
+
+    A base-URL override redirects provider traffic — including API keys — to
+    the supplied host, so it must be HTTPS. Plain http:// is permitted only
+    for loopback hosts, which covers local gateways and recording proxies.
+
+    Args:
+        str_base_url: Raw override value from configuration or a caller.
+        str_env_key: Setting name quoted in errors so the fix is obvious.
+
+    Returns:
+        The trimmed, validated base URL.
+
+    Raises:
+        AiProviderConfigurationError: When the URL is malformed or would send
+            credentials over plaintext to a non-loopback host.
+    """
+    str_trimmed: str = str_base_url.strip()
+    parsed = urllib.parse.urlparse(str_trimmed)
+    if parsed.scheme not in ("https", "http") or not parsed.hostname:
+        raise AiProviderConfigurationError(
+            f"{str_env_key} must be an absolute http(s) URL; got {str_base_url!r}."
+        )
+    if parsed.scheme == "http" and parsed.hostname not in BASE_URL_OVERRIDE_LOCAL_HOSTS:
+        raise AiProviderConfigurationError(
+            f"{str_env_key} must use https:// so provider credentials are not "
+            f"sent in plaintext; got {str_base_url!r}. Plain http:// is allowed "
+            f"only for {', '.join(BASE_URL_OVERRIDE_LOCAL_HOSTS)}."
+        )
+    # Normal return with the validated override URL.
+    return str_trimmed
+
+
+def resolve_base_url_override(
+    env_settings: Any,
+    *,
+    str_env_key: str,
+    str_explicit: str | None = None,
+) -> str | None:
+    """
+    Resolves a validated base-URL override from a caller argument or config.
+
+    Precedence: explicit argument, then the `<ENGINE>_BASE_URL_OVERRIDE`
+    setting. The override name is deliberately distinct from the provider
+    SDKs' own base-URL environment variables (OPENAI_BASE_URL,
+    ANTHROPIC_BASE_URL, GOOGLE_GEMINI_BASE_URL): engines pass the resolved
+    value to the SDK explicitly, so a native variable can never take effect
+    unvalidated and bypass the https check.
+
+    Args:
+        env_settings: EnvSettings-like accessor exposing get_setting.
+        str_env_key: Override setting name for this engine.
+        str_explicit: Optional caller-supplied override.
+
+    Returns:
+        Validated override URL, or None when no override is configured.
+    """
+    str_candidate: str = str_explicit or ""
+    if not str_candidate.strip():
+        str_candidate = str(env_settings.get_setting(str_env_key, "") or "")
+    if not str_candidate.strip():
+        # Early return because no override is configured.
+        return None
+    # Normal return with the validated override URL.
+    return validate_base_url_override(str_candidate, str_env_key=str_env_key)
 
 
 def normalize_retry_policy(retry_policy: str) -> str:

--- a/src/ai_api_unified/ai_base.py
+++ b/src/ai_api_unified/ai_base.py
@@ -360,6 +360,22 @@ class AIProviderOrgInfoCapability(BaseModel):
 BASE_URL_OVERRIDE_LOCAL_HOSTS: tuple[str, ...] = ("localhost", "127.0.0.1", "::1")
 
 
+def _redact_url_for_error(str_base_url: str, parsed: Any) -> str:
+    """
+    Builds a display form of a URL safe to place in errors and logs.
+
+    Gateway URLs legitimately carry secrets in userinfo or query strings, and
+    configuration errors surface in logs and tracebacks, so only the scheme,
+    host, and port are echoed back.
+    """
+    if not parsed.hostname:
+        # Early return because a malformed value has no host to show.
+        return "<malformed url>"
+    str_port: str = f":{parsed.port}" if parsed.port else ""
+    # Normal return with scheme, host, and port only.
+    return f"{parsed.scheme}://{parsed.hostname}{str_port}"
+
+
 def validate_base_url_override(str_base_url: str, *, str_env_key: str) -> str:
     """
     Validates one base-URL override before any credential is sent to it.
@@ -383,13 +399,15 @@ def validate_base_url_override(str_base_url: str, *, str_env_key: str) -> str:
     parsed = urllib.parse.urlparse(str_trimmed)
     if parsed.scheme not in ("https", "http") or not parsed.hostname:
         raise AiProviderConfigurationError(
-            f"{str_env_key} must be an absolute http(s) URL; got {str_base_url!r}."
+            f"{str_env_key} must be an absolute http(s) URL; got "
+            f"{_redact_url_for_error(str_trimmed, parsed)}."
         )
     if parsed.scheme == "http" and parsed.hostname not in BASE_URL_OVERRIDE_LOCAL_HOSTS:
         raise AiProviderConfigurationError(
             f"{str_env_key} must use https:// so provider credentials are not "
-            f"sent in plaintext; got {str_base_url!r}. Plain http:// is allowed "
-            f"only for {', '.join(BASE_URL_OVERRIDE_LOCAL_HOSTS)}."
+            f"sent in plaintext; got "
+            f"{_redact_url_for_error(str_trimmed, parsed)}. Plain http:// is "
+            f"allowed only for {', '.join(BASE_URL_OVERRIDE_LOCAL_HOSTS)}."
         )
     # Normal return with the validated override URL.
     return str_trimmed

--- a/src/ai_api_unified/ai_factory.py
+++ b/src/ai_api_unified/ai_factory.py
@@ -10,9 +10,11 @@ from __future__ import annotations
 import importlib.machinery
 import importlib.util
 import logging
+from typing import Any
 
 from .ai_base import AIBaseCompletions, AIBaseEmbeddings, AIBaseImages, AIBaseVideos
 from .ai_provider_exceptions import (
+    AiProviderCapabilityUnsupportedError,
     AiProviderConfigurationError,
     AiProviderDependencyUnavailableError,
     AiProviderRuntimeError,
@@ -44,6 +46,14 @@ EMBEDDING_DIMENSIONS_KEY: str = "EMBEDDING_DIMENSIONS"
 IMAGE_MODEL_NAME_KEY: str = "IMAGE_MODEL_NAME"
 IMAGE_ENGINE_KEY: str = "IMAGE_ENGINE"
 VIDEO_MODEL_NAME_KEY: str = "VIDEO_MODEL_NAME"
+# Engines whose provider SDK accepts a base-URL override. Others ignore the
+# argument silently, so the factory rejects it for them instead.
+FROZENSET_BASE_URL_OVERRIDE_COMPLETIONS_ENGINES: frozenset[str] = frozenset(
+    {"claude", "openai", "openai-responses", "google-gemini"}
+)
+FROZENSET_BASE_URL_OVERRIDE_EMBEDDING_ENGINES: frozenset[str] = frozenset(
+    {"openai", "google-gemini"}
+)
 VIDEO_ENGINE_KEY: str = "VIDEO_ENGINE"
 
 
@@ -240,6 +250,7 @@ class AIFactory:
     def get_ai_completions_client(
         model_name: str | None = None,
         completions_engine: str | None = None,
+        base_url: str | None = None,
     ) -> AIBaseCompletions:
         """
         Instantiates the configured completions client.
@@ -280,8 +291,17 @@ class AIFactory:
                 AIBaseCompletions,
             )
             # Instantiate the resolved class only after lazy-load validation succeeds.
+            dict_client_kwargs: dict[str, Any] = {"model": str_model_name}
+            if base_url is not None:
+                AIFactory._require_base_url_override_support(
+                    str_engine=str_engine,
+                    frozenset_supported=(
+                        FROZENSET_BASE_URL_OVERRIDE_COMPLETIONS_ENGINES
+                    ),
+                )
+                dict_client_kwargs["base_url"] = base_url
             completions_client: AIBaseCompletions = class_completions_client(
-                model=str_model_name
+                **dict_client_kwargs
             )
             # Normal return with configured completions provider client.
             return completions_client
@@ -296,6 +316,31 @@ class AIFactory:
             raise
         except AiProviderRuntimeError:
             raise
+
+    @staticmethod
+    def _require_base_url_override_support(
+        *,
+        str_engine: str,
+        frozenset_supported: frozenset[str],
+    ) -> None:
+        """
+        Rejects a base-URL override for engines whose SDK cannot honor it.
+
+        Args:
+            str_engine: Resolved engine selector token.
+            frozenset_supported: Engines whose SDK accepts a base URL.
+
+        Raises:
+            AiProviderCapabilityUnsupportedError: When the engine cannot
+                honor a base-URL override.
+        """
+        if str_engine in frozenset_supported:
+            # Normal return because this engine honors the override.
+            return None
+        raise AiProviderCapabilityUnsupportedError(
+            f"Engine {str_engine!r} does not support a base-URL override. "
+            f"Supported engines: {', '.join(sorted(frozenset_supported))}."
+        )
 
     @staticmethod
     def get_ai_embedding_client(

--- a/src/ai_api_unified/ai_factory.py
+++ b/src/ai_api_unified/ai_factory.py
@@ -51,9 +51,6 @@ VIDEO_MODEL_NAME_KEY: str = "VIDEO_MODEL_NAME"
 FROZENSET_BASE_URL_OVERRIDE_COMPLETIONS_ENGINES: frozenset[str] = frozenset(
     {"claude", "openai", "openai-responses", "google-gemini"}
 )
-FROZENSET_BASE_URL_OVERRIDE_EMBEDDING_ENGINES: frozenset[str] = frozenset(
-    {"openai", "google-gemini"}
-)
 VIDEO_ENGINE_KEY: str = "VIDEO_ENGINE"
 
 

--- a/src/ai_api_unified/ai_google_base.py
+++ b/src/ai_api_unified/ai_google_base.py
@@ -14,6 +14,7 @@ from ai_api_unified.ai_base import (
     AIProviderOrgInfoCapability,
     ORG_INFO_SOURCE_CONFIGURATION,
     ORG_INFO_SOURCE_NONE,
+    resolve_base_url_override,
 )
 from google.api_core import exceptions as gexc  # Provided by google-* libs
 from google.auth.exceptions import DefaultCredentialsError
@@ -21,6 +22,8 @@ from google.genai import errors as gerr
 from google.genai import pagers
 
 from ai_api_unified.util.env_settings import EnvSettings
+
+GOOGLE_BASE_URL_OVERRIDE_SETTING: str = "GOOGLE_GEMINI_BASE_URL_OVERRIDE"
 
 T = TypeVar("T")
 
@@ -96,6 +99,7 @@ class AIGoogleBase:
         model: str,
         *,
         use_api_key: bool = False,
+        base_url: str | None = None,
     ) -> genai.Client:
         """
         Initialize the Google Gemini client with either Vertex AI credentials or an API key.
@@ -106,6 +110,13 @@ class AIGoogleBase:
             Model identifier to validate once the client is created.
         use_api_key:
             Backward-compatible explicit override that forces API-key mode.
+        base_url:
+            Optional API base-URL override (gateways, proxies, local test
+            servers), falling back to GOOGLE_GEMINI_BASE_URL_OVERRIDE. Must
+            be https:// unless it targets a loopback host. When unset, the
+            google-genai SDK resolves its own default, including its native
+            GOOGLE_GEMINI_BASE_URL / GOOGLE_VERTEX_BASE_URL variables, which
+            this library does not validate.
         """
 
         env_settings: EnvSettings = EnvSettings()
@@ -113,6 +124,16 @@ class AIGoogleBase:
             env_settings,
             use_api_key=use_api_key,
         )
+        str_base_url: str | None = resolve_base_url_override(
+            env_settings,
+            str_env_key=GOOGLE_BASE_URL_OVERRIDE_SETTING,
+            str_explicit=base_url,
+        )
+        dict_client_kwargs: dict[str, Any] = {}
+        if str_base_url:
+            dict_client_kwargs["http_options"] = genai.types.HttpOptions(
+                base_url=str_base_url
+            )
 
         try:
             if auth_method == self.GOOGLE_AUTH_METHOD_API_KEY:
@@ -123,7 +144,9 @@ class AIGoogleBase:
                     raise RuntimeError(
                         "GOOGLE_GEMINI_API_KEY is not configured but API-key auth was selected."
                     )
-                client: genai.Client = genai.Client(api_key=api_key)
+                client: genai.Client = genai.Client(
+                    api_key=api_key, **dict_client_kwargs
+                )
             else:
                 project_id: str = env_settings.get_setting("GOOGLE_PROJECT_ID", "")
                 location: str = env_settings.get_setting(
@@ -133,6 +156,7 @@ class AIGoogleBase:
                     vertexai=True,
                     project=project_id,
                     location=location,
+                    **dict_client_kwargs,
                 )
 
             try:

--- a/src/ai_api_unified/ai_openai_base.py
+++ b/src/ai_api_unified/ai_openai_base.py
@@ -7,6 +7,7 @@ import httpx
 from openai import AsyncOpenAI, OpenAI
 from ai_api_unified.ai_base import (
     AIProviderOrgInfoBase,
+    resolve_base_url_override,
     AIProviderOrgInfoCapability,
     ORG_INFO_SOURCE_ACCOUNT_API,
     ORG_INFO_SOURCE_NONE,
@@ -21,7 +22,8 @@ from ai_api_unified.util.env_settings import EnvSettings
 _LOGGER: logging.Logger = logging.getLogger(__name__)
 
 RETRY_POLICY_KEY: str = "COMPLETIONS_RETRY_POLICY"
-OPENAI_ME_URL: str = "https://api.openai.com/v1/me"
+OPENAI_BASE_URL_OVERRIDE_SETTING: str = "OPENAI_BASE_URL_OVERRIDE"
+OPENAI_ME_PATH: str = "/me"
 OPENAI_ORG_ID_RESPONSE_HEADER: str = "openai-organization"
 ORG_RESOLUTION_TIMEOUT_SECONDS: float = 10.0
 
@@ -43,7 +45,13 @@ class AIOpenAIBase:
     DEFAULT_OPENAI_BASE_URL: str = "https://api.openai.com/v1"
     OPENAI_US_BASE_URL: str = "https://us.api.openai.com/v1"
 
-    def __init__(self, *, retry_policy: str | None = None, **kwargs: Any):
+    def __init__(
+        self,
+        *,
+        retry_policy: str | None = None,
+        base_url: str | None = None,
+        **kwargs: Any,
+    ):
         """
         Initialize the AIOpenAIBase class with environment settings and API credentials.
 
@@ -51,13 +59,18 @@ class AIOpenAIBase:
             retry_policy: "default" keeps the OpenAI SDK's built-in retries;
                 "none" disables them (max_retries=0). Falls back to the
                 COMPLETIONS_RETRY_POLICY environment setting, then "default".
+            base_url: Optional API base-URL override (gateways, proxies,
+                OpenAI-compatible servers). Falls back to
+                OPENAI_BASE_URL_OVERRIDE, the deprecated OPENAI_BASE_URL,
+                geo-residency routing, then the OpenAI default. Must be
+                https:// unless it targets a loopback host.
         """
         self.env = EnvSettings()
         self.api_key = self.env.get_setting("OPENAI_API_KEY")
         self.user = self.env.get_setting("OPENAI_USER", "default_user")
         if not self.api_key or self.api_key.strip() == "":
             raise ValueError("OPENAI_API_KEY environment variable must be set.")
-        self.base_url = self.get_api_base_url()
+        self.base_url = self.get_api_base_url(base_url=base_url)
 
         str_candidate: str = (
             retry_policy
@@ -93,9 +106,26 @@ class AIOpenAIBase:
         # Normal return with the shared async client instance.
         return self._async_client
 
-    def get_api_base_url(self) -> str:
-        """Resolve the OpenAI base URL based on data residency constraints."""
+    def get_api_base_url(self, *, base_url: str | None = None) -> str:
+        """
+        Resolve the OpenAI base URL.
+
+        Precedence: the caller argument, then OPENAI_BASE_URL_OVERRIDE, then
+        the deprecated OPENAI_BASE_URL, then geo-residency routing, then the
+        OpenAI default. The override is validated (https, or loopback) and
+        always passed to the SDK explicitly, so the SDK's own OPENAI_BASE_URL
+        variable cannot take effect unvalidated.
+        """
         env: EnvSettings = EnvSettings()
+
+        str_validated_override: str | None = resolve_base_url_override(
+            env,
+            str_env_key=OPENAI_BASE_URL_OVERRIDE_SETTING,
+            str_explicit=base_url,
+        )
+        if str_validated_override:
+            # Early return with the validated override.
+            return str_validated_override
 
         override_url: str | None = env.get_setting("OPENAI_BASE_URL")
         if override_url:
@@ -156,7 +186,7 @@ class AIOpenAIBase:
         """
         try:
             response: httpx.Response = httpx.get(
-                OPENAI_ME_URL,
+                f"{self.base_url.rstrip('/')}{OPENAI_ME_PATH}",
                 headers={"Authorization": f"Bearer {self.api_key}"},
                 timeout=ORG_RESOLUTION_TIMEOUT_SECONDS,
             )

--- a/src/ai_api_unified/ai_openai_base.py
+++ b/src/ai_api_unified/ai_openai_base.py
@@ -8,6 +8,7 @@ from openai import AsyncOpenAI, OpenAI
 from ai_api_unified.ai_base import (
     AIProviderOrgInfoBase,
     resolve_base_url_override,
+    validate_base_url_override,
     AIProviderOrgInfoCapability,
     ORG_INFO_SOURCE_ACCOUNT_API,
     ORG_INFO_SOURCE_NONE,
@@ -130,9 +131,15 @@ class AIOpenAIBase:
         override_url: str | None = env.get_setting("OPENAI_BASE_URL")
         if override_url:
             _LOGGER.warning(
-                "OPENAI_BASE_URL is deprecated. Please use AI_API_GEO_RESIDENCY instead.",
+                "OPENAI_BASE_URL is deprecated. Please use "
+                "OPENAI_BASE_URL_OVERRIDE (or AI_API_GEO_RESIDENCY) instead.",
             )
-            return override_url
+            # Validated like the new override: this is the SDK's own variable
+            # name, so other tooling may set it process-wide, and it feeds
+            # credential-bearing requests including the org lookup.
+            return validate_base_url_override(
+                override_url, str_env_key="OPENAI_BASE_URL"
+            )
 
         geo_residency: str | None = (
             env.get_geo_residency()

--- a/src/ai_api_unified/completions/ai_google_gemini_completions.py
+++ b/src/ai_api_unified/completions/ai_google_gemini_completions.py
@@ -128,7 +128,12 @@ class GoogleGeminiCompletions(AIBaseCompletions, AIGoogleBase):
     """
 
     def __init__(
-        self, model: str = "", *, retry_policy: str | None = None, **kwargs: Any
+        self,
+        model: str = "",
+        *,
+        retry_policy: str | None = None,
+        base_url: str | None = None,
+        **kwargs: Any,
     ) -> None:
         """
         Initialize Google Gemini completions client.
@@ -139,9 +144,14 @@ class GoogleGeminiCompletions(AIBaseCompletions, AIGoogleBase):
                 retries; "none" disables them (single attempt). Falls back to
                 the COMPLETIONS_RETRY_POLICY environment setting, then
                 "default".
+            base_url: Optional API base-URL override (gateways, proxies,
+                local test servers). Falls back to
+                GOOGLE_GEMINI_BASE_URL_OVERRIDE. Must be https:// unless it
+                targets a loopback host.
             dimensions: Not used for completions but kept for interface compatibility
         """
         AIGoogleBase.__init__(self, **kwargs)
+        self._str_base_url_override: str | None = base_url
         self.env: EnvSettings = EnvSettings()
         str_retry_candidate: str = (
             retry_policy
@@ -191,7 +201,10 @@ class GoogleGeminiCompletions(AIBaseCompletions, AIGoogleBase):
         """Initialize the Google Gemini client with proper authentication."""
         ai_google_base_module.genai = genai
         ai_google_base_module.gerr = gerr
-        self.client = self.get_client(model=self.completions_model)
+        self.client = self.get_client(
+            model=self.completions_model,
+            base_url=getattr(self, "_str_base_url_override", None),
+        )
 
     @property
     def model_name(self) -> str:

--- a/tests/area_map.py
+++ b/tests/area_map.py
@@ -53,6 +53,12 @@ AREAS: tuple[str, ...] = (
 DICT_TEST_FILE_AREAS: dict[str, tuple[str, ...]] = {
     # Core factory/registry/config surface
     "test_ai_api.py": ("core",),
+    "test_base_url_override.py": (
+        "core",
+        "engine_anthropic",
+        "engine_openai",
+        "engine_gemini",
+    ),
     "test_ai_factory_provider_loading.py": ("core",),
     "test_ai_provider_loader.py": ("core",),
     "test_ai_provider_registry.py": ("core",),

--- a/tests/test_base_url_override.py
+++ b/tests/test_base_url_override.py
@@ -1,0 +1,336 @@
+# test_base_url_override.py
+"""
+Tests for per-engine API base-URL overrides (anthropic, openai, gemini).
+
+The override redirects provider traffic — including credentials — so it is
+validated as https (loopback exempt) and always passed to the SDK explicitly,
+which keeps the SDKs' own base-URL environment variables from taking effect
+unvalidated.
+"""
+
+import os
+from unittest.mock import Mock, patch
+
+import pytest
+
+from ai_api_unified.ai_base import (
+    resolve_base_url_override,
+    validate_base_url_override,
+)
+from ai_api_unified.ai_provider_exceptions import (
+    AiProviderCapabilityUnsupportedError,
+    AiProviderConfigurationError,
+)
+
+
+class _StubEnv:
+    def __init__(self, **values: str) -> None:
+        self._values = values
+
+    def get_setting(self, key: str, default=None):
+        return self._values.get(key, default)
+
+
+class TestValidation:
+    def test_https_accepted(self):
+        assert (
+            validate_base_url_override("https://gw.internal/v1", str_env_key="X")
+            == "https://gw.internal/v1"
+        )
+
+    def test_whitespace_trimmed(self):
+        assert (
+            validate_base_url_override("  https://gw.internal/v1  ", str_env_key="X")
+            == "https://gw.internal/v1"
+        )
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "http://localhost:8000/v1",
+            "http://127.0.0.1:11434/v1",
+            "http://[::1]:8080/v1",
+        ],
+    )
+    def test_loopback_http_accepted(self, url):
+        assert validate_base_url_override(url, str_env_key="X") == url
+
+    def test_plaintext_remote_rejected(self):
+        with pytest.raises(AiProviderConfigurationError, match="https"):
+            validate_base_url_override("http://gw.example.com/v1", str_env_key="X")
+
+    @pytest.mark.parametrize("url", ["not-a-url", "ftp://host/v1", "/relative/path"])
+    def test_malformed_rejected(self, url):
+        with pytest.raises(AiProviderConfigurationError):
+            validate_base_url_override(url, str_env_key="X")
+
+    def test_error_names_the_setting(self):
+        with pytest.raises(AiProviderConfigurationError, match="MY_OVERRIDE"):
+            validate_base_url_override("http://evil.example", str_env_key="MY_OVERRIDE")
+
+
+class TestResolution:
+    def test_explicit_argument_wins_over_env(self):
+        env = _StubEnv(X="https://from-env/v1")
+        assert (
+            resolve_base_url_override(
+                env, str_env_key="X", str_explicit="https://from-arg/v1"
+            )
+            == "https://from-arg/v1"
+        )
+
+    def test_env_used_when_no_argument(self):
+        env = _StubEnv(X="https://from-env/v1")
+        assert resolve_base_url_override(env, str_env_key="X") == "https://from-env/v1"
+
+    def test_none_when_unconfigured(self):
+        assert resolve_base_url_override(_StubEnv(), str_env_key="X") is None
+
+    def test_blank_env_treated_as_unset(self):
+        assert resolve_base_url_override(_StubEnv(X="   "), str_env_key="X") is None
+
+    def test_env_value_is_validated(self):
+        with pytest.raises(AiProviderConfigurationError):
+            resolve_base_url_override(
+                _StubEnv(X="http://evil.example"), str_env_key="X"
+            )
+
+
+# ── Anthropic ───────────────────────────────────────────────────────────────
+
+anthropic = pytest.importorskip("anthropic")
+
+from ai_api_unified.completions.ai_anthropic_completions import (  # noqa: E402
+    AiAnthropicCompletions,
+)
+
+
+class TestAnthropicOverride:
+    def test_default_base_url_passed_explicitly(self):
+        # Explicit passing is what keeps the SDK's native ANTHROPIC_BASE_URL
+        # from taking effect without validation.
+        with patch.dict(
+            os.environ,
+            {"ANTHROPIC_API_KEY": "k", "ANTHROPIC_BASE_URL_OVERRIDE": ""},
+        ):
+            with patch("ai_api_unified.ai_anthropic_base.Anthropic") as mock_cls:
+                AiAnthropicCompletions(model="claude-opus-4-8")
+        assert mock_cls.call_args.kwargs["base_url"] == "https://api.anthropic.com"
+
+    def test_env_override_applied(self):
+        with patch.dict(
+            os.environ,
+            {
+                "ANTHROPIC_API_KEY": "k",
+                "ANTHROPIC_BASE_URL_OVERRIDE": "https://gw.internal/anthropic",
+            },
+        ):
+            with patch("ai_api_unified.ai_anthropic_base.Anthropic") as mock_cls:
+                client = AiAnthropicCompletions(model="claude-opus-4-8")
+        assert mock_cls.call_args.kwargs["base_url"] == "https://gw.internal/anthropic"
+        assert client.base_url == "https://gw.internal/anthropic"
+
+    def test_constructor_argument_wins(self):
+        with patch.dict(
+            os.environ,
+            {
+                "ANTHROPIC_API_KEY": "k",
+                "ANTHROPIC_BASE_URL_OVERRIDE": "https://from-env/v1",
+            },
+        ):
+            with patch("ai_api_unified.ai_anthropic_base.Anthropic") as mock_cls:
+                AiAnthropicCompletions(
+                    model="claude-opus-4-8", base_url="https://from-arg/v1"
+                )
+        assert mock_cls.call_args.kwargs["base_url"] == "https://from-arg/v1"
+
+    def test_plaintext_override_rejected_at_construction(self):
+        with patch.dict(
+            os.environ,
+            {
+                "ANTHROPIC_API_KEY": "k",
+                "ANTHROPIC_BASE_URL_OVERRIDE": "http://evil.example/v1",
+            },
+        ):
+            with pytest.raises(AiProviderConfigurationError):
+                AiAnthropicCompletions(model="claude-opus-4-8")
+
+    def test_admin_org_lookup_follows_override(self):
+        # The org-identity fetch must go through the gateway too, not the
+        # hardcoded vendor host.
+        with patch.dict(
+            os.environ,
+            {
+                "ANTHROPIC_API_KEY": "k",
+                "ANTHROPIC_ADMIN_KEY": "admin",
+                "ANTHROPIC_BASE_URL_OVERRIDE": "https://gw.internal/anthropic",
+            },
+        ):
+            with patch("ai_api_unified.ai_anthropic_base.Anthropic"):
+                client = AiAnthropicCompletions(model="claude-opus-4-8")
+            response = Mock(status_code=200)
+            response.json.return_value = {"id": "org_1", "name": "Acme"}
+            with patch(
+                "ai_api_unified.ai_anthropic_base.httpx.get", return_value=response
+            ) as mock_get:
+                client.get_org_info()
+        assert (
+            mock_get.call_args.args[0]
+            == "https://gw.internal/anthropic/v1/organizations/me"
+        )
+
+
+# ── OpenAI ──────────────────────────────────────────────────────────────────
+
+openai_sdk = pytest.importorskip("openai")
+
+from ai_api_unified.completions.ai_openai_completions import (  # noqa: E402
+    AiOpenAICompletions,
+)
+
+
+class TestOpenAIOverride:
+    def test_env_override_wins_over_geo_residency(self):
+        with patch.dict(
+            os.environ,
+            {
+                "OPENAI_API_KEY": "k",
+                "OPENAI_BASE_URL_OVERRIDE": "https://gw.internal/openai",
+                "AI_API_GEO_RESIDENCY": "US",
+                "OPENAI_BASE_URL": "",
+            },
+        ):
+            with patch("ai_api_unified.ai_openai_base.OpenAI") as mock_cls:
+                client = AiOpenAICompletions(model="gpt-4o-mini")
+        assert mock_cls.call_args.kwargs["base_url"] == "https://gw.internal/openai"
+        assert client.base_url == "https://gw.internal/openai"
+
+    def test_geo_residency_still_applies_without_override(self):
+        with patch.dict(
+            os.environ,
+            {
+                "OPENAI_API_KEY": "k",
+                "OPENAI_BASE_URL_OVERRIDE": "",
+                "OPENAI_BASE_URL": "",
+                "AI_API_GEO_RESIDENCY": "US",
+            },
+        ):
+            with patch("ai_api_unified.ai_openai_base.OpenAI") as mock_cls:
+                AiOpenAICompletions(model="gpt-4o-mini")
+        assert (
+            mock_cls.call_args.kwargs["base_url"]
+            == AiOpenAICompletions.OPENAI_US_BASE_URL
+        )
+
+    def test_openai_compatible_local_server(self):
+        # The headline use case: point the openai engine at any
+        # OpenAI-compatible server (Ollama, vLLM, LiteLLM).
+        with patch.dict(
+            os.environ,
+            {
+                "OPENAI_API_KEY": "k",
+                "OPENAI_BASE_URL_OVERRIDE": "http://localhost:11434/v1",
+            },
+        ):
+            with patch("ai_api_unified.ai_openai_base.OpenAI") as mock_cls:
+                AiOpenAICompletions(model="gpt-4o-mini")
+        assert mock_cls.call_args.kwargs["base_url"] == "http://localhost:11434/v1"
+
+    def test_account_org_lookup_follows_override(self):
+        with patch.dict(
+            os.environ,
+            {
+                "OPENAI_API_KEY": "k",
+                "OPENAI_BASE_URL_OVERRIDE": "https://gw.internal/openai",
+            },
+        ):
+            with patch("ai_api_unified.ai_openai_base.OpenAI"):
+                client = AiOpenAICompletions(model="gpt-4o-mini")
+            response = Mock(status_code=200)
+            response.json.return_value = {
+                "orgs": {"data": [{"id": "org-1", "title": "Acme", "is_default": True}]}
+            }
+            with patch(
+                "ai_api_unified.ai_openai_base.httpx.get", return_value=response
+            ) as mock_get:
+                client.get_org_info()
+        assert mock_get.call_args.args[0] == "https://gw.internal/openai/me"
+
+
+# ── Gemini ──────────────────────────────────────────────────────────────────
+
+pytest.importorskip("google.genai")
+
+from ai_api_unified.ai_google_base import AIGoogleBase  # noqa: E402
+
+
+class TestGeminiOverride:
+    def test_http_options_carry_override(self):
+        base = AIGoogleBase()
+        with patch.dict(
+            os.environ,
+            {
+                "GOOGLE_GEMINI_API_KEY": "k",
+                "GOOGLE_AUTH_METHOD": "api_key",
+                "GOOGLE_GEMINI_BASE_URL_OVERRIDE": "https://gw.internal/gemini",
+            },
+        ):
+            with patch("ai_api_unified.ai_google_base.genai") as mock_genai:
+                mock_genai.types.HttpOptions = lambda **kw: kw
+                base.get_client(model="gemini-2.5-flash")
+        kwargs = mock_genai.Client.call_args.kwargs
+        assert kwargs["http_options"] == {"base_url": "https://gw.internal/gemini"}
+
+    def test_no_http_options_without_override(self):
+        base = AIGoogleBase()
+        with patch.dict(
+            os.environ,
+            {
+                "GOOGLE_GEMINI_API_KEY": "k",
+                "GOOGLE_AUTH_METHOD": "api_key",
+                "GOOGLE_GEMINI_BASE_URL_OVERRIDE": "",
+            },
+        ):
+            with patch("ai_api_unified.ai_google_base.genai") as mock_genai:
+                base.get_client(model="gemini-2.5-flash")
+        assert "http_options" not in mock_genai.Client.call_args.kwargs
+
+    def test_plaintext_override_rejected(self):
+        base = AIGoogleBase()
+        with patch.dict(
+            os.environ,
+            {
+                "GOOGLE_GEMINI_API_KEY": "k",
+                "GOOGLE_AUTH_METHOD": "api_key",
+                "GOOGLE_GEMINI_BASE_URL_OVERRIDE": "http://evil.example/v1",
+            },
+        ):
+            with pytest.raises(AiProviderConfigurationError):
+                base.get_client(model="gemini-2.5-flash")
+
+
+# ── Factory ─────────────────────────────────────────────────────────────────
+
+from ai_api_unified import AIFactory  # noqa: E402
+
+
+class TestFactoryOverride:
+    def test_factory_passes_override_to_supported_engine(self):
+        with patch.dict(os.environ, {"ANTHROPIC_API_KEY": "k"}):
+            with patch("ai_api_unified.ai_anthropic_base.Anthropic") as mock_cls:
+                AIFactory.get_ai_completions_client(
+                    model_name="claude-opus-4-8",
+                    completions_engine="claude",
+                    base_url="https://gw.internal/anthropic",
+                )
+        assert mock_cls.call_args.kwargs["base_url"] == "https://gw.internal/anthropic"
+
+    def test_unsupported_engine_rejects_override(self):
+        # Silently ignoring the argument would send traffic to the vendor
+        # while the caller believed it was proxied.
+        with pytest.raises(AiProviderCapabilityUnsupportedError, match="base-URL"):
+            AIFactory.get_ai_completions_client(
+                model_name="amazon.nova-lite-v1:0",
+                completions_engine="nova",
+                base_url="https://gw.internal/bedrock",
+            )

--- a/tests/test_base_url_override.py
+++ b/tests/test_base_url_override.py
@@ -69,6 +69,21 @@ class TestValidation:
             validate_base_url_override("http://evil.example", str_env_key="MY_OVERRIDE")
 
 
+class TestErrorRedaction:
+    def test_credentials_in_url_are_not_echoed(self):
+        # Gateway URLs can carry secrets in userinfo or query strings, and
+        # config errors land in logs and tracebacks.
+        with pytest.raises(AiProviderConfigurationError) as exc_info:
+            validate_base_url_override(
+                "http://user:sk-secret-token@gw.example.com/v1?api-key=sk-another",
+                str_env_key="X",
+            )
+        str_message = str(exc_info.value)
+        assert "sk-secret-token" not in str_message
+        assert "sk-another" not in str_message
+        assert "gw.example.com" in str_message
+
+
 class TestResolution:
     def test_explicit_argument_wins_over_env(self):
         env = _StubEnv(X="https://from-env/v1")
@@ -155,15 +170,17 @@ class TestAnthropicOverride:
             with pytest.raises(AiProviderConfigurationError):
                 AiAnthropicCompletions(model="claude-opus-4-8")
 
-    def test_admin_org_lookup_follows_override(self):
-        # The org-identity fetch must go through the gateway too, not the
-        # hardcoded vendor host.
+    def test_admin_key_does_not_follow_the_inference_override(self):
+        # The admin key grants org-wide read/write. Routing inference through
+        # a gateway must not silently hand that gateway an administration
+        # credential, so the admin lookup stays on the vendor host.
         with patch.dict(
             os.environ,
             {
                 "ANTHROPIC_API_KEY": "k",
                 "ANTHROPIC_ADMIN_KEY": "admin",
                 "ANTHROPIC_BASE_URL_OVERRIDE": "https://gw.internal/anthropic",
+                "ANTHROPIC_ADMIN_BASE_URL_OVERRIDE": "",
             },
         ):
             with patch("ai_api_unified.ai_anthropic_base.Anthropic"):
@@ -176,7 +193,31 @@ class TestAnthropicOverride:
                 client.get_org_info()
         assert (
             mock_get.call_args.args[0]
-            == "https://gw.internal/anthropic/v1/organizations/me"
+            == "https://api.anthropic.com/v1/organizations/me"
+        )
+
+    def test_admin_lookup_follows_its_own_opt_in_override(self):
+        # Egress-restricted networks can route the admin call too, explicitly.
+        with patch.dict(
+            os.environ,
+            {
+                "ANTHROPIC_API_KEY": "k",
+                "ANTHROPIC_ADMIN_KEY": "admin",
+                "ANTHROPIC_BASE_URL_OVERRIDE": "https://gw.internal/anthropic",
+                "ANTHROPIC_ADMIN_BASE_URL_OVERRIDE": "https://admin-gw.internal",
+            },
+        ):
+            with patch("ai_api_unified.ai_anthropic_base.Anthropic"):
+                client = AiAnthropicCompletions(model="claude-opus-4-8")
+            response = Mock(status_code=200)
+            response.json.return_value = {"id": "org_1", "name": "Acme"}
+            with patch(
+                "ai_api_unified.ai_anthropic_base.httpx.get", return_value=response
+            ) as mock_get:
+                client.get_org_info()
+        assert (
+            mock_get.call_args.args[0]
+            == "https://admin-gw.internal/v1/organizations/me"
         )
 
 
@@ -204,6 +245,33 @@ class TestOpenAIOverride:
                 client = AiOpenAICompletions(model="gpt-4o-mini")
         assert mock_cls.call_args.kwargs["base_url"] == "https://gw.internal/openai"
         assert client.base_url == "https://gw.internal/openai"
+
+    def test_deprecated_openai_base_url_is_validated(self):
+        # The SDK's own variable name is commonly set process-wide by other
+        # tooling; it must not smuggle a plaintext destination past the guard.
+        with patch.dict(
+            os.environ,
+            {
+                "OPENAI_API_KEY": "k",
+                "OPENAI_BASE_URL_OVERRIDE": "",
+                "OPENAI_BASE_URL": "http://gw.corp.internal/v1",
+            },
+        ):
+            with pytest.raises(AiProviderConfigurationError):
+                AiOpenAICompletions(model="gpt-4o-mini")
+
+    def test_deprecated_openai_base_url_still_works_over_https(self):
+        with patch.dict(
+            os.environ,
+            {
+                "OPENAI_API_KEY": "k",
+                "OPENAI_BASE_URL_OVERRIDE": "",
+                "OPENAI_BASE_URL": "https://legacy-gw.internal/v1",
+            },
+        ):
+            with patch("ai_api_unified.ai_openai_base.OpenAI") as mock_cls:
+                AiOpenAICompletions(model="gpt-4o-mini")
+        assert mock_cls.call_args.kwargs["base_url"] == "https://legacy-gw.internal/v1"
 
     def test_geo_residency_still_applies_without_override(self):
         with patch.dict(


### PR DESCRIPTION
## What this PR does

Adds **per-engine API base-URL overrides** so provider traffic can route through an LLM gateway, a corporate egress proxy, a recording proxy in tests, or any OpenAI-compatible server. Scoped to the three engines requested: `claude`, `openai`/`openai-responses`, and `google-gemini`.

### Configuration

| Engine | Setting |
|---|---|
| `claude` | `ANTHROPIC_BASE_URL_OVERRIDE` |
| `openai`, `openai-responses` | `OPENAI_BASE_URL_OVERRIDE` |
| `google-gemini` | `GOOGLE_GEMINI_BASE_URL_OVERRIDE` |

Config-first per the library's founding principle, with a `base_url` argument on the factory and constructors for processes that need several destinations at once (a single env value can't express per-tenant routing).

### Why `_OVERRIDE` is load-bearing, not cosmetic

The OpenAI, Anthropic, and Google SDKs **already read** `OPENAI_BASE_URL`, `ANTHROPIC_BASE_URL`, and `GOOGLE_GEMINI_BASE_URL` natively (verified against the installed SDKs). Had our variables shared those names, the SDK would pick the value up on its own and the https guard would never run — a silent bypass. Distinct names, plus passing the resolved value to **every** SDK constructor explicitly, close that hole.

### Security

- **https required.** An override redirects your API keys to that host, so plain `http://` raises `AiProviderConfigurationError` before a credential leaves the process — except for `localhost`/`127.0.0.1`/`::1`, which keeps local gateways and test servers usable.
- **Org lookups follow the override** — except the Anthropic **Admin API key**, which grants org-wide read/write and therefore stays on the vendor host unless `ANTHROPIC_ADMIN_BASE_URL_OVERRIDE` opts it in. Configuring an inference gateway never silently hands it an administration credential.
- **The deprecated `OPENAI_BASE_URL` is validated too**, since other tooling commonly sets that name process-wide.
- **No silent no-ops.** Engines whose SDK can't honor an override (Bedrock-routed, `titan`, `voyage`, voice) raise `AiProviderCapabilityUnsupportedError` rather than accepting `base_url` and quietly calling the vendor.

Precedence: `base_url` argument → `<ENGINE>_BASE_URL_OVERRIDE` → (OpenAI only) deprecated `OPENAI_BASE_URL`, then geo-residency → provider default.

### Verification

- 29 new tests: validation (https, loopback exemptions, malformed input), precedence, per-engine SDK wiring, org-lookup routing through the gateway, and factory gating. Full mocked regression: **571 passed**.
- **Live**: the Anthropic sync and async SDK clients both report the overridden `base_url`; an unmodified call still succeeds against the vendor default; a plaintext remote override is refused at construction.

One documented asymmetry: on `google-gemini` with no override set, the SDK resolves its own default including its native variables, which this library does not validate. Anthropic and OpenAI are fully closed because their defaults are simple constants we always pass.

<!-- pr-review-prep:start -->
## PR Composition

Composition percentages are based on changed lines (added + deleted) versus the base branch `main`.

| Change Type | Lines Changed | Percentage |
|---|---:|---:|
| Core logic changes | 299 | 37% |
| Documentation | 104 | 13% |
| Tests | 410 | 50% |
| Other | 2 | 0% |
| Total | 815 | 100% |
<!-- pr-review-prep:end -->

<!-- pr-content-attribution:start -->
## Content Attribution Summary

Based on changed lines across counted PR commits in this PR. Pure data files are excluded — their content is deterministic process output, not authored work.

| Attribution Type | Commits | Lines Changed | Percentage |
|---|---:|---:|---:|
| AI-attributed | 2 | 815 | 100% |
| Human-attributed | 0 | 0 | 0% |
| Bot-attributed | 0 | 0 | 0% |
| Total | 2 | 815 | 100% |

Excluded from attribution:
- none (no merge/sync commits, no data-file lines)
<!-- pr-content-attribution:end -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

