### PR TITLE
chore: retire claude-opus-4-1 (2.22.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ Notable changes per release, so consumers can gate on the package version.
 Versions follow [semantic versioning](https://semver.org/); the authoritative
 version lives in `pyproject.toml` (see the README release section).
 
+## 2.22.0
+
+- `claude-opus-4-1` is now RETIRED (Anthropic withdrew it 2026-08-05) with
+  `claude-opus-5` as its replacement. Requesting it raises
+  `AiProviderConfigurationError` at construction instead of emitting a
+  deprecation warning. Callers still on it must switch models.
+- Retired registry entries keep the pricing they carried while active, so
+  cost enrichment can still price usage recorded before the withdrawal
+  date. Lifecycle enforcement is independent of whether rates are present.
+- Lifecycle messages now read a sunset date as history for retired models
+  ("withdrawn on <date>") and as a schedule for deprecated ones
+  ("scheduled for withdrawal on <date>").
+
 ## 2.21.0
 
 - Catalogue the latest models served by all three major completions

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# ai-api-unified 2.21.0
+# ai-api-unified 2.22.0
 
 `ai-api-unified` is a unified Python library for AI completions, embeddings, image generation, video generation, and voice. Application code targets stable base interfaces and factory entry points while concrete providers are selected at runtime from environment configuration.
 
@@ -532,6 +532,11 @@ surfacing the problem at setup. Requesting a **deprecated** model logs a
 warning and emits a `DeprecationWarning` once per process, naming the sunset
 date and replacement, then proceeds. Set `AI_STRICT_DEPRECATIONS=1` to escalate
 deprecated models to the same construction-time error (useful in CI).
+
+A retired model keeps whatever pricing it carried while it was active, so cost
+enrichment can still price usage recorded before the withdrawal date. As of
+2.22.0, `claude-opus-4-1` is retired (withdrawn 2026-08-05); use
+`claude-opus-5`.
 
 ### Embeddings
 

--- a/docs/pricing_research.md
+++ b/docs/pricing_research.md
@@ -80,7 +80,10 @@ models split into input / cached-input / output.
 | Anthropic | claude-opus-4-6 | 5.00 | 0.50 | 25.00 | high |
 | Anthropic | claude-sonnet-4-6 | 3.00 | 0.30 | 15.00 | high |
 | Anthropic | claude-haiku-4-5 | 1.00 | 0.10 | 5.00 | high |
-| Anthropic | claude-opus-4-1 ⚠ | 15.00 | 1.50 | 75.00 | high |
+| Anthropic | claude-opus-4-1 ✖ | 15.00 | 1.50 | 75.00 | high |
+
+Lifecycle markers: ⚠ deprecated (still served; warns once per process).
+✖ retired (no longer served; requesting it raises).
 
 Notes: rows added 2026-08-03 (claude-opus-5, claude-sonnet-5, and the Gemini
 3.x generation) were compiled from the same provider pricing pages as the rest
@@ -90,9 +93,10 @@ latest pro tier served by the Gemini API (preview-only as of 2026-08).
 Anthropic rates are the native-API list (added 2026-07 with the `claude`
 engine); the cached-input column is the documented 0.1x prompt-cache read rate,
 and 5-minute cache writes bill 1.25x input (not modeled). Anthropic lifecycle
-entries also cover claude-opus-4-1 (deprecated, retires 2026-08-05, replace
-with claude-opus-4-8) and the retired claude-3-7-sonnet, claude-3-5-haiku, and
-claude-3-opus snapshots. Gemini audio input is priced higher than text (2.5-flash audio input
+entries also cover claude-opus-4-1 (retired 2026-08-05, replace with
+claude-opus-5) and the retired claude-3-7-sonnet, claude-3-5-haiku, and
+claude-3-opus snapshots. Retired entries that were priced while active keep
+their rates so historical usage can still be costed; requesting one raises. Gemini audio input is priced higher than text (2.5-flash audio input
 $1.00/1M). Gemini rates shown are the Gemini Developer API list; Vertex differs
 for the 2.0 family ($0.15 in / $0.60 out). Bedrock on-demand; cross-region
 inference profiles add ~10%, batch ≈50% off.

--- a/docs/pricing_research.md
+++ b/docs/pricing_research.md
@@ -96,7 +96,8 @@ and 5-minute cache writes bill 1.25x input (not modeled). Anthropic lifecycle
 entries also cover claude-opus-4-1 (retired 2026-08-05, replace with
 claude-opus-5) and the retired claude-3-7-sonnet, claude-3-5-haiku, and
 claude-3-opus snapshots. Retired entries that were priced while active keep
-their rates so historical usage can still be costed; requesting one raises. Gemini audio input is priced higher than text (2.5-flash audio input
+their rates so historical usage can still be costed; requesting one raises.
+Gemini audio input is priced higher than text (2.5-flash audio input
 $1.00/1M). Gemini rates shown are the Gemini Developer API list; Vertex differs
 for the 2.0 family ($0.15 in / $0.60 out). Bedrock on-demand; cross-region
 inference profiles add ~10%, batch ≈50% off.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@
 [project]
 name = "ai_api_unified"
 
-version = "2.21.0" # keep in sync with src/ai_api_unified/__version__.py and the README.md title
+version = "2.22.0" # keep in sync with src/ai_api_unified/__version__.py and the README.md title
 description = "Unified access layer for AI completions (LLM), embedding (semantic), image, video, and voice services"
 authors = [{ name = "Dave Thomas", email = "davidcthomas@gmail.com" }]
 license = "MIT"

--- a/src/ai_api_unified/__version__.py
+++ b/src/ai_api_unified/__version__.py
@@ -9,4 +9,4 @@ from __future__ import annotations
 
 __all__: list[str] = ["__version__"]
 
-__version__: str = "2.21.0"
+__version__: str = "2.22.0"

--- a/src/ai_api_unified/pricing/pricing_registry.py
+++ b/src/ai_api_unified/pricing/pricing_registry.py
@@ -435,16 +435,18 @@ DICT_MODEL_INFO: dict[tuple[str, str], AIModelInfo] = dict(
             "claude-haiku-4-5",
             _tok("1.00", "5.00", "0.10", _SRC_ANTHROPIC),
         ),
-        # ── Anthropic completions (deprecated, still billable) ──────────────
+        # ── Anthropic completions (retired: hard 404) ───────────────────────
+        # Rates are retained on entries that were priced while active so
+        # historical cost enrichment can still price calls made before the
+        # withdrawal date; lifecycle enforcement is independent of pricing.
         _info(
             PROVIDER_ANTHROPIC,
             "claude-opus-4-1",
             _tok("15.00", "75.00", "1.50", _SRC_ANTHROPIC),
-            status=ModelLifecycleStatus.DEPRECATED,
+            status=ModelLifecycleStatus.RETIRED,
             sunset=date(2026, 8, 5),
             replacement="claude-opus-5",
         ),
-        # ── Anthropic completions (retired: hard 404) ───────────────────────
         _info(
             PROVIDER_ANTHROPIC,
             "claude-3-7-sonnet-20250219",
@@ -510,7 +512,12 @@ def _format_lifecycle_message(info: AIModelInfo) -> str:
         f"Model '{info.model}' ({info.provider}) is {info.status.value}"
     ]
     if info.sunset_date is not None:
-        parts.append(f"scheduled for withdrawal on {info.sunset_date.isoformat()}")
+        # Retired models are already withdrawn, so the date reads as history;
+        # deprecated ones are still served until it arrives.
+        if info.status is ModelLifecycleStatus.RETIRED:
+            parts.append(f"withdrawn on {info.sunset_date.isoformat()}")
+        else:
+            parts.append(f"scheduled for withdrawal on {info.sunset_date.isoformat()}")
     if info.recommended_replacement is not None:
         parts.append(f"use '{info.recommended_replacement}' instead")
     return "; ".join(parts) + "."

--- a/tests/test_anthropic_completions.py
+++ b/tests/test_anthropic_completions.py
@@ -31,7 +31,6 @@ from ai_api_unified.completions.ai_anthropic_completions import (
 from ai_api_unified.completions.ai_openai_completions import (
     AICompletionsPromptParamsOpenAI,
 )
-from ai_api_unified.pricing import pricing_registry
 from ai_api_unified.pricing.pricing_registry import (
     PROVIDER_ANTHROPIC,
     get_model_pricing,
@@ -351,9 +350,10 @@ class TestPricingAndLifecycle:
         assert haiku is not None
         assert haiku.token_rates.input_per_1m == Decimal("1.00")
 
-    def test_deprecated_model_is_still_priced(self) -> None:
-        # Deprecated models keep billing until retirement, so finops cost
-        # enrichment must still find rates for them.
+    def test_retired_model_retains_pricing(self) -> None:
+        # Retirement stops new calls but not cost enrichment: an entry priced
+        # while it was active keeps its rates so usage recorded before the
+        # withdrawal date can still be priced.
         pricing = get_model_pricing(PROVIDER_ANTHROPIC, "claude-opus-4-1")
         assert pricing is not None
         assert pricing.token_rates.input_per_1m == Decimal("15.00")
@@ -363,10 +363,13 @@ class TestPricingAndLifecycle:
             with pytest.raises(AiProviderConfigurationError, match="retired"):
                 AiAnthropicCompletions(model="claude-3-opus-20240229")
 
-    def test_deprecated_model_warns_once(self) -> None:
-        pricing_registry._SET_WARNED_MODELS.discard(
-            (PROVIDER_ANTHROPIC, "claude-opus-4-1")
-        )
+    def test_retired_opus_4_1_fails_fast_naming_replacement(self) -> None:
+        # claude-opus-4-1 was withdrawn 2026-08-05: construction must raise
+        # rather than warn, and the message reads as history, not a schedule.
         with patch.dict(os.environ, {"ANTHROPIC_API_KEY": "test-key"}):
-            with pytest.warns(DeprecationWarning, match="claude-opus-5"):
+            with pytest.raises(AiProviderConfigurationError) as excinfo:
                 AiAnthropicCompletions(model="claude-opus-4-1")
+        message = str(excinfo.value)
+        assert "retired" in message
+        assert "withdrawn on 2026-08-05" in message
+        assert "claude-opus-5" in message

--- a/tests/test_google_gemini.py
+++ b/tests/test_google_gemini.py
@@ -345,6 +345,48 @@ class TestGoogleGeminiModules:
                     assert hasattr(client, "send_prompt")
                     assert hasattr(client, "strict_schema_prompt")
 
+    def test_gemini_completions_deprecated_model_warns_and_proceeds(self):
+        """A deprecated model warns at construction but still builds a client.
+
+        This is the client-level half of the lifecycle policy: deprecated
+        warns and continues, retired raises. It lives here because Google is
+        the only provider with a deprecated completions model catalogued.
+        """
+        from ai_api_unified.pricing import pricing_registry
+        from ai_api_unified.pricing.pricing_registry import PROVIDER_GOOGLE
+
+        # The warning is deduped per process, so clear any prior emission.
+        pricing_registry._SET_WARNED_MODELS.discard(
+            (PROVIDER_GOOGLE, "gemini-2.0-flash")
+        )
+
+        completions_module = _import_google_gemini_completions_module()
+        with patch.object(completions_module, "genai") as mock_genai:
+            with patch.object(completions_module, "gerr"):
+                with patch.object(completions_module, "EnvSettings") as mock_env:
+                    mock_env_instance = Mock()
+                    mock_env_instance.get_setting.side_effect = (
+                        lambda key, default: default
+                    )
+                    mock_env.return_value = mock_env_instance
+
+                    mock_client = Mock()
+                    mock_models = Mock()
+                    mock_client.models = mock_models
+                    mock_models.get.return_value = None
+                    mock_genai.Client.return_value = mock_client
+                    mock_genai.types = Mock()
+
+                    from ai_api_unified.completions.ai_google_gemini_completions import (
+                        GoogleGeminiCompletions,
+                    )
+
+                    with pytest.warns(DeprecationWarning, match="gemini-2.5-flash"):
+                        client = GoogleGeminiCompletions(model="gemini-2.0-flash")
+
+                    # Warned rather than raised, and the client is usable.
+                    assert client.model_name == "gemini-2.0-flash"
+
     def test_gemini_embeddings_basic_functionality(self):
         """Test basic Google Gemini embeddings functionality with mocking."""
         embeddings_module = _import_google_gemini_embeddings_module()

--- a/tests/test_model_pricing.py
+++ b/tests/test_model_pricing.py
@@ -147,7 +147,9 @@ class TestLifecycle:
         with warnings.catch_warnings(record=True) as caught:
             warnings.simplefilter("always")
             enforce_model_lifecycle("google", "gemini-2.0-flash")
-        assert "scheduled for withdrawal on 2026-06-01" in str(caught[0].message)
+        dep = [w for w in caught if issubclass(w.category, DeprecationWarning)]
+        assert len(dep) == 1
+        assert "scheduled for withdrawal on 2026-06-01" in str(dep[0].message)
 
     def test_deprecated_model_warns_once(self) -> None:
         with warnings.catch_warnings(record=True) as caught:

--- a/tests/test_model_pricing.py
+++ b/tests/test_model_pricing.py
@@ -135,6 +135,20 @@ class TestLifecycle:
         with pytest.raises(AiProviderConfigurationError, match="retired"):
             enforce_model_lifecycle("google", "gemini-1.5-pro-002")
 
+    def test_sunset_date_phrasing_matches_status(self) -> None:
+        # A sunset date on a retired entry describes a past withdrawal; on a
+        # deprecated entry it is still a schedule.
+        with pytest.raises(AiProviderConfigurationError) as excinfo:
+            enforce_model_lifecycle("anthropic", "claude-opus-4-1")
+        retired_message = str(excinfo.value)
+        assert "withdrawn on 2026-08-05" in retired_message
+        assert "scheduled" not in retired_message
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            enforce_model_lifecycle("google", "gemini-2.0-flash")
+        assert "scheduled for withdrawal on 2026-06-01" in str(caught[0].message)
+
     def test_deprecated_model_warns_once(self) -> None:
         with warnings.catch_warnings(record=True) as caught:
             warnings.simplefilter("always")


### PR DESCRIPTION
## What

Anthropic withdraws `claude-opus-4-1` on **2026-08-05**. This lands the retirement so callers get a clear construction-time error naming `claude-opus-5`, rather than a deprecation warning followed by an opaque provider 404 once the model stops being served. Bumps to **2.22.0**.

- **Registry**: `claude-opus-4-1` moves `DEPRECATED` → `RETIRED`, keeping its rates, sunset date, and `claude-opus-5` replacement.
- **Retired entries keep their pricing.** Every pre-existing `RETIRED` entry was added after the fact and carries no rates, so it was ambiguous whether retiring an entry should strip pricing. It should not: cost enrichment prices *historical* usage, and calls made before the withdrawal date still need rates. Lifecycle enforcement already gates usage independently of whether pricing is present.
- **Message tense**: this is the first retired entry to carry a sunset date, which previously would have rendered as "scheduled for withdrawal on 2026-08-05" about a date already passed. Retired entries now read "withdrawn on `<date>`"; deprecated ones keep the schedule phrasing.
- **Docs**: README lifecycle section, `pricing_research.md` lifecycle note plus a legend for the ⚠/✖ table markers (the ⚠ marker was previously undocumented), CHANGELOG.

### Behavior change

Constructing a client on `claude-opus-4-1` now raises instead of warning:

```
AiProviderConfigurationError: Model 'claude-opus-4-1' (anthropic) is retired;
withdrawn on 2026-08-05; use 'claude-opus-5' instead.
```

Landing this on 2026-08-04 means the error arrives one day before the provider actually stops serving the model. That is deliberate — the alternative is shipping after callers have already started getting 404s.

**Version rationale:** minor, not patch. The repo policy buckets deprecations under minor, and this changes runtime behavior (warn → raise) rather than fixing a bug. No public API surface changed, so it is not major.

## Test changes

Anthropic no longer has any deprecated model, so the two tests that used `claude-opus-4-1` as their deprecation fixture had no valid subject. They are replaced by retired-model coverage:

- `test_retired_opus_4_1_fails_fast_naming_replacement` — raises, names the replacement, and reads as history
- `test_retired_model_retains_pricing` — rates survive retirement for historical costing
- `test_sunset_date_phrasing_matches_status` — retired vs deprecated phrasing contract

Dropping those tests removed the suite's only client-level assertion that a deprecated model **warns and still yields a usable client** (`pytest.warns(DeprecationWarning)` appeared nowhere afterwards). The review loop caught this and restored it on `gemini-2.0-flash`, the one remaining catalogued deprecated completions model:

- `test_gemini_completions_deprecated_model_warns_and_proceeds` — warns, names the replacement, and still builds a client

## Verification

- Full mocked regression: **579 passed** (`pytest -q -m "not nonmock"`), including `test_version_sync`.
- Manual end-to-end check: `claude-opus-4-1` raises with the message above; pricing lookup still returns `15.00`; `claude-opus-5` constructs normally.

<!-- pr-review-prep:start -->
## PR Composition

Composition percentages are based on changed lines (added + deleted) vs. the base branch `main`.

| Change Type | Lines Changed | Percentage |
|---|---:|---:|
| Core logic changes | 17 | 13% |
| Documentation | 33 | 25% |
| Tests | 79 | 60% |
| Other | 2 | 2% |
| Total | 131 | 100% |

Other = the `pyproject.toml` version line.
<!-- pr-review-prep:end -->

<!-- pr-content-attribution:start -->
## Content Attribution Summary

Based on changed lines across counted PR commits in this PR. Pure data files are excluded — their content is deterministic process output, not authored work.

| Attribution Type | Commits | Lines Changed | Percentage |
|---|---:|---:|---:|
| AI-attributed | 3 | 131 | 100% |
| Human-attributed | 0 | 0 | 0% |
| Bot-attributed | 0 | 0 | 0% |
| Total | 3 | 131 | 100% |

Excluded from attribution: none (no merge/sync commits, no data files).
<!-- pr-content-attribution:end -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014gRTVnVYzzxa6nx5aR62nD
