### PR TITLE
feat: latest provider models — Claude Opus/Sonnet 5, GPT-5.5 family, Gemini 3.x (2.21.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,27 @@ Notable changes per release, so consumers can gate on the package version.
 Versions follow [semantic versioning](https://semver.org/); the authoritative
 version lives in `pyproject.toml` (see the README release section).
 
+## 2.21.0
+
+- Catalogue the latest models served by all three major completions
+  providers (verified against each provider's live models API on
+  2026-08-03), with registry pricing and capability entries:
+  - Anthropic: `claude-opus-5` and `claude-sonnet-5` (both 1M context;
+    Sonnet 5 priced at list rates, introductory pricing noted through
+    2026-08-31). `claude-opus-4-1`'s recommended replacement is now
+    `claude-opus-5`.
+  - OpenAI: `gpt-5.5`, `gpt-5.4-mini`, `gpt-5.4-nano`, and `gpt-5.2` are now
+    in the model list and context-window table (they were previously priced
+    in the registry but not selectable).
+  - Google Gemini: the 3.x generation — `gemini-3.6-flash`,
+    `gemini-3.5-flash`, `gemini-3.5-flash-lite`, `gemini-3.1-flash-lite`,
+    and `gemini-3.1-pro-preview` (tiered >200K pricing) — with a
+    reasoning-capable Gemini 3 capabilities branch.
+- Engine defaults are unchanged (`claude-opus-4-8`, `gpt-4o-mini`,
+  `gemini-2.5-flash`); the new models are opt-in via
+  `COMPLETIONS_MODEL_NAME`. `env_template` now lists per-engine model
+  choices including the new generation.
+
 ## 2.20.0
 
 - Per-engine API base-URL overrides for `claude`, `openai`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,10 +20,16 @@ version lives in `pyproject.toml` (see the README release section).
     `gemini-3.5-flash`, `gemini-3.5-flash-lite`, `gemini-3.1-flash-lite`,
     and `gemini-3.1-pro-preview` (tiered >200K pricing) — with a
     reasoning-capable Gemini 3 capabilities branch.
-- Engine defaults are unchanged (`claude-opus-4-8`, `gpt-4o-mini`,
-  `gemini-2.5-flash`); the new models are opt-in via
-  `COMPLETIONS_MODEL_NAME`. `env_template` now lists per-engine model
-  choices including the new generation.
+- Engine defaults move to one generation behind the newest catalogued
+  model: OpenAI `gpt-4o-mini` -> `gpt-5.4-mini`, Gemini
+  `gemini-2.5-flash` -> `gemini-3.5-flash` (default and unknown-model
+  fallback). The Claude default stays `claude-opus-4-8`, already one
+  generation behind `claude-opus-5`. `env_template` now lists per-engine
+  model choices including the new generation.
+- Fix: `AiOpenAICompletions()` constructed with no arguments previously
+  used the literal `"4o-mini"` (an invalid model ID) and never consulted
+  `COMPLETIONS_MODEL_NAME`; the signature default is now empty so the
+  environment setting and the `gpt-5.4-mini` fallback apply.
 
 ## 2.20.0
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# ai-api-unified 2.20.0
+# ai-api-unified 2.21.0
 
 `ai-api-unified` is a unified Python library for AI completions, embeddings, image generation, video generation, and voice. Application code targets stable base interfaces and factory entry points while concrete providers are selected at runtime from environment configuration.
 
@@ -240,11 +240,11 @@ ANTHROPIC_API_KEY=...
 ```
 
 Models catalogued for the `claude` engine (alias model IDs):
-`claude-fable-5`, `claude-opus-4-8` (default), `claude-opus-4-7`,
-`claude-opus-4-6`, `claude-sonnet-4-6`, and `claude-haiku-4-5`. Capabilities
-per model include the context window (1M tokens except `claude-haiku-4-5` at
-200K), streaming, provider-side token counting, image inputs, and registry
-pricing. Structured output uses the Messages API JSON-schema response format,
+`claude-fable-5`, `claude-opus-5`, `claude-sonnet-5`, `claude-opus-4-8`
+(default), `claude-opus-4-7`, `claude-opus-4-6`, `claude-sonnet-4-6`, and
+`claude-haiku-4-5`. Capabilities per model include the context window (1M
+tokens except `claude-haiku-4-5` at 200K), streaming, provider-side token
+counting, image inputs, and registry pricing. Structured output uses the Messages API JSON-schema response format,
 so `strict_schema_prompt` works on every catalogued model. On
 `claude-fable-5`, whose thinking is always on and counts against `max_tokens`,
 pass a `max_response_tokens` well above the 2048 default so the budget covers

--- a/README.md
+++ b/README.md
@@ -773,6 +773,25 @@ There is no implicit default provider. Set the selector for each capability you 
 | `GOOGLE_GEMINI_BASE_URL_OVERRIDE` | Optional API base-URL override for `google-gemini` (https required) |
 | `ANTHROPIC_ADMIN_BASE_URL_OVERRIDE` | Optional separate override for the Anthropic Admin API lookup; the admin key does not follow the inference override |
 
+### Catalogued Completions Models
+
+Models with capability and pricing entries per engine, last verified against
+each provider's live models API on 2026-08-03. Defaults sit one generation
+behind the newest catalogued model.
+
+| Engine | Default (no `COMPLETIONS_MODEL_NAME`) | Catalogued models |
+| --- | --- | --- |
+| `openai` / `openai-responses` | `gpt-5.4-mini` | `gpt-5.5`, `gpt-5.4`, `gpt-5.4-mini`, `gpt-5.4-nano`, `gpt-5.2`, `gpt-5.1-codex-max`, `gpt-5`, `gpt-5-mini`, `gpt-5-nano`, `gpt-4.1`, `gpt-4.1-mini`, `gpt-4.1-nano`, `o4-mini`, `o4-mini-high`, `gpt-4o`, `gpt-4o-mini` |
+| `claude` | `claude-opus-4-8` | `claude-fable-5`, `claude-opus-5`, `claude-sonnet-5`, `claude-opus-4-8`, `claude-opus-4-7`, `claude-opus-4-6`, `claude-sonnet-4-6`, `claude-haiku-4-5` |
+| `google-gemini` | `gemini-3.5-flash` | `gemini-3.6-flash`, `gemini-3.5-flash`, `gemini-3.5-flash-lite`, `gemini-3.1-flash-lite`, `gemini-3.1-pro-preview`, `gemini-2.5-pro`, `gemini-2.5-flash`, `gemini-2.5-flash-lite` (2.0 family deprecated) |
+| `nova` (Bedrock) | `amazon.nova-lite-v1:0` | `amazon.nova-micro-v1:0`, `amazon.nova-lite-v1:0`, `amazon.nova-pro-v1:0`, `amazon.nova-premier-v1:0` |
+
+An uncatalogued model name passes through to the provider on the OpenAI and
+Claude engines (with a conservative default context window); the
+`google-gemini` engine falls back to its default model and logs a warning.
+Deprecated models warn once per process with a sunset date and replacement;
+retired models fail fast (see the pricing registry).
+
 ### API Base URL Overrides
 
 The `claude`, `openai`, `openai-responses`, and `google-gemini` engines accept

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ The public entry points are the stable base interfaces and factories:
 Default model guidance in the checked-in OSS env files:
 
 - Anthropic completions: `claude-opus-4-8`
-- Google completions: `gemini-2.5-flash`
+- Google completions: `gemini-3.5-flash`
 - Google embeddings: `gemini-embedding-001` (text-only) or `gemini-embedding-2` (multimodal)
 - Google images: `imagen-4.0-generate-001`
 - Google videos: `veo-3.1-lite-generate-preview`
@@ -142,7 +142,7 @@ AI_VOICE_ENGINE=google
 GOOGLE_GEMINI_API_KEY=...
 GOOGLE_AUTH_METHOD=api_key
 
-COMPLETIONS_MODEL_NAME=gemini-2.5-flash
+COMPLETIONS_MODEL_NAME=gemini-3.5-flash
 EMBEDDING_MODEL_NAME=gemini-embedding-001
 IMAGE_MODEL_NAME=imagen-4.0-generate-001
 VIDEO_MODEL_NAME=veo-3.1-lite-generate-preview

--- a/docs/pricing_research.md
+++ b/docs/pricing_research.md
@@ -55,6 +55,12 @@ models split into input / cached-input / output.
 | OpenAI | o4-mini | 1.10 | 0.275 | 4.40 | high |
 | OpenAI | gpt-4o | 2.50 | 1.25 | 10.00 | high |
 | OpenAI | gpt-4o-mini | 0.15 | 0.075 | 0.60 | high |
+| Google | gemini-3.6-flash | 1.50 | 0.15 | 7.50 | high |
+| Google | gemini-3.5-flash | 1.50 | 0.15 | 9.00 | high |
+| Google | gemini-3.5-flash-lite | 0.30 | 0.03 | 2.50 | high |
+| Google | gemini-3.1-flash-lite | 0.25 | 0.025 | 1.50 | high |
+| Google | gemini-3.1-pro-preview (≤200K) | 2.00 | 0.20 | 12.00 | high |
+| Google | gemini-3.1-pro-preview (>200K) | 4.00 | 0.40 | 18.00 | high |
 | Google | gemini-2.5-pro (≤200K) | 1.25 | 0.13 | 10.00 | high |
 | Google | gemini-2.5-pro (>200K) | 2.50 | 0.25 | 15.00 | high |
 | Google | gemini-2.5-flash | 0.30 | 0.03 | 2.50 | high |
@@ -67,6 +73,8 @@ models split into input / cached-input / output.
 | Bedrock | amazon.nova-premier | 2.50 | n/a | 12.50 | high |
 | Bedrock | claude-3-5-haiku | 0.80 | n/a | 4.00 | high |
 | Anthropic | claude-fable-5 | 10.00 | 1.00 | 50.00 | high |
+| Anthropic | claude-opus-5 | 5.00 | 0.50 | 25.00 | high |
+| Anthropic | claude-sonnet-5 † | 3.00 | 0.30 | 15.00 | high |
 | Anthropic | claude-opus-4-8 | 5.00 | 0.50 | 25.00 | high |
 | Anthropic | claude-opus-4-7 | 5.00 | 0.50 | 25.00 | high |
 | Anthropic | claude-opus-4-6 | 5.00 | 0.50 | 25.00 | high |
@@ -74,7 +82,12 @@ models split into input / cached-input / output.
 | Anthropic | claude-haiku-4-5 | 1.00 | 0.10 | 5.00 | high |
 | Anthropic | claude-opus-4-1 ⚠ | 15.00 | 1.50 | 75.00 | high |
 
-Notes: Anthropic rates are the native-API list (added 2026-07 with the `claude`
+Notes: rows added 2026-08-03 (claude-opus-5, claude-sonnet-5, and the Gemini
+3.x generation) were compiled from the same provider pricing pages as the rest
+of the table. † claude-sonnet-5 shows list rates; introductory pricing
+($2.00 in / $10.00 out) runs through 2026-08-31. gemini-3.1-pro-preview is the
+latest pro tier served by the Gemini API (preview-only as of 2026-08).
+Anthropic rates are the native-API list (added 2026-07 with the `claude`
 engine); the cached-input column is the documented 0.1x prompt-cache read rate,
 and 5-minute cache writes bill 1.25x input (not modeled). Anthropic lifecycle
 entries also cover claude-opus-4-1 (deprecated, retires 2026-08-05, replace

--- a/env_template
+++ b/env_template
@@ -47,11 +47,12 @@ COMPLETIONS_ENGINE=google-gemini
 # Embedding model name (text-embedding-3-small | amazon.titan-embed-text-v2:0 | gemini-embedding-001 | voyage-3)
 EMBEDDING_MODEL_NAME=gemini-embedding-001
 # EMBEDDING_MODEL_NAME=amazon.titan-embed-text-v2:0
-# Completions model name, by engine:
-#   openai:        gpt-5.5 | gpt-5.4 | gpt-5.4-mini | gpt-5.4-nano | gpt-4o-mini
-#   claude:        claude-opus-5 | claude-sonnet-5 | claude-fable-5 | claude-opus-4-8 | claude-haiku-4-5
-#   google-gemini: gemini-3.6-flash | gemini-3.5-flash | gemini-3.5-flash-lite | gemini-3.1-pro-preview | gemini-2.5-flash
-#   nova:          amazon.nova-micro-v1:0 | amazon.nova-lite-v1:0
+# Completions model name, by engine. Leave unset to use the engine default
+# (one generation behind the newest catalogued model):
+#   openai:        default gpt-5.4-mini    | gpt-5.5 | gpt-5.4 | gpt-5.4-nano | gpt-4o-mini
+#   claude:        default claude-opus-4-8 | claude-opus-5 | claude-sonnet-5 | claude-fable-5 | claude-haiku-4-5
+#   google-gemini: default gemini-3.5-flash | gemini-3.6-flash | gemini-3.5-flash-lite | gemini-3.1-pro-preview | gemini-2.5-flash
+#   nova:          default amazon.nova-lite-v1:0 | amazon.nova-micro-v1:0
 COMPLETIONS_MODEL_NAME=gemini-3.5-flash
 # COMPLETIONS_MODEL_NAME=gemini-3.6-flash
 # COMPLETIONS_MODEL_NAME=claude-opus-5

--- a/env_template
+++ b/env_template
@@ -52,7 +52,7 @@ EMBEDDING_MODEL_NAME=gemini-embedding-001
 #   claude:        claude-opus-5 | claude-sonnet-5 | claude-fable-5 | claude-opus-4-8 | claude-haiku-4-5
 #   google-gemini: gemini-3.6-flash | gemini-3.5-flash | gemini-3.5-flash-lite | gemini-3.1-pro-preview | gemini-2.5-flash
 #   nova:          amazon.nova-micro-v1:0 | amazon.nova-lite-v1:0
-COMPLETIONS_MODEL_NAME=gemini-2.5-flash
+COMPLETIONS_MODEL_NAME=gemini-3.5-flash
 # COMPLETIONS_MODEL_NAME=gemini-3.6-flash
 # COMPLETIONS_MODEL_NAME=claude-opus-5
 # COMPLETIONS_MODEL_NAME=gpt-5.5
@@ -102,7 +102,7 @@ DEFAULT_GEMINI_TTS_MODEL=gemini-2.5-pro-tts
 # COMPLETIONS_ENGINE=google-gemini
 # EMBEDDING_ENGINE=google-gemini
 # Default models:
-#   Completions: gemini-2.5-flash
+#   Completions: gemini-3.5-flash
 #   Embeddings: gemini-embedding-001
 
 ########################################################################

--- a/env_template
+++ b/env_template
@@ -47,9 +47,15 @@ COMPLETIONS_ENGINE=google-gemini
 # Embedding model name (text-embedding-3-small | amazon.titan-embed-text-v2:0 | gemini-embedding-001 | voyage-3)
 EMBEDDING_MODEL_NAME=gemini-embedding-001
 # EMBEDDING_MODEL_NAME=amazon.titan-embed-text-v2:0
-# Completions model name (gpt-4o-mini | claude-opus-4-8 | amazon.nova-micro-v1:0 | amazon.nova-lite-v1:0 | gemini-2.5-flash)
+# Completions model name, by engine:
+#   openai:        gpt-5.5 | gpt-5.4 | gpt-5.4-mini | gpt-5.4-nano | gpt-4o-mini
+#   claude:        claude-opus-5 | claude-sonnet-5 | claude-fable-5 | claude-opus-4-8 | claude-haiku-4-5
+#   google-gemini: gemini-3.6-flash | gemini-3.5-flash | gemini-3.5-flash-lite | gemini-3.1-pro-preview | gemini-2.5-flash
+#   nova:          amazon.nova-micro-v1:0 | amazon.nova-lite-v1:0
 COMPLETIONS_MODEL_NAME=gemini-2.5-flash
-# COMPLETIONS_MODEL_NAME=claude-opus-4-8
+# COMPLETIONS_MODEL_NAME=gemini-3.6-flash
+# COMPLETIONS_MODEL_NAME=claude-opus-5
+# COMPLETIONS_MODEL_NAME=gpt-5.5
 # COMPLETIONS_MODEL_NAME=amazon.nova-lite-v1:0
 # Embedding dimensions (1536 for OpenAI | 1024 for Titan | 3072 default for Gemini)
 # Leave unset to use the provider default for the selected engine.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@
 [project]
 name = "ai_api_unified"
 
-version = "2.20.0" # keep in sync with src/ai_api_unified/__version__.py and the README.md title
+version = "2.21.0" # keep in sync with src/ai_api_unified/__version__.py and the README.md title
 description = "Unified access layer for AI completions (LLM), embedding (semantic), image, video, and voice services"
 authors = [{ name = "Dave Thomas", email = "davidcthomas@gmail.com" }]
 license = "MIT"

--- a/src/ai_api_unified/__version__.py
+++ b/src/ai_api_unified/__version__.py
@@ -9,4 +9,4 @@ from __future__ import annotations
 
 __all__: list[str] = ["__version__"]
 
-__version__: str = "2.20.0"
+__version__: str = "2.21.0"

--- a/src/ai_api_unified/completions/ai_anthropic_completions.py
+++ b/src/ai_api_unified/completions/ai_anthropic_completions.py
@@ -73,6 +73,8 @@ class AICompletionsCapabilitiesAnthropic(AICompletionsCapabilitiesBase):
     # Context window sizes (max input tokens each model can handle).
     DICT_ANTHROPIC_CONTEXT_WINDOWS: ClassVar[dict[str, int]] = {
         "claude-fable-5": 1_000_000,
+        "claude-opus-5": 1_000_000,
+        "claude-sonnet-5": 1_000_000,
         "claude-opus-4-8": 1_000_000,
         "claude-opus-4-7": 1_000_000,
         "claude-opus-4-6": 1_000_000,
@@ -172,10 +174,12 @@ class AiAnthropicCompletions(AIAnthropicBase, AIBaseCompletions):
         # date-suffixed snapshots).
         return [
             "claude-fable-5",  # most capable, premium tier
-            "claude-opus-4-8",  # most capable Opus-tier model (default)
+            "claude-opus-5",  # current Opus-tier flagship
+            "claude-sonnet-5",  # latest speed/intelligence balance
+            "claude-opus-4-8",  # previous Opus-tier flagship (default)
             "claude-opus-4-7",  # previous-generation Opus
             "claude-opus-4-6",  # older Opus
-            "claude-sonnet-4-6",  # speed/intelligence balance
+            "claude-sonnet-4-6",  # previous-generation Sonnet
             "claude-haiku-4-5",  # fastest, most cost-effective
         ]
 

--- a/src/ai_api_unified/completions/ai_google_gemini_capabilities.py
+++ b/src/ai_api_unified/completions/ai_google_gemini_capabilities.py
@@ -42,7 +42,15 @@ class AICompletionsCapabilitiesGoogle(AICompletionsCapabilitiesBase):
         }
 
         # Model-specific capabilities
-        if "2.5" in model_name:
+        if model_name.startswith("gemini-3"):
+            capabilities.update(
+                {
+                    "context_window_length": 1048576,
+                    "knowledge_cutoff_date": date(2025, 1, 1),  # Approximate
+                    "reasoning": True,  # Gemini 3.x supports reasoning
+                }
+            )
+        elif "2.5" in model_name:
             capabilities.update(
                 {
                     "context_window_length": 1048576,

--- a/src/ai_api_unified/completions/ai_google_gemini_completions.py
+++ b/src/ai_api_unified/completions/ai_google_gemini_completions.py
@@ -78,8 +78,8 @@ GOOGLE_GENAI_ERRORS: object = gerr
 _LOGGER: logging.Logger = logging.getLogger(__name__)
 
 # Constants
-DEFAULT_COMPLETIONS_MODEL: str = "gemini-2.5-flash"
-DEFAULT_FALLBACK_MODEL: str = "gemini-2.5-flash"
+DEFAULT_COMPLETIONS_MODEL: str = "gemini-3.5-flash"
+DEFAULT_FALLBACK_MODEL: str = "gemini-3.5-flash"
 MAX_RETRIES: int = 5
 INITIAL_BACKOFF_DELAY: float = 1.0
 BACKOFF_MULTIPLIER: float = 2.0

--- a/src/ai_api_unified/completions/ai_google_gemini_completions.py
+++ b/src/ai_api_unified/completions/ai_google_gemini_completions.py
@@ -98,12 +98,23 @@ STRUCTURED_DEFAULT_TOP_P: float = 0.8
 # Context window and status only. Pricing now lives in the pricing registry
 # (single source of truth); lifecycle (deprecated/retired) is enforced there.
 GEMINI_MODEL_SPECS: dict[str, dict[str, Any]] = {
-    # Latest stable models
-    "gemini-2.5-pro": {"max_context_tokens": 1_048_576, "status": "Latest Stable"},
-    "gemini-2.5-flash": {"max_context_tokens": 1_048_576, "status": "Latest Stable"},
-    "gemini-2.5-flash-lite": {
+    # Latest stable models (Gemini 3.x generation; token limits confirmed via
+    # the models.get API 2026-08-03: 1,048,576 in / 65,536 out).
+    "gemini-3.6-flash": {"max_context_tokens": 1_048_576, "status": "Latest Stable"},
+    "gemini-3.5-flash": {"max_context_tokens": 1_048_576, "status": "Latest Stable"},
+    "gemini-3.5-flash-lite": {
         "max_context_tokens": 1_048_576,
         "status": "Latest Stable",
+    },
+    "gemini-3.1-flash-lite": {"max_context_tokens": 1_048_576, "status": "Stable"},
+    # Latest pro tier is preview-only on the Gemini API as of 2026-08.
+    "gemini-3.1-pro-preview": {"max_context_tokens": 1_048_576, "status": "Preview"},
+    # Previous stable generation
+    "gemini-2.5-pro": {"max_context_tokens": 1_048_576, "status": "Stable"},
+    "gemini-2.5-flash": {"max_context_tokens": 1_048_576, "status": "Stable"},
+    "gemini-2.5-flash-lite": {
+        "max_context_tokens": 1_048_576,
+        "status": "Stable",
     },
     # Deprecated (still functional; the registry warns and names a replacement).
     "gemini-2.0-flash-lite": {"max_context_tokens": 1_048_576, "status": "Deprecated"},

--- a/src/ai_api_unified/completions/ai_openai_completions.py
+++ b/src/ai_api_unified/completions/ai_openai_completions.py
@@ -222,7 +222,7 @@ class AICompletionsPromptParamsOpenAI(AICompletionsPromptParamsBase):
 
 
 class AiOpenAICompletions(AIOpenAIBase, AIBaseCompletions):
-    def __init__(self, model: str = "4o-mini", **kwargs: Any):
+    def __init__(self, model: str = "", **kwargs: Any):
         """
         Initializes the AiOpenAICompletions class, setting the model and related configuration.
 
@@ -232,7 +232,7 @@ class AiOpenAICompletions(AIOpenAIBase, AIBaseCompletions):
         AIOpenAIBase.__init__(self, **kwargs)
         explicit_model: str = model.strip() if model else ""
         self.completions_model = explicit_model or self.env.get_setting(
-            "COMPLETIONS_MODEL_NAME", "gpt-4o-mini"
+            "COMPLETIONS_MODEL_NAME", "gpt-5.4-mini"
         )
         AIBaseCompletions.__init__(self, model=self.completions_model, **kwargs)
         self.model = self.completions_model

--- a/src/ai_api_unified/completions/ai_openai_completions.py
+++ b/src/ai_api_unified/completions/ai_openai_completions.py
@@ -74,7 +74,11 @@ class AICompletionsCapabilitiesOpenAI(AICompletionsCapabilitiesBase):
     # Context window sizes (max tokens each model can handle)
     DICT_OPENAI_CONTEXT_WINDOWS: ClassVar[dict[str, int]] = {
         # --- GPT-5.x current family (API) ---
+        "gpt-5.5": 400_000,
         "gpt-5.4": 400_000,
+        "gpt-5.4-mini": 400_000,
+        "gpt-5.4-nano": 400_000,
+        "gpt-5.2": 400_000,
         "gpt-5.1-codex-max": 400_000,
         # --- GPT-5 Family (API) ---
         "gpt-5": 400_000,
@@ -248,7 +252,11 @@ class AiOpenAICompletions(AIOpenAIBase, AIBaseCompletions):
         # Updated as of Aug 2025 based on OpenAI announcements and docs
         return [
             # --- GPT-5.x current family ---
-            "gpt-5.4",  # current workhorse
+            "gpt-5.5",  # current flagship (Apr 2026)
+            "gpt-5.4",  # previous flagship, current workhorse
+            "gpt-5.4-mini",  # smaller, cheaper 5.4 variant
+            "gpt-5.4-nano",  # lowest-cost 5.4 variant
+            "gpt-5.2",  # older 5.x generation, still served
             "gpt-5.1-codex-max",  # coding-optimized, large context
             # --- GPT-5 Family (previous generation, still available) ---
             "gpt-5",  # flagship

--- a/src/ai_api_unified/pricing/pricing_registry.py
+++ b/src/ai_api_unified/pricing/pricing_registry.py
@@ -38,6 +38,8 @@ _LOGGER: logging.Logger = logging.getLogger(__name__)
 
 # Provenance shared by this compilation.
 _EFFECTIVE: date = date(2026, 7, 7)
+# Later compilation date for models added after the initial 2026-07-07 sweep.
+_EFFECTIVE_AUG: date = date(2026, 8, 3)
 _SRC_OPENAI: str = "https://developers.openai.com/api/docs/pricing"
 _SRC_GOOGLE: str = "https://ai.google.dev/gemini-api/docs/pricing"
 _SRC_GOOGLE_DEP: str = "https://ai.google.dev/gemini-api/docs/deprecations"
@@ -61,11 +63,12 @@ def _tok(
     confidence: str = "high",
     tiers: list[AIPricingTier] | None = None,
     notes: str | None = None,
+    effective: date = _EFFECTIVE,
 ) -> AIModelPricing:
     """Build a token-unit AIModelPricing from string decimals (per 1M tokens)."""
     return AIModelPricing(
         unit=PricingUnit.TOKEN,
-        effective_date=_EFFECTIVE,
+        effective_date=effective,
         source=source,
         confidence=confidence,  # type: ignore[arg-type]
         token_rates=AITokenRates(
@@ -184,6 +187,56 @@ DICT_MODEL_INFO: dict[tuple[str, str], AIModelInfo] = dict(
             _tok("0.12", None, None, _SRC_VOYAGE),
         ),
         # ── Google completions (active) ─────────────────────────────────────
+        _info(
+            PROVIDER_GOOGLE,
+            "gemini-3.6-flash",
+            _tok("1.50", "7.50", "0.15", _SRC_GOOGLE, effective=_EFFECTIVE_AUG),
+        ),
+        _info(
+            PROVIDER_GOOGLE,
+            "gemini-3.5-flash",
+            _tok("1.50", "9.00", "0.15", _SRC_GOOGLE, effective=_EFFECTIVE_AUG),
+        ),
+        _info(
+            PROVIDER_GOOGLE,
+            "gemini-3.5-flash-lite",
+            _tok("0.30", "2.50", "0.03", _SRC_GOOGLE, effective=_EFFECTIVE_AUG),
+        ),
+        _info(
+            PROVIDER_GOOGLE,
+            "gemini-3.1-flash-lite",
+            _tok(
+                "0.25",
+                "1.50",
+                "0.025",
+                _SRC_GOOGLE,
+                effective=_EFFECTIVE_AUG,
+                notes="Audio input priced higher ($0.50/1M).",
+            ),
+        ),
+        _info(
+            PROVIDER_GOOGLE,
+            "gemini-3.1-pro-preview",
+            _tok(
+                "2.00",
+                "12.00",
+                "0.20",
+                _SRC_GOOGLE,
+                effective=_EFFECTIVE_AUG,
+                tiers=[
+                    AIPricingTier(
+                        label="context>200k",
+                        token_rates=AITokenRates(
+                            input_per_1m=Decimal("4.00"),
+                            output_per_1m=Decimal("18.00"),
+                            cached_input_per_1m=Decimal("0.40"),
+                        ),
+                    )
+                ],
+                notes="Base rates apply to <=200K input tokens. Preview model; "
+                "latest pro tier served by the Gemini API.",
+            ),
+        ),
         _info(
             PROVIDER_GOOGLE,
             "gemini-2.5-pro",
@@ -341,6 +394,24 @@ DICT_MODEL_INFO: dict[tuple[str, str], AIModelInfo] = dict(
         ),
         _info(
             PROVIDER_ANTHROPIC,
+            "claude-opus-5",
+            _tok("5.00", "25.00", "0.50", _SRC_ANTHROPIC, effective=_EFFECTIVE_AUG),
+        ),
+        _info(
+            PROVIDER_ANTHROPIC,
+            "claude-sonnet-5",
+            _tok(
+                "3.00",
+                "15.00",
+                "0.30",
+                _SRC_ANTHROPIC,
+                effective=_EFFECTIVE_AUG,
+                notes="List rates; introductory pricing ($2.00 in / $10.00 out) "
+                "runs through 2026-08-31.",
+            ),
+        ),
+        _info(
+            PROVIDER_ANTHROPIC,
             "claude-opus-4-8",
             _tok("5.00", "25.00", "0.50", _SRC_ANTHROPIC),
         ),
@@ -371,7 +442,7 @@ DICT_MODEL_INFO: dict[tuple[str, str], AIModelInfo] = dict(
             _tok("15.00", "75.00", "1.50", _SRC_ANTHROPIC),
             status=ModelLifecycleStatus.DEPRECATED,
             sunset=date(2026, 8, 5),
-            replacement="claude-opus-4-8",
+            replacement="claude-opus-5",
         ),
         # ── Anthropic completions (retired: hard 404) ───────────────────────
         _info(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -166,7 +166,7 @@ def pytest_addoption(parser: pytest.Parser) -> None:
     parser.addoption(
         "--llmmodel",
         action="store",
-        default="gemini-2.5-flash",
+        default="gemini-3.5-flash",
         help="LLM model to use (default: gemini-2.5-flash)",
     )
 

--- a/tests/test_anthropic_completions.py
+++ b/tests/test_anthropic_completions.py
@@ -368,5 +368,5 @@ class TestPricingAndLifecycle:
             (PROVIDER_ANTHROPIC, "claude-opus-4-1")
         )
         with patch.dict(os.environ, {"ANTHROPIC_API_KEY": "test-key"}):
-            with pytest.warns(DeprecationWarning, match="claude-opus-4-8"):
+            with pytest.warns(DeprecationWarning, match="claude-opus-5"):
                 AiAnthropicCompletions(model="claude-opus-4-1")

--- a/tests/test_model_pricing.py
+++ b/tests/test_model_pricing.py
@@ -81,6 +81,40 @@ class TestRegistry:
     def test_uncatalogued_model_returns_none(self) -> None:
         assert get_model_pricing("openai", "does-not-exist") is None
 
+    def test_anthropic_claude_5_generation(self) -> None:
+        # Added 2026-08-03 from the live models API; opus-5 matches opus-4-8
+        # rates, sonnet-5 is registered at list (not introductory) rates.
+        opus = get_model_pricing("anthropic", "claude-opus-5")
+        assert opus is not None
+        assert opus.token_rates.input_per_1m == Decimal("5.00")
+        assert opus.token_rates.output_per_1m == Decimal("25.00")
+        assert opus.token_rates.cached_input_per_1m == Decimal("0.50")
+
+        sonnet = get_model_pricing("anthropic", "claude-sonnet-5")
+        assert sonnet is not None
+        assert sonnet.token_rates.input_per_1m == Decimal("3.00")
+        assert sonnet.token_rates.output_per_1m == Decimal("15.00")
+
+    def test_openai_gpt_5_5_present(self) -> None:
+        pricing = get_model_pricing("openai", "gpt-5.5")
+        assert pricing is not None
+        assert pricing.token_rates.input_per_1m == Decimal("5.00")
+        assert pricing.token_rates.output_per_1m == Decimal("30.00")
+
+    def test_gemini_3_generation(self) -> None:
+        flash = get_model_pricing("google", "gemini-3.5-flash")
+        assert flash is not None
+        assert flash.token_rates.input_per_1m == Decimal("1.50")
+        assert flash.token_rates.output_per_1m == Decimal("9.00")
+
+        # The pro preview carries a >200K pricing tier like gemini-2.5-pro.
+        pro = get_model_pricing("google", "gemini-3.1-pro-preview")
+        assert pro is not None
+        assert pro.token_rates.input_per_1m == Decimal("2.00")
+        assert pro.tiers is not None and len(pro.tiers) == 1
+        assert pro.tiers[0].token_rates is not None
+        assert pro.tiers[0].token_rates.input_per_1m == Decimal("4.00")
+
 
 class TestLifecycle:
     """enforce_model_lifecycle policy per status."""


### PR DESCRIPTION
## What

Catalogue the latest models served by all three major completions providers, verified against each provider's **live models API on 2026-08-03**, and bump the library to **2.21.0** (minor: new capability support).

- **Anthropic**: add `claude-opus-5` ($5/$25 per 1M) and `claude-sonnet-5` ($3/$15 list; introductory pricing noted through 2026-08-31), both 1M context. `claude-opus-4-1`'s recommended replacement is now `claude-opus-5` (it retires 2026-08-05).
- **OpenAI**: surface `gpt-5.5` (current flagship), `gpt-5.4-mini`, `gpt-5.4-nano`, and `gpt-5.2` in the model list and context-window table (400K each). These were already priced in the registry but not selectable — pre-existing drift, now fixed.
- **Gemini**: add the 3.x generation — `gemini-3.6-flash`, `gemini-3.5-flash`, `gemini-3.5-flash-lite`, `gemini-3.1-flash-lite`, and `gemini-3.1-pro-preview` (tiered >200K pricing) — with a reasoning-capable Gemini 3 capabilities branch. Token limits confirmed via the `models.get` API.
- **Engine defaults move to current-gen-minus-1**: OpenAI `gpt-4o-mini` → `gpt-5.4-mini`, Gemini `gemini-2.5-flash` → `gemini-3.5-flash` (default and unknown-model fallback). Claude stays `claude-opus-4-8`, already one generation behind Opus 5.
- **Bug fix**: `AiOpenAICompletions()` with no arguments used the literal `"4o-mini"` (an invalid model ID) and never consulted `COMPLETIONS_MODEL_NAME`; the signature default is now empty so the env setting and fallback apply.
- **env_template**: `COMPLETIONS_MODEL_NAME` now lists per-engine selections including the new generation; active default is `gemini-3.5-flash`.

## Verification

- Full mocked regression: **575 passed** (`pytest -q -m "not nonmock"`), including `test_version_sync`.
- Live smoke test through `AIFactory` succeeded for `claude-opus-5`, `claude-sonnet-5`, `gpt-5.5`, and `gemini-3.6-flash` — each returned a completion with correct context window and registry pricing attached.
- Live no-config smoke test: with `COMPLETIONS_MODEL_NAME` unset, clients resolve to `gpt-5.4-mini` / `gemini-3.5-flash` and answer.
- Tests updated: opus-4-1 deprecation-warning match string, conftest `--llmmodel` default.

<!-- pr-review-prep:start -->
## PR Composition

Composition percentages are based on changed lines (added + deleted) vs. the base branch `main`.

| Change Type | Lines Changed | Percentage |
|---|---:|---:|
| Core logic changes | 132 | 50% |
| Documentation | 77 | 29% |
| Tests | 38 | 14% |
| Other | 17 | 7% |
| Total | 264 | 100% |

Other = `env_template` and the `pyproject.toml` version line.
<!-- pr-review-prep:end -->

<!-- pr-content-attribution:start -->
## Content Attribution Summary

Based on changed lines across counted PR commits in this PR. Pure data files are excluded — their content is deterministic process output, not authored work.

| Attribution Type | Commits | Lines Changed | Percentage |
|---|---:|---:|---:|
| AI-attributed | 5 | 264 | 100% |
| Human-attributed | 0 | 0 | 0% |
| Bot-attributed | 0 | 0 | 0% |
| Total | 5 | 264 | 100% |

Excluded from attribution: none (no merge/sync commits, no data files).
<!-- pr-content-attribution:end -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014gRTVnVYzzxa6nx5aR62nD
