### PR TITLE
fix: voice caller-id attribution across all providers, OpenAI streaming, and AIFactory voice constructor (2.23.0)

### DIFF
--- a/.agents/memory/daily/2026-08-12/events/2026-08-12T18-03-00Z--2355287-davecthomas--thread_bcd551a6-ba5b-4ac4-8fb6-6b3182463480--turn_c19e1adf4e.md
+++ b/.agents/memory/daily/2026-08-12/events/2026-08-12T18-03-00Z--2355287-davecthomas--thread_bcd551a6-ba5b-4ac4-8fb6-6b3182463480--turn_c19e1adf4e.md
@@ -1,0 +1,60 @@
+---
+agentmemory_version: "0.4.4"
+timestamp: "2026-08-12T18:03:00Z"
+author: "2355287-davecthomas"
+branch: "fix/voice-caller-id-attribution-and-voice-factory"
+thread_id: "bcd551a6-ba5b-4ac4-8fb6-6b3182463480"
+turn_id: "c19e1adf4e"
+workstream_id: "thread-bcd551a6-ba5b-4ac4-8fb6-6b3182463480"
+workstream_scope: "thread"
+episode_id: "episode-main-b34c818a56"
+episode_scope: "mixed"
+checkpoint_goal: "Make voice a first-class capability of the unified library, reachable and attributable on the same terms as completions, embeddings, images, and video."
+checkpoint_surface: "The voice provider layer (src/ai_api_unified/voice/) where it meets the AIFactory entry point and the shared OpenAI base class that supplies caller-id attribution and retry configuration."
+checkpoint_outcome: "Added AIFactory.get_ai_voice_client() and repaired the pydantic-MRO defect that silently stripped the OpenAI voice client of every attribute AIOpenAIBase.__init__ would have set, shipping as 2.23.0."
+decision_candidate: true
+enriched: true
+ai_generated: true
+ai_model: "opus[1m]"
+ai_tool: "claude"
+ai_surface: "claude-code"
+ai_executor: "local-agent"
+related_adrs:
+files_touched:
+  - "README.md"
+  - "pyproject.toml"
+  - "src/ai_api_unified/__version__.py"
+  - "src/ai_api_unified/ai_factory.py"
+  - "src/ai_api_unified/ai_openai_base.py"
+  - "src/ai_api_unified/embeddings/ai_openai_embeddings.py"
+  - "src/ai_api_unified/voice/ai_voice_base.py"
+  - "src/ai_api_unified/voice/ai_voice_factory.py"
+  - "src/ai_api_unified/voice/ai_voice_openai.py"
+  - "tests/area_map.py"
+  - "tests/test_ai_factory_voice_client.py"
+  - "tests/test_observability_tts_phase_f.py"
+  - "tests/test_voice_caller_id_attribution.py"
+design_docs_touched:
+verification:
+  - "git diff:  11 files changed, 247 insertions(+), 60 deletions(-); # ai-api-unified 2.23.0; - `AIFactory.get_ai_voice_client()` (or `AIVoiceFactory.create()`); from ai_api_unified import AIFactory, AIVoiceBase"
+source_pending_shards:
+  - ".agents/memory/pending/2026-08-12/2026-08-12T18-03-00Z--2355287-davecthomas--thread_bcd551a6-ba5b-4ac4-8fb6-6b3182463480--turn_c19e1adf4e.md"
+---
+
+## Why
+
+- Voice was the one capability callers could not reach through AIFactory; it required the separate AIVoiceFactory.create(), which took no engine argument and so offered no override path. Underneath that inconsistency sat a real defect: AIVoiceOpenAI inherits from both AIVoiceBase (a pydantic BaseModel) and AIOpenAIBase, and pydantic's BaseModel sits ahead of AIOpenAIBase in the MRO without chaining to super(). AIOpenAIBase.__init__ therefore never ran, so user, retry_policy, async_client, and the rest were never assigned. Observability attribution passed self.user explicitly at each call site to paper over this, which meant any provider that forgot the argument silently emitted calls with no originating caller id. The general lesson for future work in this package: a pydantic voice model that also inherits a vendor base class cannot rely on the vendor initializer running.
+
+## What changed
+
+- Voice gained a factory constructor consistent with the other four capabilities, with AIVoiceFactory.create() now accepting an optional engine override and remaining supported as the delegate. Caller-id attribution moved from per-call-site arguments to a _resolve_legacy_caller_id() hook on AIVoiceBase that returns None by default and is overridden by the OpenAI provider to return its configured OPENAI_USER, so attribution is a provider property rather than something each call site must remember. The OpenAI voice provider now establishes its inherited AIOpenAIBase surface explicitly through PrivateAttr-backed properties, covering the env, api key, user, base URL, retry policy, and backoff schedule. A separate defect was fixed alongside: streaming text-to-speech called speech.create(stream=True), an argument no openai 2.x release accepts, and now goes through with_streaming_response. The OPENAI_USER setting key and its default were promoted to named constants shared with the embeddings provider.
+
+## Evidence
+
+- tests/test_voice_caller_id_attribution.py is a cross-provider guard that AST-inspects each voice provider initializer and asserts every attribute a skipped vendor __init__ would have assigned is established some other way — it fails for any future provider that reintroduces the MRO gap. tests/test_ai_factory_voice_client.py pins the factory delegation and engine-override passthrough. tests/test_observability_tts_phase_f.py was reworked for the hook-based attribution path. All three plus tests/test_version_sync.py pass (18 passed, 3 skipped); the three skips are the non-OpenAI providers, which have no skipped vendor initializer. Version bumped across the three required locations (pyproject.toml, __version__.py, README title) to 2.23.0, and README documents that OpenAI is the only voice engine exposing a vendor user setting, so other engines carry no caller id unless the application sets one through the observability context. Relates to the observability middleware line of ADR-0003 and ADR-0015.
+
+## Next
+
+- Only the OpenAI voice engine resolves a vendor caller id; Google, Azure, and ElevenLabs return None from the hook, so their calls remain unattributed unless the observability context supplies a caller. Decide whether that gap should be closed per-vendor or documented as permanent.
+- The same pydantic-plus-vendor-base MRO trap applies to any future voice provider that inherits a vendor base class; the AST guard test catches it, but the underlying inheritance shape is still the fragile part.
+- Version 2.23.0 is bumped but unreleased on this branch; the full mocked suite is the release gate.

--- a/.agents/memory/daily/2026-08-12/summary.md
+++ b/.agents/memory/daily/2026-08-12/summary.md
@@ -1,0 +1,41 @@
+# 2026-08-12 summary
+
+## Snapshot
+
+- Captured 1 memory event.
+- Main work: Voice gained a factory constructor consistent with the other four capabilities, with AIVoiceFactory.create() now accepting an optional engine override and remaining supported as the delegate. Caller-id attribution moved from per-call-site arguments to a _resolve_legacy_caller_id() hook on AIVoiceBase that returns None by default and is overridden by the OpenAI provider to return its configured OPENAI_USER, so attribution is a provider property rather than something each call site must remember. The OpenAI voice provider now establishes its inherited AIOpenAIBase surface explicitly through PrivateAttr-backed properties, covering the env, api key, user, base URL, retry policy, and backoff schedule. A separate defect was fixed alongside: streaming text-to-speech called speech.create(stream=True), an argument no openai 2.x release accepts, and now goes through with_streaming_response. The OPENAI_USER setting key and its default were promoted to named constants shared with the embeddings provider.
+- Top decision: Voice was the one capability callers could not reach through AIFactory; it required the separate AIVoiceFactory.create(), which took no engine argument and so offered no override path. Underneath that inconsistency sat a real defect: AIVoiceOpenAI inherits from both AIVoiceBase (a pydantic BaseModel) and AIOpenAIBase, and pydantic's BaseModel sits ahead of AIOpenAIBase in the MRO without chaining to super(). AIOpenAIBase.__init__ therefore never ran, so user, retry_policy, async_client, and the rest were never assigned. Observability attribution passed self.user explicitly at each call site to paper over this, which meant any provider that forgot the argument silently emitted calls with no originating caller id. The general lesson for future work in this package: a pydantic voice model that also inherits a vendor base class cannot rely on the vendor initializer running. ([2026-08-12 18:03:00 UTC by 2355287-davecthomas](events/2026-08-12T18-03-00Z--2355287-davecthomas--thread_bcd551a6-ba5b-4ac4-8fb6-6b3182463480--turn_c19e1adf4e.md))
+- Blockers: Voice was the one capability callers could not reach through AIFactory; it required the separate AIVoiceFactory.create(), which took no engine argument and so offered no override path. Underneath that inconsistency sat a real defect: AIVoiceOpenAI inherits from both AIVoiceBase (a pydantic BaseModel) and AIOpenAIBase, and pydantic's BaseModel sits ahead of AIOpenAIBase in the MRO without chaining to super(). AIOpenAIBase.__init__ therefore never ran, so user, retry_policy, async_client, and the rest were never assigned. Observability attribution passed self.user explicitly at each call site to paper over this, which meant any provider that forgot the argument silently emitted calls with no originating caller id. The general lesson for future work in this package: a pydantic voice model that also inherits a vendor base class cannot rely on the vendor initializer running.
+
+| Metric | Value |
+|---|---|
+| Memory events captured | 1 |
+| Repo files changed | 1 |
+| Decision candidates | 1 |
+| Active blockers | 1 |
+
+## Major work completed
+
+- Voice gained a factory constructor consistent with the other four capabilities, with AIVoiceFactory.create() now accepting an optional engine override and remaining supported as the delegate. Caller-id attribution moved from per-call-site arguments to a _resolve_legacy_caller_id() hook on AIVoiceBase that returns None by default and is overridden by the OpenAI provider to return its configured OPENAI_USER, so attribution is a provider property rather than something each call site must remember. The OpenAI voice provider now establishes its inherited AIOpenAIBase surface explicitly through PrivateAttr-backed properties, covering the env, api key, user, base URL, retry policy, and backoff schedule. A separate defect was fixed alongside: streaming text-to-speech called speech.create(stream=True), an argument no openai 2.x release accepts, and now goes through with_streaming_response. The OPENAI_USER setting key and its default were promoted to named constants shared with the embeddings provider.
+
+## Why this mattered
+
+- Voice was the one capability callers could not reach through AIFactory; it required the separate AIVoiceFactory.create(), which took no engine argument and so offered no override path. Underneath that inconsistency sat a real defect: AIVoiceOpenAI inherits from both AIVoiceBase (a pydantic BaseModel) and AIOpenAIBase, and pydantic's BaseModel sits ahead of AIOpenAIBase in the MRO without chaining to super(). AIOpenAIBase.__init__ therefore never ran, so user, retry_policy, async_client, and the rest were never assigned. Observability attribution passed self.user explicitly at each call site to paper over this, which meant any provider that forgot the argument silently emitted calls with no originating caller id. The general lesson for future work in this package: a pydantic voice model that also inherits a vendor base class cannot rely on the vendor initializer running.
+
+## Active blockers
+
+- Voice was the one capability callers could not reach through AIFactory; it required the separate AIVoiceFactory.create(), which took no engine argument and so offered no override path. Underneath that inconsistency sat a real defect: AIVoiceOpenAI inherits from both AIVoiceBase (a pydantic BaseModel) and AIOpenAIBase, and pydantic's BaseModel sits ahead of AIOpenAIBase in the MRO without chaining to super(). AIOpenAIBase.__init__ therefore never ran, so user, retry_policy, async_client, and the rest were never assigned. Observability attribution passed self.user explicitly at each call site to paper over this, which meant any provider that forgot the argument silently emitted calls with no originating caller id. The general lesson for future work in this package: a pydantic voice model that also inherits a vendor base class cannot rely on the vendor initializer running.
+
+## Decision candidates
+
+- Voice was the one capability callers could not reach through AIFactory; it required the separate AIVoiceFactory.create(), which took no engine argument and so offered no override path. Underneath that inconsistency sat a real defect: AIVoiceOpenAI inherits from both AIVoiceBase (a pydantic BaseModel) and AIOpenAIBase, and pydantic's BaseModel sits ahead of AIOpenAIBase in the MRO without chaining to super(). AIOpenAIBase.__init__ therefore never ran, so user, retry_policy, async_client, and the rest were never assigned. Observability attribution passed self.user explicitly at each call site to paper over this, which meant any provider that forgot the argument silently emitted calls with no originating caller id. The general lesson for future work in this package: a pydantic voice model that also inherits a vendor base class cannot rely on the vendor initializer running. ([2026-08-12 18:03:00 UTC by 2355287-davecthomas](events/2026-08-12T18-03-00Z--2355287-davecthomas--thread_bcd551a6-ba5b-4ac4-8fb6-6b3182463480--turn_c19e1adf4e.md))
+
+## Next likely steps
+
+- Only the OpenAI voice engine resolves a vendor caller id; Google, Azure, and ElevenLabs return None from the hook, so their calls remain unattributed unless the observability context supplies a caller. Decide whether that gap should be closed per-vendor or documented as permanent.
+- The same pydantic-plus-vendor-base MRO trap applies to any future voice provider that inherits a vendor base class; the AST guard test catches it, but the underlying inheritance shape is still the fragile part.
+- Version 2.23.0 is bumped but unreleased on this branch; the full mocked suite is the release gate.
+
+## Relevant event shards
+
+- [2026-08-12 18:03:00 UTC by 2355287-davecthomas](events/2026-08-12T18-03-00Z--2355287-davecthomas--thread_bcd551a6-ba5b-4ac4-8fb6-6b3182463480--turn_c19e1adf4e.md)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,33 @@ Notable changes per release, so consumers can gate on the package version.
 Versions follow [semantic versioning](https://semver.org/); the authoritative
 version lives in `pyproject.toml` (see the README release section).
 
+## 2.23.0
+
+- Fixed OpenAI text-to-speech: every `text_to_voice` and `stream_audio` call
+  raised `AttributeError` because pydantic's MRO skipped
+  `AIOpenAIBase.__init__`. The voice constructor now invokes that shared
+  initializer, so the inherited surface (`async_client`, organization lookup,
+  `OPENAI_USER` caller attribution) works.
+- Fixed OpenAI `stream_audio` passing an unsupported `stream=True` argument;
+  streaming now uses the SDK's `with_streaming_response` API.
+- Fixed a latent `AttributeError` in OpenAI `speech_to_text` rate-limit
+  backoff (`time.sleep` called on the `time` function).
+- Added `AIFactory.get_ai_voice_client(voice_engine=None, base_url=None,
+  retry_policy=None)`; `AIVoiceFactory.create()` gains the same optional
+  arguments and stays callable with none. The `base_url` and `retry_policy`
+  arguments apply to the `openai` engine and are rejected with
+  `AiProviderCapabilityUnsupportedError` on engines that cannot honor them.
+- Voice caller attribution now flows through
+  `AIVoiceBase._resolve_legacy_caller_id()`: OpenAI attributes to
+  `OPENAI_USER` (falling back to `default_user`), other voice engines stay
+  unattributed unless the application sets an observability context.
+- A present-but-blank `COMPLETIONS_RETRY_POLICY` or `OPENAI_USER` is now
+  treated as unconfigured across all engines instead of raising or silently
+  dropping attribution; explicit blank constructor arguments still raise.
+- Fixed `get_default_voice()` dropping `language`, `locale`, `accent`, and
+  `gender` from the returned selection, which mislabeled synthesis language
+  on Azure and Google.
+
 ## 2.22.0
 
 - `claude-opus-4-1` is now RETIRED (Anthropic withdrew it 2026-08-05) with

--- a/README.md
+++ b/README.md
@@ -748,9 +748,15 @@ explicit `voice_engine` override, matching the other capability constructors.
 It delegates to `AIVoiceFactory.create()`, which remains supported and callable
 with no arguments.
 
-Calls are attributed to `OPENAI_USER` on the OpenAI engine. The other voice
-engines expose no vendor user setting, so their calls carry no originating
-caller id unless the application sets one through the observability context.
+Calls are attributed to `OPENAI_USER` on the OpenAI engine, falling back to the
+`default_user` sentinel when it is unset — the same behavior the OpenAI
+completions, embeddings, images, and videos clients already have. The other
+voice engines expose no vendor user setting, so their calls carry no
+originating caller id unless the application sets one through the
+observability context.
+
+The OpenAI voice client also honors `COMPLETIONS_RETRY_POLICY`, since it shares
+`AIOpenAIBase`; set it to `none` to disable SDK-level retries for voice as well.
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -755,8 +755,22 @@ voice engines expose no vendor user setting, so their calls carry no
 originating caller id unless the application sets one through the
 observability context.
 
-The OpenAI voice client also honors `COMPLETIONS_RETRY_POLICY`, since it shares
-`AIOpenAIBase`; set it to `none` to disable SDK-level retries for voice as well.
+The OpenAI voice client shares `AIOpenAIBase` with the other OpenAI-backed
+capabilities, so it honors `COMPLETIONS_RETRY_POLICY` and `OPENAI_BASE_URL_OVERRIDE`,
+and accepts the same `retry_policy` and `base_url` constructor arguments:
+
+```python
+from ai_api_unified.voice.ai_voice_openai import AIVoiceOpenAI
+
+voice = AIVoiceOpenAI(
+    engine="openai",
+    base_url="https://gateway.example.com/v1",
+    retry_policy="none",
+)
+```
+
+A blank retry-policy setting (`COMPLETIONS_RETRY_POLICY=`) is treated as
+unconfigured and falls back to `default` across every OpenAI-backed capability.
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# ai-api-unified 2.22.0
+# ai-api-unified 2.23.0
 
 `ai-api-unified` is a unified Python library for AI completions, embeddings, image generation, video generation, and voice. Application code targets stable base interfaces and factory entry points while concrete providers are selected at runtime from environment configuration.
 
@@ -31,7 +31,7 @@ The public entry points are the stable base interfaces and factories:
 - `AIFactory.get_ai_embedding_client()`
 - `AIFactory.get_ai_images_client()`
 - `AIFactory.get_ai_video_client()`
-- `AIVoiceFactory.create()`
+- `AIFactory.get_ai_voice_client()` (or `AIVoiceFactory.create()`)
 
 ## Capabilities
 
@@ -734,14 +734,23 @@ Frame extraction requires the optional `video_frames` extra.
 ### Voice
 
 ```python
-from ai_api_unified import AIVoiceBase, AIVoiceFactory
+from ai_api_unified import AIFactory, AIVoiceBase
 
-voice: AIVoiceBase = AIVoiceFactory.create()
+voice: AIVoiceBase = AIFactory.get_ai_voice_client()
 audio_bytes: bytes = voice.text_to_speech("Hello from ai-api-unified")
 
 with open("out.wav", "wb") as output_file:
     output_file.write(audio_bytes)
 ```
+
+`AIFactory.get_ai_voice_client()` reads `AI_VOICE_ENGINE` and accepts an
+explicit `voice_engine` override, matching the other capability constructors.
+It delegates to `AIVoiceFactory.create()`, which remains supported and callable
+with no arguments.
+
+Calls are attributed to `OPENAI_USER` on the OpenAI engine. The other voice
+engines expose no vendor user setting, so their calls carry no originating
+caller id unless the application sets one through the observability context.
 
 ## Configuration
 
@@ -1004,7 +1013,7 @@ Factory entry points:
 - `AIFactory.get_ai_embedding_client()`
 - `AIFactory.get_ai_images_client()`
 - `AIFactory.get_ai_video_client()`
-- `AIVoiceFactory.create()`
+- `AIFactory.get_ai_voice_client()` (or `AIVoiceFactory.create()`)
 
 Concrete providers are no longer re-exported from package `__init__.py` modules. If you need a concrete class directly, import it from its implementation module, for example:
 

--- a/README.md
+++ b/README.md
@@ -737,11 +737,19 @@ Frame extraction requires the optional `video_frames` extra.
 from ai_api_unified import AIFactory, AIVoiceBase
 
 voice: AIVoiceBase = AIFactory.get_ai_voice_client()
-audio_bytes: bytes = voice.text_to_speech("Hello from ai-api-unified")
+audio_bytes: bytes = voice.text_to_voice(
+    text_to_convert="Hello from ai-api-unified",
+    voice=voice.get_default_voice(),
+    audio_format=voice.default_audio_format,
+)
 
-with open("out.wav", "wb") as output_file:
+with open(f"out{voice.default_audio_format.file_extension}", "wb") as output_file:
     output_file.write(audio_bytes)
 ```
+
+`text_to_voice` is keyword-only, and `voice` and `audio_format` are required;
+`get_default_voice()` and `default_audio_format` supply the provider's own
+defaults. Use `stream_audio(text)` for the streaming variant.
 
 `AIFactory.get_ai_voice_client()` reads `AI_VOICE_ENGINE` and accepts an
 explicit `voice_engine` override, matching the other capability constructors.
@@ -760,14 +768,16 @@ capabilities, so it honors `COMPLETIONS_RETRY_POLICY` and `OPENAI_BASE_URL_OVERR
 and accepts the same `retry_policy` and `base_url` constructor arguments:
 
 ```python
-from ai_api_unified.voice.ai_voice_openai import AIVoiceOpenAI
-
-voice = AIVoiceOpenAI(
-    engine="openai",
+voice = AIFactory.get_ai_voice_client(
+    voice_engine="openai",
     base_url="https://gateway.example.com/v1",
     retry_policy="none",
 )
 ```
+
+Only the `openai` voice engine accepts these; passing them to `google`,
+`azure`, or `elevenlabs` raises `AiProviderCapabilityUnsupportedError` rather
+than ignoring them.
 
 A blank retry-policy setting (`COMPLETIONS_RETRY_POLICY=`) is treated as
 unconfigured and falls back to `default` across every OpenAI-backed capability.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@
 [project]
 name = "ai_api_unified"
 
-version = "2.22.0" # keep in sync with src/ai_api_unified/__version__.py and the README.md title
+version = "2.23.0" # keep in sync with src/ai_api_unified/__version__.py and the README.md title
 description = "Unified access layer for AI completions (LLM), embedding (semantic), image, video, and voice services"
 authors = [{ name = "Dave Thomas", email = "davidcthomas@gmail.com" }]
 license = "MIT"

--- a/src/ai_api_unified/__version__.py
+++ b/src/ai_api_unified/__version__.py
@@ -9,4 +9,4 @@ from __future__ import annotations
 
 __all__: list[str] = ["__version__"]
 
-__version__: str = "2.22.0"
+__version__: str = "2.23.0"

--- a/src/ai_api_unified/ai_anthropic_base.py
+++ b/src/ai_api_unified/ai_anthropic_base.py
@@ -25,7 +25,7 @@ from ai_api_unified.ai_base import (
     ORG_INFO_SOURCE_RESPONSE_HEADER,
     RETRY_POLICY_DEFAULT,
     RETRY_POLICY_NONE,
-    normalize_retry_policy,
+    resolve_retry_policy,
 )
 from ai_api_unified.ai_provider_exceptions import AiProviderRequestError
 from ai_api_unified.util.env_settings import EnvSettings
@@ -143,13 +143,13 @@ class AIAnthropicBase:
         Raises:
             ValueError: When an unrecognized retry policy value is supplied.
         """
-        str_candidate: str = (
-            retry_policy
-            if retry_policy is not None
-            else str(self.env.get_setting(RETRY_POLICY_KEY, RETRY_POLICY_DEFAULT))
-        )
         # Normal return with the normalized retry policy token.
-        return normalize_retry_policy(str_candidate)
+        return resolve_retry_policy(
+            str_explicit=retry_policy,
+            object_configured=self.env.get_setting(
+                RETRY_POLICY_KEY, RETRY_POLICY_DEFAULT
+            ),
+        )
 
     @property
     def async_client(self) -> AsyncAnthropic:

--- a/src/ai_api_unified/ai_base.py
+++ b/src/ai_api_unified/ai_base.py
@@ -470,6 +470,44 @@ def normalize_retry_policy(retry_policy: str) -> str:
     return str_normalized
 
 
+def resolve_retry_policy(
+    *,
+    str_explicit: str | None,
+    object_configured: object,
+) -> str:
+    """
+    Resolves one retry policy from an explicit argument or configuration.
+
+    Every engine reads the same COMPLETIONS_RETRY_POLICY key, so they must agree
+    on what a blank value means. Configuration that is present but blank is
+    unconfigured: settings accessors return "" rather than the default for such a
+    key, and a stray `COMPLETIONS_RETRY_POLICY=` line must not break construction.
+    An argument a caller typed is validated as given, because passing "" is a
+    mistake worth reporting rather than silently defaulting.
+
+    Takes the already-read configuration value rather than an accessor, since
+    engines source it from either EnvSettings or a settings mapping.
+
+    Args:
+        str_explicit: Retry policy supplied by the caller, or None when absent.
+        object_configured: Raw configured value read from environment or settings.
+
+    Returns:
+        Normalized retry policy token ("default" or "none").
+
+    Raises:
+        ValueError: When an explicit or non-blank configured value is unrecognized.
+    """
+    if str_explicit is not None:
+        # Early return validating the caller's argument exactly as supplied.
+        return normalize_retry_policy(str_explicit)
+    str_configured: str = (
+        str(object_configured).strip() if object_configured is not None else ""
+    )
+    # Normal return treating a blank configured value as unconfigured.
+    return normalize_retry_policy(str_configured or RETRY_POLICY_DEFAULT)
+
+
 class AIFinishReason(str, Enum):
     """
     Normalized reason a completions turn stopped, uniform across engines.

--- a/src/ai_api_unified/ai_factory.py
+++ b/src/ai_api_unified/ai_factory.py
@@ -53,9 +53,6 @@ VIDEO_MODEL_NAME_KEY: str = "VIDEO_MODEL_NAME"
 FROZENSET_BASE_URL_OVERRIDE_COMPLETIONS_ENGINES: frozenset[str] = frozenset(
     {"claude", "openai", "openai-responses", "google-gemini"}
 )
-# Only the OpenAI voice provider shares AIOpenAIBase, so it is the one voice
-# engine whose constructor accepts a base-URL override or a retry policy.
-FROZENSET_BASE_URL_OVERRIDE_VOICE_ENGINES: frozenset[str] = frozenset({"openai"})
 VIDEO_ENGINE_KEY: str = "VIDEO_ENGINE"
 
 
@@ -580,18 +577,12 @@ class AIFactory:
             str_engine_override=voice_engine,
         )
 
+        # AIVoiceFactory owns the per-engine support check, since it is the
+        # layer that accepts and forwards these arguments.
         dict_provider_kwargs: dict[str, Any] = {}
         if base_url is not None:
-            AIFactory._require_base_url_override_support(
-                str_engine=str_voice_engine,
-                frozenset_supported=FROZENSET_BASE_URL_OVERRIDE_VOICE_ENGINES,
-            )
             dict_provider_kwargs["base_url"] = base_url
         if retry_policy is not None:
-            AIFactory._require_base_url_override_support(
-                str_engine=str_voice_engine,
-                frozenset_supported=FROZENSET_BASE_URL_OVERRIDE_VOICE_ENGINES,
-            )
             dict_provider_kwargs["retry_policy"] = retry_policy
         # Normal return with the voice client resolved by the voice factory.
         return AIVoiceFactory.create(str_voice_engine, **dict_provider_kwargs)

--- a/src/ai_api_unified/ai_factory.py
+++ b/src/ai_api_unified/ai_factory.py
@@ -30,6 +30,8 @@ from .ai_provider_registry import (
     get_ai_provider_spec,
 )
 from .util.env_settings import EnvSettings
+from .voice.ai_voice_base import AIVoiceBase
+from .voice.ai_voice_factory import AIVoiceFactory
 
 _LOGGER: logging.Logger = logging.getLogger(__name__)
 
@@ -52,6 +54,7 @@ FROZENSET_BASE_URL_OVERRIDE_COMPLETIONS_ENGINES: frozenset[str] = frozenset(
     {"claude", "openai", "openai-responses", "google-gemini"}
 )
 VIDEO_ENGINE_KEY: str = "VIDEO_ENGINE"
+AI_VOICE_ENGINE_KEY: str = "AI_VOICE_ENGINE"
 
 
 def _is_python_module_available(str_module_name: str) -> bool:
@@ -547,3 +550,28 @@ class AIFactory:
             raise
         except AiProviderRuntimeError:
             raise
+
+    @staticmethod
+    def get_ai_voice_client(
+        voice_engine: str | None = None,
+    ) -> AIVoiceBase:
+        """
+        Instantiates the configured voice (text-to-speech) client.
+
+        Delegates to AIVoiceFactory, which owns voice provider construction, so
+        every capability is reachable from the same factory.
+
+        Args:
+            voice_engine: Optional engine override; falls back to AI_VOICE_ENGINE config.
+
+        Returns:
+            Concrete AIVoiceBase implementation for the requested voice engine.
+        """
+        env_settings: EnvSettings = EnvSettings()
+        str_voice_engine: str = AIFactory._resolve_required_engine(
+            env_settings=env_settings,
+            str_engine_key=AI_VOICE_ENGINE_KEY,
+            str_engine_override=voice_engine,
+        )
+        # Normal return with the voice client resolved by the voice factory.
+        return AIVoiceFactory.create(str_voice_engine)

--- a/src/ai_api_unified/ai_factory.py
+++ b/src/ai_api_unified/ai_factory.py
@@ -31,7 +31,7 @@ from .ai_provider_registry import (
 )
 from .util.env_settings import EnvSettings
 from .voice.ai_voice_base import AIVoiceBase
-from .voice.ai_voice_factory import AIVoiceFactory
+from .voice.ai_voice_factory import AI_VOICE_ENGINE_ENV_KEY, AIVoiceFactory
 
 _LOGGER: logging.Logger = logging.getLogger(__name__)
 
@@ -54,7 +54,6 @@ FROZENSET_BASE_URL_OVERRIDE_COMPLETIONS_ENGINES: frozenset[str] = frozenset(
     {"claude", "openai", "openai-responses", "google-gemini"}
 )
 VIDEO_ENGINE_KEY: str = "VIDEO_ENGINE"
-AI_VOICE_ENGINE_KEY: str = "AI_VOICE_ENGINE"
 
 
 def _is_python_module_available(str_module_name: str) -> bool:
@@ -570,7 +569,7 @@ class AIFactory:
         env_settings: EnvSettings = EnvSettings()
         str_voice_engine: str = AIFactory._resolve_required_engine(
             env_settings=env_settings,
-            str_engine_key=AI_VOICE_ENGINE_KEY,
+            str_engine_key=AI_VOICE_ENGINE_ENV_KEY,
             str_engine_override=voice_engine,
         )
         # Normal return with the voice client resolved by the voice factory.

--- a/src/ai_api_unified/ai_factory.py
+++ b/src/ai_api_unified/ai_factory.py
@@ -53,6 +53,9 @@ VIDEO_MODEL_NAME_KEY: str = "VIDEO_MODEL_NAME"
 FROZENSET_BASE_URL_OVERRIDE_COMPLETIONS_ENGINES: frozenset[str] = frozenset(
     {"claude", "openai", "openai-responses", "google-gemini"}
 )
+# Only the OpenAI voice provider shares AIOpenAIBase, so it is the one voice
+# engine whose constructor accepts a base-URL override or a retry policy.
+FROZENSET_BASE_URL_OVERRIDE_VOICE_ENGINES: frozenset[str] = frozenset({"openai"})
 VIDEO_ENGINE_KEY: str = "VIDEO_ENGINE"
 
 
@@ -553,6 +556,8 @@ class AIFactory:
     @staticmethod
     def get_ai_voice_client(
         voice_engine: str | None = None,
+        base_url: str | None = None,
+        retry_policy: str | None = None,
     ) -> AIVoiceBase:
         """
         Instantiates the configured voice (text-to-speech) client.
@@ -562,6 +567,8 @@ class AIFactory:
 
         Args:
             voice_engine: Optional engine override; falls back to AI_VOICE_ENGINE config.
+            base_url: Optional API base-URL override for engines whose SDK accepts one.
+            retry_policy: Optional retry policy for engines whose SDK accepts one.
 
         Returns:
             Concrete AIVoiceBase implementation for the requested voice engine.
@@ -572,5 +579,19 @@ class AIFactory:
             str_engine_key=AI_VOICE_ENGINE_ENV_KEY,
             str_engine_override=voice_engine,
         )
+
+        dict_provider_kwargs: dict[str, Any] = {}
+        if base_url is not None:
+            AIFactory._require_base_url_override_support(
+                str_engine=str_voice_engine,
+                frozenset_supported=FROZENSET_BASE_URL_OVERRIDE_VOICE_ENGINES,
+            )
+            dict_provider_kwargs["base_url"] = base_url
+        if retry_policy is not None:
+            AIFactory._require_base_url_override_support(
+                str_engine=str_voice_engine,
+                frozenset_supported=FROZENSET_BASE_URL_OVERRIDE_VOICE_ENGINES,
+            )
+            dict_provider_kwargs["retry_policy"] = retry_policy
         # Normal return with the voice client resolved by the voice factory.
-        return AIVoiceFactory.create(str_voice_engine)
+        return AIVoiceFactory.create(str_voice_engine, **dict_provider_kwargs)

--- a/src/ai_api_unified/ai_openai_base.py
+++ b/src/ai_api_unified/ai_openai_base.py
@@ -81,22 +81,23 @@ class AIOpenAIBase:
             raise ValueError("OPENAI_API_KEY environment variable must be set.")
         self.base_url = self.get_api_base_url(base_url=base_url)
 
-        # get_setting returns "" for a key that is present but blank, not the
-        # default, and "" is not a valid policy. Treat blank as unconfigured so a
-        # stray `COMPLETIONS_RETRY_POLICY=` line cannot break client construction.
-        object_configured_policy: object = (
-            retry_policy
-            if retry_policy is not None
-            else self.env.get_setting(RETRY_POLICY_KEY, RETRY_POLICY_DEFAULT)
-        )
-        str_candidate: str = (
-            str(object_configured_policy).strip()
-            if object_configured_policy is not None
-            else ""
-        )
-        self.retry_policy: str = normalize_retry_policy(
-            str_candidate or RETRY_POLICY_DEFAULT
-        )
+        # An explicit argument is validated as given: a caller passing "" made a
+        # mistake and should hear about it. Only the environment value treats
+        # blank as unconfigured, because get_setting returns "" rather than the
+        # default for a present-but-blank key, and a stray
+        # `COMPLETIONS_RETRY_POLICY=` line must not break client construction.
+        str_candidate: str
+        if retry_policy is not None:
+            str_candidate = retry_policy
+        else:
+            object_env_policy: object = self.env.get_setting(
+                RETRY_POLICY_KEY, RETRY_POLICY_DEFAULT
+            )
+            str_env_policy: str = (
+                str(object_env_policy).strip() if object_env_policy is not None else ""
+            )
+            str_candidate = str_env_policy or RETRY_POLICY_DEFAULT
+        self.retry_policy: str = normalize_retry_policy(str_candidate)
         dict_client_kwargs: dict[str, Any] = {
             "api_key": self.api_key,
             "base_url": self.base_url,

--- a/src/ai_api_unified/ai_openai_base.py
+++ b/src/ai_api_unified/ai_openai_base.py
@@ -15,7 +15,7 @@ from ai_api_unified.ai_base import (
     ORG_INFO_SOURCE_RESPONSE_HEADER,
     RETRY_POLICY_DEFAULT,
     RETRY_POLICY_NONE,
-    normalize_retry_policy,
+    resolve_retry_policy,
 )
 from ai_api_unified.ai_provider_exceptions import AiProviderRequestError
 from ai_api_unified.util.env_settings import EnvSettings
@@ -81,23 +81,12 @@ class AIOpenAIBase:
             raise ValueError("OPENAI_API_KEY environment variable must be set.")
         self.base_url = self.get_api_base_url(base_url=base_url)
 
-        # An explicit argument is validated as given: a caller passing "" made a
-        # mistake and should hear about it. Only the environment value treats
-        # blank as unconfigured, because get_setting returns "" rather than the
-        # default for a present-but-blank key, and a stray
-        # `COMPLETIONS_RETRY_POLICY=` line must not break client construction.
-        str_candidate: str
-        if retry_policy is not None:
-            str_candidate = retry_policy
-        else:
-            object_env_policy: object = self.env.get_setting(
+        self.retry_policy: str = resolve_retry_policy(
+            str_explicit=retry_policy,
+            object_configured=self.env.get_setting(
                 RETRY_POLICY_KEY, RETRY_POLICY_DEFAULT
-            )
-            str_env_policy: str = (
-                str(object_env_policy).strip() if object_env_policy is not None else ""
-            )
-            str_candidate = str_env_policy or RETRY_POLICY_DEFAULT
-        self.retry_policy: str = normalize_retry_policy(str_candidate)
+            ),
+        )
         dict_client_kwargs: dict[str, Any] = {
             "api_key": self.api_key,
             "base_url": self.base_url,

--- a/src/ai_api_unified/ai_openai_base.py
+++ b/src/ai_api_unified/ai_openai_base.py
@@ -24,6 +24,8 @@ _LOGGER: logging.Logger = logging.getLogger(__name__)
 
 RETRY_POLICY_KEY: str = "COMPLETIONS_RETRY_POLICY"
 OPENAI_BASE_URL_OVERRIDE_SETTING: str = "OPENAI_BASE_URL_OVERRIDE"
+OPENAI_USER_SETTING_KEY: str = "OPENAI_USER"
+DEFAULT_OPENAI_USER: str = "default_user"
 OPENAI_ME_PATH: str = "/me"
 OPENAI_ORG_ID_RESPONSE_HEADER: str = "openai-organization"
 ORG_RESOLUTION_TIMEOUT_SECONDS: float = 10.0
@@ -68,7 +70,7 @@ class AIOpenAIBase:
         """
         self.env = EnvSettings()
         self.api_key = self.env.get_setting("OPENAI_API_KEY")
-        self.user = self.env.get_setting("OPENAI_USER", "default_user")
+        self.user = self.env.get_setting(OPENAI_USER_SETTING_KEY, DEFAULT_OPENAI_USER)
         if not self.api_key or self.api_key.strip() == "":
             raise ValueError("OPENAI_API_KEY environment variable must be set.")
         self.base_url = self.get_api_base_url(base_url=base_url)

--- a/src/ai_api_unified/ai_openai_base.py
+++ b/src/ai_api_unified/ai_openai_base.py
@@ -75,12 +75,22 @@ class AIOpenAIBase:
             raise ValueError("OPENAI_API_KEY environment variable must be set.")
         self.base_url = self.get_api_base_url(base_url=base_url)
 
-        str_candidate: str = (
+        # get_setting returns "" for a key that is present but blank, not the
+        # default, and "" is not a valid policy. Treat blank as unconfigured so a
+        # stray `COMPLETIONS_RETRY_POLICY=` line cannot break client construction.
+        object_configured_policy: object = (
             retry_policy
             if retry_policy is not None
-            else str(self.env.get_setting(RETRY_POLICY_KEY, RETRY_POLICY_DEFAULT))
+            else self.env.get_setting(RETRY_POLICY_KEY, RETRY_POLICY_DEFAULT)
         )
-        self.retry_policy: str = normalize_retry_policy(str_candidate)
+        str_candidate: str = (
+            str(object_configured_policy).strip()
+            if object_configured_policy is not None
+            else ""
+        )
+        self.retry_policy: str = normalize_retry_policy(
+            str_candidate or RETRY_POLICY_DEFAULT
+        )
         dict_client_kwargs: dict[str, Any] = {
             "api_key": self.api_key,
             "base_url": self.base_url,

--- a/src/ai_api_unified/ai_openai_base.py
+++ b/src/ai_api_unified/ai_openai_base.py
@@ -70,7 +70,13 @@ class AIOpenAIBase:
         """
         self.env = EnvSettings()
         self.api_key = self.env.get_setting("OPENAI_API_KEY")
-        self.user = self.env.get_setting(OPENAI_USER_SETTING_KEY, DEFAULT_OPENAI_USER)
+        # Blank is unconfigured here too: a present-but-blank OPENAI_USER would
+        # otherwise resolve to "" and drop caller attribution to None, while the
+        # documented contract promises the sentinel.
+        str_configured_user: str = str(
+            self.env.get_setting(OPENAI_USER_SETTING_KEY, DEFAULT_OPENAI_USER) or ""
+        ).strip()
+        self.user = str_configured_user or DEFAULT_OPENAI_USER
         if not self.api_key or self.api_key.strip() == "":
             raise ValueError("OPENAI_API_KEY environment variable must be set.")
         self.base_url = self.get_api_base_url(base_url=base_url)

--- a/src/ai_api_unified/completions/ai_bedrock_completions.py
+++ b/src/ai_api_unified/completions/ai_bedrock_completions.py
@@ -24,6 +24,7 @@ from ..ai_base import (
     RETRY_POLICY_NONE,
     SupportedDataType,
     normalize_retry_policy,
+    resolve_retry_policy,
 )
 from ..ai_bedrock_base import AIBedrockBase, BotoCoreError, ClientError
 from ..ai_provider_exceptions import (
@@ -118,12 +119,12 @@ class AiBedrockCompletions(AIBedrockBase, AIBaseCompletions):
         )
         self.completions_model: str = resolved_model
         enforce_model_lifecycle(PROVIDER_BEDROCK, resolved_model)
-        str_retry_candidate: str = (
-            retry_policy
-            if retry_policy is not None
-            else str(settings.get("COMPLETIONS_RETRY_POLICY", RETRY_POLICY_DEFAULT))
+        self.retry_policy: str = resolve_retry_policy(
+            str_explicit=retry_policy,
+            object_configured=settings.get(
+                "COMPLETIONS_RETRY_POLICY", RETRY_POLICY_DEFAULT
+            ),
         )
-        self.retry_policy: str = normalize_retry_policy(str_retry_candidate)
         AIBedrockBase.__init__(self, model=resolved_model, **kwargs)
         AIBaseCompletions.__init__(self, model=resolved_model, **kwargs)
         # Reuse the existing retry schedule from the base but allow overrides via kwargs

--- a/src/ai_api_unified/completions/ai_google_gemini_completions.py
+++ b/src/ai_api_unified/completions/ai_google_gemini_completions.py
@@ -60,6 +60,7 @@ from ..ai_base import (
     RETRY_POLICY_NONE,
     SupportedDataType,
     normalize_retry_policy,
+    resolve_retry_policy,
 )
 from ..ai_provider_exceptions import AiProviderRequestError
 from ..middleware.observability_runtime import (
@@ -164,14 +165,12 @@ class GoogleGeminiCompletions(AIBaseCompletions, AIGoogleBase):
         AIGoogleBase.__init__(self, **kwargs)
         self._str_base_url_override: str | None = base_url
         self.env: EnvSettings = EnvSettings()
-        str_retry_candidate: str = (
-            retry_policy
-            if retry_policy is not None
-            else str(
-                self.env.get_setting("COMPLETIONS_RETRY_POLICY", RETRY_POLICY_DEFAULT)
-            )
+        self.retry_policy: str = resolve_retry_policy(
+            str_explicit=retry_policy,
+            object_configured=self.env.get_setting(
+                "COMPLETIONS_RETRY_POLICY", RETRY_POLICY_DEFAULT
+            ),
         )
-        self.retry_policy: str = normalize_retry_policy(str_retry_candidate)
         self.geo_residency: str | None = self.env.get_geo_residency()
         if self.geo_residency:
             _LOGGER.warning(

--- a/src/ai_api_unified/embeddings/ai_openai_embeddings.py
+++ b/src/ai_api_unified/embeddings/ai_openai_embeddings.py
@@ -116,7 +116,13 @@ class AiOpenAIEmbeddings(AIBaseEmbeddings, AIOpenAIBase):
         self.base_url = self.get_api_base_url()
         self.client = OpenAI(api_key=self.api_key, base_url=self.base_url)
         self.backoff_delays = [1, 2, 4, 8, 16]
-        self.user = env.get_setting(OPENAI_USER_SETTING_KEY, DEFAULT_OPENAI_USER)
+        # Blank is unconfigured, matching AIOpenAIBase: a present-but-blank
+        # OPENAI_USER would otherwise resolve to "" and normalize to None,
+        # dropping caller attribution only for embeddings.
+        str_configured_user: str = str(
+            env.get_setting(OPENAI_USER_SETTING_KEY, DEFAULT_OPENAI_USER) or ""
+        ).strip()
+        self.user = str_configured_user or DEFAULT_OPENAI_USER
 
     @property
     def model_name(self) -> str:

--- a/src/ai_api_unified/embeddings/ai_openai_embeddings.py
+++ b/src/ai_api_unified/embeddings/ai_openai_embeddings.py
@@ -9,7 +9,11 @@ import httpx
 from openai import BadRequestError, OpenAI
 from openai.types import CreateEmbeddingResponse, EmbeddingCreateParams
 
-from ai_api_unified.ai_openai_base import AIOpenAIBase
+from ai_api_unified.ai_openai_base import (
+    AIOpenAIBase,
+    DEFAULT_OPENAI_USER,
+    OPENAI_USER_SETTING_KEY,
+)
 
 from ..ai_base import (
     AIBaseEmbeddings,
@@ -112,7 +116,7 @@ class AiOpenAIEmbeddings(AIBaseEmbeddings, AIOpenAIBase):
         self.base_url = self.get_api_base_url()
         self.client = OpenAI(api_key=self.api_key, base_url=self.base_url)
         self.backoff_delays = [1, 2, 4, 8, 16]
-        self.user = env.get_setting("OPENAI_USER", "default_user")
+        self.user = env.get_setting(OPENAI_USER_SETTING_KEY, DEFAULT_OPENAI_USER)
 
     @property
     def model_name(self) -> str:

--- a/src/ai_api_unified/embeddings/ai_voyage_embeddings.py
+++ b/src/ai_api_unified/embeddings/ai_voyage_embeddings.py
@@ -28,7 +28,7 @@ from ..ai_base import (
     RETRY_POLICY_DEFAULT,
     RETRY_POLICY_NONE,
     SupportedDataType,
-    normalize_retry_policy,
+    resolve_retry_policy,
 )
 from ..ai_provider_exceptions import (
     AiProviderDependencyUnavailableError,
@@ -153,14 +153,12 @@ class AiVoyageEmbeddings(AIBaseEmbeddings):
         )
         int_dimensions: int = dimensions or self._capabilities.default_dimensions
         super().__init__(model=self.embedding_model, dimensions=int_dimensions)
-        str_retry_candidate: str = (
-            retry_policy
-            if retry_policy is not None
-            else str(
-                self.env.get_setting("COMPLETIONS_RETRY_POLICY", RETRY_POLICY_DEFAULT)
-            )
+        self.retry_policy: str = resolve_retry_policy(
+            str_explicit=retry_policy,
+            object_configured=self.env.get_setting(
+                "COMPLETIONS_RETRY_POLICY", RETRY_POLICY_DEFAULT
+            ),
         )
-        self.retry_policy: str = normalize_retry_policy(str_retry_candidate)
         # SDK clients are created lazily so the voyageai import happens only
         # on first use; construction works without the extra installed.
         self._client: Any | None = None

--- a/src/ai_api_unified/voice/ai_voice_base.py
+++ b/src/ai_api_unified/voice/ai_voice_base.py
@@ -663,10 +663,11 @@ class AIVoiceBase(BaseModel, ABC):
                 "No voices available. Call get_available_voices() first."
             )
         first_voice: AIVoiceSelectionBase = self.list_available_voices[0]
-        return AIVoiceSelectionBase(
-            voice_id=first_voice.voice_id,
-            voice_name=first_voice.voice_name,
-        )
+        # Copy the catalog entry whole: rebuilding from voice_id and voice_name
+        # dropped language, locale, accent, and gender, and Azure and Google
+        # read locale during synthesis, so the rebuilt default synthesized a
+        # non-English voice under an en-US language tag.
+        return first_voice.model_copy()
 
     def get_available_voices(self) -> list[AIVoiceSelectionBase]:
         """Return the cached list of voices."""

--- a/src/ai_api_unified/voice/ai_voice_base.py
+++ b/src/ai_api_unified/voice/ai_voice_base.py
@@ -294,14 +294,19 @@ class AIVoiceBase(BaseModel, ABC):
         Args:
             operation: Public operation name such as `text_to_voice` or `stream_audio`.
             dict_metadata: Optional scalar metadata describing the request side of the call.
-            legacy_caller_id: Optional explicit legacy caller hint supplied by existing config.
+            legacy_caller_id: Optional explicit legacy caller hint overriding the provider default.
 
         Returns:
             AiApiCallContextModel containing shared metadata for input, output, and error events.
         """
         observability_context = get_observability_context()
+        effective_legacy_caller_id: str | None = (
+            legacy_caller_id
+            if legacy_caller_id is not None
+            else self._resolve_legacy_caller_id()
+        )
         resolved_caller_id, caller_id_source = resolve_originating_caller(
-            legacy_caller_id=legacy_caller_id
+            legacy_caller_id=effective_legacy_caller_id
         )
         dict_context_metadata: dict[str, ObservabilityMetadataValue] = dict(
             dict_metadata or {}
@@ -481,6 +486,24 @@ class AIVoiceBase(BaseModel, ABC):
             # Early return with the configured default voice model identifier.
             return self.default_model_id
         # Early return because no voice model identifier is currently available.
+        return None
+
+    def _resolve_legacy_caller_id(self) -> str | None:
+        """
+        Resolves the vendor-configured legacy caller identifier for observability attribution.
+
+        Voice providers are pydantic models, so a vendor base class listed after
+        `AIVoiceBase` in the MRO never has its `__init__` run and never gets to
+        assign attributes such as `user`. Providers therefore override this hook
+        instead of reading vendor state directly at the call site.
+
+        Args:
+            None
+
+        Returns:
+            Vendor-configured legacy caller identifier, or None when the vendor has no such setting.
+        """
+        # Normal return because the vendor exposes no legacy caller identifier by default.
         return None
 
     def _resolve_observability_provider_vendor(self) -> str:

--- a/src/ai_api_unified/voice/ai_voice_factory.py
+++ b/src/ai_api_unified/voice/ai_voice_factory.py
@@ -8,6 +8,7 @@ import logging
 from typing import Any
 
 from ai_api_unified.ai_provider_exceptions import (
+    AiProviderCapabilityUnsupportedError,
     AiProviderConfigurationError,
     AiProviderDependencyUnavailableError,
     AiProviderRuntimeError,
@@ -24,6 +25,12 @@ from ai_api_unified.voice.ai_voice_base import AIVoiceBase
 _LOGGER: logging.Logger = logging.getLogger(__name__)
 
 AI_VOICE_ENGINE_ENV_KEY: str = "AI_VOICE_ENGINE"
+# Only the OpenAI voice provider shares AIOpenAIBase, so it is the one voice
+# engine whose constructor accepts these arguments.
+FROZENSET_AI_OPENAI_BASE_VOICE_ENGINES: frozenset[str] = frozenset({"openai"})
+FROZENSET_AI_OPENAI_BASE_VOICE_KWARGS: frozenset[str] = frozenset(
+    {"base_url", "retry_policy"}
+)
 
 
 class AIVoiceFactory:
@@ -64,10 +71,26 @@ class AIVoiceFactory:
                 "AI_VOICE_ENGINE must be configured explicitly; there is no default provider."
             )
 
+        # Scope this catch to the registry lookup alone. Provider construction
+        # raises the same exception type for unrelated reasons -- a rejected
+        # plaintext base URL among them -- and reporting those as an unsupported
+        # engine sends the caller after the wrong problem.
         try:
             ai_provider_spec: AiProviderSpec = get_ai_provider_spec(
                 AI_PROVIDER_CAPABILITY_VOICE, str_engine
             )
+        except AiProviderConfigurationError as exception:
+            _LOGGER.error("Unsupported AI_VOICE_ENGINE: %s", str_engine)
+            raise ValueError(
+                f"Unsupported AI_VOICE_ENGINE: {str_engine}"
+            ) from exception
+
+        AIVoiceFactory._require_provider_kwargs_support(
+            str_engine=str_engine,
+            dict_provider_kwargs=kwargs,
+        )
+
+        try:
             class_ai_voice_provider: type[AIVoiceBase] = load_ai_provider_class(
                 ai_provider_spec,
                 AIVoiceBase,
@@ -77,13 +100,46 @@ class AIVoiceFactory:
             )
             # Normal return with resolved voice provider client.
             return voice_provider_client
-        except AiProviderConfigurationError as exception:
-            _LOGGER.error("Unsupported AI_VOICE_ENGINE: %s", str_engine)
-            raise ValueError(
-                f"Unsupported AI_VOICE_ENGINE: {str_engine}"
-            ) from exception
         except AiProviderDependencyUnavailableError as exception:
             _LOGGER.warning(str(exception))
             raise
         except AiProviderRuntimeError:
             raise
+
+    @staticmethod
+    def _require_provider_kwargs_support(
+        *,
+        str_engine: str,
+        dict_provider_kwargs: dict[str, Any],
+    ) -> None:
+        """
+        Rejects provider kwargs for voice engines whose constructor cannot honor them.
+
+        This lives here rather than in AIFactory because this is the factory that
+        accepts the kwargs: AIVoiceBase ignores unknown model fields, so an
+        unguarded override would be dropped in silence.
+
+        Args:
+            str_engine: Resolved voice engine selector token.
+            dict_provider_kwargs: Provider constructor arguments supplied by the caller.
+
+        Raises:
+            AiProviderCapabilityUnsupportedError: When the engine cannot honor a
+                supplied argument.
+        """
+        for str_kwarg_name in sorted(dict_provider_kwargs):
+            frozenset_supported: frozenset[str] = (
+                FROZENSET_AI_OPENAI_BASE_VOICE_ENGINES
+                if str_kwarg_name in FROZENSET_AI_OPENAI_BASE_VOICE_KWARGS
+                else frozenset()
+            )
+            if str_engine in frozenset_supported:
+                continue
+            raise AiProviderCapabilityUnsupportedError(
+                f"Voice engine {str_engine!r} does not support {str_kwarg_name!r}. "
+                + (
+                    f"Supported engines: {', '.join(sorted(frozenset_supported))}."
+                    if frozenset_supported
+                    else "No voice engine accepts that argument."
+                )
+            )

--- a/src/ai_api_unified/voice/ai_voice_factory.py
+++ b/src/ai_api_unified/voice/ai_voice_factory.py
@@ -31,27 +31,31 @@ class AIVoiceFactory:
     """
 
     @staticmethod
-    def create() -> AIVoiceBase:
+    def create(voice_engine: str | None = None) -> AIVoiceBase:
         """
         Creates a voice provider client based on the configured voice engine.
 
         Args:
-            None
+            voice_engine: Optional engine override; falls back to AI_VOICE_ENGINE config.
 
         Returns:
-            Concrete AIVoiceBase implementation for the configured voice engine.
+            Concrete AIVoiceBase implementation for the requested voice engine.
             Raises ValueError for unsupported engines and RuntimeError-derived
             provider exceptions for dependency/runtime loading failures.
         """
-        env_settings: EnvSettings = EnvSettings()
-        object_engine_value: object = env_settings.get_setting(
-            AI_VOICE_ENGINE_ENV_KEY, ""
-        )
-        str_engine: str = (
-            str(object_engine_value).strip().lower()
-            if object_engine_value is not None
-            else ""
-        )
+        str_engine: str
+        if voice_engine is not None and voice_engine.strip():
+            str_engine = voice_engine.strip().lower()
+        else:
+            env_settings: EnvSettings = EnvSettings()
+            object_engine_value: object = env_settings.get_setting(
+                AI_VOICE_ENGINE_ENV_KEY, ""
+            )
+            str_engine = (
+                str(object_engine_value).strip().lower()
+                if object_engine_value is not None
+                else ""
+            )
         if not str_engine:
             raise ValueError(
                 "AI_VOICE_ENGINE must be configured explicitly; there is no default provider."

--- a/src/ai_api_unified/voice/ai_voice_factory.py
+++ b/src/ai_api_unified/voice/ai_voice_factory.py
@@ -5,6 +5,7 @@ Factory for creating voice provider clients through centralized lazy loading.
 from __future__ import annotations
 
 import logging
+from typing import Any
 
 from ai_api_unified.ai_provider_exceptions import (
     AiProviderConfigurationError,
@@ -31,12 +32,14 @@ class AIVoiceFactory:
     """
 
     @staticmethod
-    def create(voice_engine: str | None = None) -> AIVoiceBase:
+    def create(voice_engine: str | None = None, **kwargs: Any) -> AIVoiceBase:
         """
         Creates a voice provider client based on the configured voice engine.
 
         Args:
             voice_engine: Optional engine override; falls back to AI_VOICE_ENGINE config.
+            **kwargs: Provider-specific constructor arguments such as base_url
+                and retry_policy, forwarded to the resolved voice provider.
 
         Returns:
             Concrete AIVoiceBase implementation for the requested voice engine.
@@ -70,7 +73,7 @@ class AIVoiceFactory:
                 AIVoiceBase,
             )
             voice_provider_client: AIVoiceBase = class_ai_voice_provider(
-                engine=str_engine
+                engine=str_engine, **kwargs
             )
             # Normal return with resolved voice provider client.
             return voice_provider_client

--- a/src/ai_api_unified/voice/ai_voice_openai.py
+++ b/src/ai_api_unified/voice/ai_voice_openai.py
@@ -8,12 +8,22 @@ from io import BytesIO
 from time import time
 from typing import Any, ClassVar
 
-from openai import BadRequestError, OpenAI, OpenAIError, RateLimitError
+from openai import AsyncOpenAI, BadRequestError, OpenAI, OpenAIError, RateLimitError
 from openai.types.audio import (
     TranscriptionCreateResponse,
 )
-from pydantic import Field
-from ai_api_unified.ai_openai_base import AIOpenAIBase
+from pydantic import Field, PrivateAttr
+from ai_api_unified.ai_base import (
+    RETRY_POLICY_DEFAULT,
+    RETRY_POLICY_NONE,
+    normalize_retry_policy,
+)
+from ai_api_unified.ai_openai_base import (
+    AIOpenAIBase,
+    DEFAULT_OPENAI_USER,
+    OPENAI_USER_SETTING_KEY,
+    RETRY_POLICY_KEY,
+)
 from ai_api_unified.util._lazy_pydub import AudioSegment, get_CouldntDecodeError
 
 from .ai_voice_base import (
@@ -63,6 +73,18 @@ class AIVoiceOpenAI(AIVoiceBase, AIOpenAIBase):
 
     default_model_id: str = Field("tts-1-hd", description="Default OpenAI TTS model")
 
+    # AIOpenAIBase.__init__ never runs for this class: pydantic's BaseModel sits
+    # ahead of it in the MRO and does not chain to super(). Every attribute that
+    # initializer would assign is therefore established here instead, so the
+    # inherited AIOpenAIBase surface (async_client, organization lookup) works.
+    _env: EnvSettings | None = PrivateAttr(default=None)
+    _api_key: str = PrivateAttr(default="")
+    _user: str = PrivateAttr(default=DEFAULT_OPENAI_USER)
+    _base_url: str = PrivateAttr(default="")
+    _retry_policy: str = PrivateAttr(default=RETRY_POLICY_DEFAULT)
+    _backoff_delays: list[int] = PrivateAttr(default_factory=lambda: [1, 2, 4, 8, 16])
+    _async_client: AsyncOpenAI | None = PrivateAttr(default=None)
+
     def __init__(self, *, engine: str, **kwargs: Any) -> None:
         super().__init__(engine=engine, **kwargs)
         env: EnvSettings = EnvSettings()
@@ -71,7 +93,21 @@ class AIVoiceOpenAI(AIVoiceBase, AIOpenAIBase):
             raise RuntimeError("OPENAI_API_KEY is not set")
 
         base_url: str = self.get_api_base_url()
-        self.client: OpenAI = OpenAI(api_key=api_key, base_url=base_url)
+        self._env = env
+        self._api_key = api_key
+        self._user = env.get_setting(OPENAI_USER_SETTING_KEY, DEFAULT_OPENAI_USER)
+        self._base_url = base_url
+        self._retry_policy = normalize_retry_policy(
+            str(env.get_setting(RETRY_POLICY_KEY, RETRY_POLICY_DEFAULT))
+        )
+
+        dict_client_kwargs: dict[str, Any] = {
+            "api_key": api_key,
+            "base_url": base_url,
+        }
+        if self._retry_policy == RETRY_POLICY_NONE:
+            dict_client_kwargs["max_retries"] = 0
+        self.client: OpenAI = OpenAI(**dict_client_kwargs)
 
         # Supported formats – all 24 kHz output
         self.list_output_formats: list[AudioFormat] = [
@@ -144,6 +180,49 @@ class AIVoiceOpenAI(AIVoiceBase, AIOpenAIBase):
         self.list_models_capabilities = self._initialize_models_and_capabilities()
 
         self.selected_model: AIVoiceModelBase = self.get_default_model()
+
+    @property
+    def env(self) -> EnvSettings | None:
+        """Environment accessor resolved at construction, mirroring AIOpenAIBase."""
+        return self._env
+
+    @property
+    def api_key(self) -> str:
+        """OpenAI API key resolved at construction, mirroring AIOpenAIBase."""
+        return self._api_key
+
+    @property
+    def user(self) -> str:
+        """Configured OPENAI_USER value, mirroring AIOpenAIBase."""
+        return self._user
+
+    @property
+    def base_url(self) -> str:
+        """Resolved OpenAI base URL, mirroring AIOpenAIBase."""
+        return self._base_url
+
+    @property
+    def retry_policy(self) -> str:
+        """Normalized retry policy applied to the SDK clients, mirroring AIOpenAIBase."""
+        return self._retry_policy
+
+    @property
+    def backoff_delays(self) -> list[int]:
+        """Caller-owned backoff schedule, mirroring AIOpenAIBase."""
+        return self._backoff_delays
+
+    def _resolve_legacy_caller_id(self) -> str | None:
+        """
+        Resolves the OPENAI_USER attribution value captured during construction.
+
+        Args:
+            None
+
+        Returns:
+            Configured OPENAI_USER value, or None when the client was built without one.
+        """
+        # Normal return with the OPENAI_USER value resolved at construction time.
+        return self.user
 
     def _initialize_models_and_capabilities(self) -> list[AIVoiceModelBase]:
         """
@@ -284,16 +363,19 @@ class AIVoiceOpenAI(AIVoiceBase, AIOpenAIBase):
         model_id: str = (
             self.selected_model.name if self.selected_model else self.default_model_id
         )
-        response = self.client.audio.speech.create(
+        # Streaming goes through with_streaming_response; speech.create() takes no
+        # `stream` argument in any openai 2.x release and raises TypeError if given one.
+        with self.client.audio.speech.with_streaming_response.create(
             model=model_id,
             voice=voice.voice_id,
             input=text_to_convert,
             response_format=self._format_to_response_key(audio_format),
             speed=1.0,
-            stream=True,
             instructions=self.DEFAULT_INSTRUCTIONS,
-        )
-        combined_audio_bytes: bytes = b"".join(chunk for chunk in response.iter_bytes())
+        ) as response:
+            combined_audio_bytes: bytes = b"".join(
+                chunk for chunk in response.iter_bytes()
+            )
         if not is_hex_enabled():
             self._play_bytes(combined_audio_bytes)
         # Normal return with the fully aggregated streaming audio payload.
@@ -333,7 +415,6 @@ class AIVoiceOpenAI(AIVoiceBase, AIOpenAIBase):
                 ),
                 provider_elapsed_ms=provider_elapsed_ms,
             ),
-            legacy_caller_id=self.user,
         )
         # Normal return with caller-facing audio bytes after optional observability wrapping.
         return audio_bytes
@@ -369,7 +450,6 @@ class AIVoiceOpenAI(AIVoiceBase, AIOpenAIBase):
                 ),
                 provider_elapsed_ms=provider_elapsed_ms,
             ),
-            legacy_caller_id=self.user,
         )
         # Normal return with aggregated streaming audio bytes after optional observability wrapping.
         return audio_bytes

--- a/src/ai_api_unified/voice/ai_voice_openai.py
+++ b/src/ai_api_unified/voice/ai_voice_openai.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 import logging
 from io import BytesIO
-from time import time
+from time import sleep
 from typing import Any, ClassVar
 
 from openai import AsyncOpenAI, BadRequestError, OpenAI, OpenAIError, RateLimitError
@@ -97,8 +97,16 @@ class AIVoiceOpenAI(AIVoiceBase, AIOpenAIBase):
         self._api_key = api_key
         self._user = env.get_setting(OPENAI_USER_SETTING_KEY, DEFAULT_OPENAI_USER)
         self._base_url = base_url
+        # A key present but blank makes get_setting return "" instead of the
+        # default, and "" is not a valid policy, so fall back explicitly.
+        object_retry_policy: object = env.get_setting(
+            RETRY_POLICY_KEY, RETRY_POLICY_DEFAULT
+        )
+        str_retry_policy: str = (
+            str(object_retry_policy).strip() if object_retry_policy is not None else ""
+        )
         self._retry_policy = normalize_retry_policy(
-            str(env.get_setting(RETRY_POLICY_KEY, RETRY_POLICY_DEFAULT))
+            str_retry_policy or RETRY_POLICY_DEFAULT
         )
 
         dict_client_kwargs: dict[str, Any] = {
@@ -181,45 +189,76 @@ class AIVoiceOpenAI(AIVoiceBase, AIOpenAIBase):
 
         self.selected_model: AIVoiceModelBase = self.get_default_model()
 
+    # These mirror the plain instance attributes AIOpenAIBase.__init__ assigns on
+    # every other OpenAI-backed client. They stay writable so the surface matches:
+    # existing suites reassign backoff_delays and api_key on sibling capabilities.
     @property
     def env(self) -> EnvSettings | None:
         """Environment accessor resolved at construction, mirroring AIOpenAIBase."""
         return self._env
+
+    @env.setter
+    def env(self, env_settings: EnvSettings | None) -> None:
+        self._env = env_settings
 
     @property
     def api_key(self) -> str:
         """OpenAI API key resolved at construction, mirroring AIOpenAIBase."""
         return self._api_key
 
+    @api_key.setter
+    def api_key(self, str_api_key: str) -> None:
+        self._api_key = str_api_key
+
     @property
     def user(self) -> str:
         """Configured OPENAI_USER value, mirroring AIOpenAIBase."""
         return self._user
+
+    @user.setter
+    def user(self, str_user: str) -> None:
+        self._user = str_user
 
     @property
     def base_url(self) -> str:
         """Resolved OpenAI base URL, mirroring AIOpenAIBase."""
         return self._base_url
 
+    @base_url.setter
+    def base_url(self, str_base_url: str) -> None:
+        self._base_url = str_base_url
+
     @property
     def retry_policy(self) -> str:
         """Normalized retry policy applied to the SDK clients, mirroring AIOpenAIBase."""
         return self._retry_policy
+
+    @retry_policy.setter
+    def retry_policy(self, str_retry_policy: str) -> None:
+        self._retry_policy = str_retry_policy
 
     @property
     def backoff_delays(self) -> list[int]:
         """Caller-owned backoff schedule, mirroring AIOpenAIBase."""
         return self._backoff_delays
 
+    @backoff_delays.setter
+    def backoff_delays(self, list_backoff_delays: list[int]) -> None:
+        self._backoff_delays = list_backoff_delays
+
     def _resolve_legacy_caller_id(self) -> str | None:
         """
         Resolves the OPENAI_USER attribution value captured during construction.
+
+        Matches the other OpenAI-backed capabilities: when OPENAI_USER is unset,
+        this reports the DEFAULT_OPENAI_USER sentinel rather than None, so voice
+        events carry the same caller id completions and embeddings already emit.
 
         Args:
             None
 
         Returns:
-            Configured OPENAI_USER value, or None when the client was built without one.
+            Configured OPENAI_USER value, or the DEFAULT_OPENAI_USER sentinel when unset.
         """
         # Normal return with the OPENAI_USER value resolved at construction time.
         return self.user
@@ -531,7 +570,7 @@ class AIVoiceOpenAI(AIVoiceBase, AIOpenAIBase):
                         backoff,
                         attempt,
                     )
-                    time.sleep(backoff)
+                    sleep(backoff)
                     buf.seek(0)
                     continue
                 except OpenAIError as exc:

--- a/src/ai_api_unified/voice/ai_voice_openai.py
+++ b/src/ai_api_unified/voice/ai_voice_openai.py
@@ -89,7 +89,14 @@ class AIVoiceOpenAI(AIVoiceBase, AIOpenAIBase):
         **kwargs: Any,
     ) -> None:
         super().__init__(engine=engine, **kwargs)
-        if not EnvSettings().get_setting("OPENAI_API_KEY", ""):
+        # Voice providers signal a missing key with RuntimeError (azure and
+        # elevenlabs do the same), so this runs ahead of the base's ValueError to
+        # keep that contract. Strip first: the base treats a whitespace-only key
+        # as missing, and this guard must agree or the exception type changes.
+        str_configured_api_key: str = str(
+            EnvSettings().get_setting("OPENAI_API_KEY", "") or ""
+        ).strip()
+        if not str_configured_api_key:
             raise RuntimeError("OPENAI_API_KEY is not set")
 
         # Invoke the shared initializer rather than copying it: a duplicate drifts

--- a/src/ai_api_unified/voice/ai_voice_openai.py
+++ b/src/ai_api_unified/voice/ai_voice_openai.py
@@ -8,21 +8,15 @@ from io import BytesIO
 from time import sleep
 from typing import Any, ClassVar
 
-from openai import AsyncOpenAI, BadRequestError, OpenAI, OpenAIError, RateLimitError
+from openai import AsyncOpenAI, BadRequestError, OpenAIError, RateLimitError
 from openai.types.audio import (
     TranscriptionCreateResponse,
 )
 from pydantic import Field, PrivateAttr
-from ai_api_unified.ai_base import (
-    RETRY_POLICY_DEFAULT,
-    RETRY_POLICY_NONE,
-    normalize_retry_policy,
-)
+from ai_api_unified.ai_base import RETRY_POLICY_DEFAULT
 from ai_api_unified.ai_openai_base import (
     AIOpenAIBase,
     DEFAULT_OPENAI_USER,
-    OPENAI_USER_SETTING_KEY,
-    RETRY_POLICY_KEY,
 )
 from ai_api_unified.util._lazy_pydub import AudioSegment, get_CouldntDecodeError
 
@@ -73,10 +67,11 @@ class AIVoiceOpenAI(AIVoiceBase, AIOpenAIBase):
 
     default_model_id: str = Field("tts-1-hd", description="Default OpenAI TTS model")
 
-    # AIOpenAIBase.__init__ never runs for this class: pydantic's BaseModel sits
-    # ahead of it in the MRO and does not chain to super(). Every attribute that
-    # initializer would assign is therefore established here instead, so the
-    # inherited AIOpenAIBase surface (async_client, organization lookup) works.
+    # AIOpenAIBase.__init__ never runs implicitly for this class: pydantic's
+    # BaseModel sits ahead of it in the MRO and does not chain to super(), so the
+    # constructor invokes it explicitly. These private attributes back the
+    # property pairs below, which is what lets that initializer's plain
+    # `self.<name> = ...` assignments land on a pydantic model.
     _env: EnvSettings | None = PrivateAttr(default=None)
     _api_key: str = PrivateAttr(default="")
     _user: str = PrivateAttr(default=DEFAULT_OPENAI_USER)
@@ -85,37 +80,26 @@ class AIVoiceOpenAI(AIVoiceBase, AIOpenAIBase):
     _backoff_delays: list[int] = PrivateAttr(default_factory=lambda: [1, 2, 4, 8, 16])
     _async_client: AsyncOpenAI | None = PrivateAttr(default=None)
 
-    def __init__(self, *, engine: str, **kwargs: Any) -> None:
+    def __init__(
+        self,
+        *,
+        engine: str,
+        retry_policy: str | None = None,
+        base_url: str | None = None,
+        **kwargs: Any,
+    ) -> None:
         super().__init__(engine=engine, **kwargs)
-        env: EnvSettings = EnvSettings()
-        api_key: str = env.get_setting("OPENAI_API_KEY", "")
-        if not api_key:
+        if not EnvSettings().get_setting("OPENAI_API_KEY", ""):
             raise RuntimeError("OPENAI_API_KEY is not set")
 
-        base_url: str = self.get_api_base_url()
-        self._env = env
-        self._api_key = api_key
-        self._user = env.get_setting(OPENAI_USER_SETTING_KEY, DEFAULT_OPENAI_USER)
-        self._base_url = base_url
-        # A key present but blank makes get_setting return "" instead of the
-        # default, and "" is not a valid policy, so fall back explicitly.
-        object_retry_policy: object = env.get_setting(
-            RETRY_POLICY_KEY, RETRY_POLICY_DEFAULT
+        # Invoke the shared initializer rather than copying it: a duplicate drifts
+        # from the base the moment either side changes, and every attribute it
+        # assigns routes through this class's property setters.
+        AIOpenAIBase.__init__(
+            self,
+            retry_policy=retry_policy,
+            base_url=base_url,
         )
-        str_retry_policy: str = (
-            str(object_retry_policy).strip() if object_retry_policy is not None else ""
-        )
-        self._retry_policy = normalize_retry_policy(
-            str_retry_policy or RETRY_POLICY_DEFAULT
-        )
-
-        dict_client_kwargs: dict[str, Any] = {
-            "api_key": api_key,
-            "base_url": base_url,
-        }
-        if self._retry_policy == RETRY_POLICY_NONE:
-            dict_client_kwargs["max_retries"] = 0
-        self.client: OpenAI = OpenAI(**dict_client_kwargs)
 
         # Supported formats – all 24 kHz output
         self.list_output_formats: list[AudioFormat] = [

--- a/tests/area_map.py
+++ b/tests/area_map.py
@@ -149,6 +149,8 @@ DICT_TEST_FILE_AREAS: dict[str, tuple[str, ...]] = {
     # Voice
     "test_audio_dependency_isolation.py": ("core", "voice", "engine_anthropic"),
     "test_ai_voice_factory_provider_loading.py": ("voice",),
+    "test_ai_factory_voice_client.py": ("core", "voice"),
+    "test_voice_caller_id_attribution.py": ("voice", "middleware"),
     "test_voice_env_settings.py": ("voice",),
     "test_voice_nonmock.py": ("voice",),
 }

--- a/tests/test_ai_factory_voice_client.py
+++ b/tests/test_ai_factory_voice_client.py
@@ -7,7 +7,10 @@ from unittest.mock import Mock, patch
 import pytest
 
 from ai_api_unified.ai_factory import AIFactory
-from ai_api_unified.ai_provider_exceptions import AiProviderConfigurationError
+from ai_api_unified.ai_provider_exceptions import (
+    AiProviderCapabilityUnsupportedError,
+    AiProviderConfigurationError,
+)
 from ai_api_unified.voice.ai_voice_factory import AIVoiceFactory
 
 
@@ -90,6 +93,36 @@ class TestAiFactoryVoiceClient:
             voice_factory_exception_info.value
         )
         assert "Unsupported AI_VOICE_ENGINE: nope" == str(factory_exception_info.value)
+
+    def test_base_url_and_retry_policy_reach_the_provider(self) -> None:
+        """Provider kwargs should be forwarded like the sibling constructors do."""
+        with patch.object(
+            AIVoiceFactory, "create", return_value=FakeVoiceClient(engine="openai")
+        ) as mock_create:
+            AIFactory.get_ai_voice_client(
+                voice_engine="openai",
+                base_url="https://gateway.invalid/v1",
+                retry_policy="none",
+            )
+
+        mock_create.assert_called_once_with(
+            "openai",
+            base_url="https://gateway.invalid/v1",
+            retry_policy="none",
+        )
+
+    @pytest.mark.parametrize(
+        "str_unsupported_engine", ["google", "azure", "elevenlabs"]
+    )
+    def test_base_url_rejected_for_engines_that_cannot_honor_it(
+        self, str_unsupported_engine: str
+    ) -> None:
+        """Engines without an AIOpenAIBase constructor must reject the override."""
+        with pytest.raises(AiProviderCapabilityUnsupportedError):
+            AIFactory.get_ai_voice_client(
+                voice_engine=str_unsupported_engine,
+                base_url="https://gateway.invalid/v1",
+            )
 
     def test_voice_factory_create_remains_callable_without_arguments(self) -> None:
         """The pre-existing no-argument AIVoiceFactory.create contract must still hold."""

--- a/tests/test_ai_factory_voice_client.py
+++ b/tests/test_ai_factory_voice_client.py
@@ -114,15 +114,54 @@ class TestAiFactoryVoiceClient:
     @pytest.mark.parametrize(
         "str_unsupported_engine", ["google", "azure", "elevenlabs"]
     )
-    def test_base_url_rejected_for_engines_that_cannot_honor_it(
-        self, str_unsupported_engine: str
+    @pytest.mark.parametrize(
+        "str_kwarg_name, object_kwarg_value",
+        [("base_url", "https://gateway.invalid/v1"), ("retry_policy", "none")],
+    )
+    def test_provider_kwargs_rejected_for_engines_that_cannot_honor_them(
+        self,
+        str_unsupported_engine: str,
+        str_kwarg_name: str,
+        object_kwarg_value: object,
     ) -> None:
-        """Engines without an AIOpenAIBase constructor must reject the override."""
-        with pytest.raises(AiProviderCapabilityUnsupportedError):
+        """Engines without an AIOpenAIBase constructor must reject these arguments."""
+        with pytest.raises(AiProviderCapabilityUnsupportedError) as exception_info:
             AIFactory.get_ai_voice_client(
                 voice_engine=str_unsupported_engine,
-                base_url="https://gateway.invalid/v1",
+                **{str_kwarg_name: object_kwarg_value},
             )
+
+        # The message must name the argument the caller actually passed.
+        assert str_kwarg_name in str(exception_info.value)
+
+    @pytest.mark.parametrize(
+        "str_unsupported_engine", ["google", "azure", "elevenlabs"]
+    )
+    def test_voice_factory_create_rejects_unsupported_provider_kwargs(
+        self, str_unsupported_engine: str
+    ) -> None:
+        """The guard belongs to the factory that accepts the kwargs, not only AIFactory.
+
+        AIVoiceBase ignores unknown model fields, so an unguarded override here
+        would be dropped in silence.
+        """
+        with pytest.raises(AiProviderCapabilityUnsupportedError):
+            AIVoiceFactory.create(
+                str_unsupported_engine, base_url="https://gateway.invalid/v1"
+            )
+
+    def test_base_url_rejection_reports_its_own_reason(self) -> None:
+        """A rejected base URL must not surface as an unsupported-engine error.
+
+        Provider construction raises AiProviderConfigurationError for reasons
+        unrelated to engine resolution, and the plaintext-credential rejection
+        is one of them.
+        """
+        with pytest.raises(AiProviderConfigurationError) as exception_info:
+            AIVoiceFactory.create("openai", base_url="http://insecure.invalid/v1")
+
+        assert "https://" in str(exception_info.value)
+        assert "Unsupported AI_VOICE_ENGINE" not in str(exception_info.value)
 
     def test_voice_factory_create_remains_callable_without_arguments(self) -> None:
         """The pre-existing no-argument AIVoiceFactory.create contract must still hold."""

--- a/tests/test_ai_factory_voice_client.py
+++ b/tests/test_ai_factory_voice_client.py
@@ -1,0 +1,113 @@
+"""Tests for AIFactory.get_ai_voice_client delegation to AIVoiceFactory."""
+
+from __future__ import annotations
+
+from unittest.mock import Mock, patch
+
+import pytest
+
+from ai_api_unified.ai_factory import AIFactory
+from ai_api_unified.ai_provider_exceptions import AiProviderConfigurationError
+from ai_api_unified.voice.ai_voice_factory import AIVoiceFactory
+
+
+class FakeVoiceClient:
+    """Minimal fake voice client constructor target for factory delegation tests."""
+
+    def __init__(self, engine: str) -> None:
+        self.engine: str = engine
+
+
+class TestAiFactoryVoiceClient:
+    """Validate voice is reachable from AIFactory alongside the other capabilities."""
+
+    def test_voice_constructor_is_a_sibling_of_the_other_capabilities(self) -> None:
+        """AIFactory should expose a voice constructor next to the other four."""
+        for str_method_name in (
+            "get_ai_completions_client",
+            "get_ai_embedding_client",
+            "get_ai_images_client",
+            "get_ai_video_client",
+            "get_ai_voice_client",
+        ):
+            assert callable(getattr(AIFactory, str_method_name))
+
+    def test_explicit_engine_override_is_passed_through(self) -> None:
+        """An explicit engine argument should reach AIVoiceFactory unchanged."""
+        with patch.object(
+            AIVoiceFactory, "create", return_value=FakeVoiceClient(engine="openai")
+        ) as mock_create:
+            voice_client: FakeVoiceClient = AIFactory.get_ai_voice_client(
+                voice_engine="OpenAI"
+            )
+
+        assert voice_client.engine == "openai"
+        mock_create.assert_called_once_with("openai")
+
+    def test_engine_falls_back_to_environment_configuration(self) -> None:
+        """With no override the engine should come from AI_VOICE_ENGINE."""
+        mock_env_settings: Mock = Mock()
+        mock_env_settings.get_setting.return_value = "elevenlabs"
+
+        with patch(
+            "ai_api_unified.ai_factory.EnvSettings", return_value=mock_env_settings
+        ):
+            with patch.object(
+                AIVoiceFactory,
+                "create",
+                return_value=FakeVoiceClient(engine="elevenlabs"),
+            ) as mock_create:
+                AIFactory.get_ai_voice_client()
+
+        mock_create.assert_called_once_with("elevenlabs")
+
+    def test_unconfigured_engine_raises_value_error(self) -> None:
+        """An unset AI_VOICE_ENGINE should raise the shared required-engine error."""
+        mock_env_settings: Mock = Mock()
+        mock_env_settings.get_setting.return_value = ""
+
+        with patch(
+            "ai_api_unified.ai_factory.EnvSettings", return_value=mock_env_settings
+        ):
+            with pytest.raises(
+                ValueError,
+                match="AI_VOICE_ENGINE must be configured explicitly",
+            ):
+                AIFactory.get_ai_voice_client()
+
+    def test_unsupported_engine_error_matches_the_voice_factory(self) -> None:
+        """Both entry points should report an unsupported engine identically."""
+        with patch(
+            "ai_api_unified.voice.ai_voice_factory.get_ai_provider_spec",
+            side_effect=AiProviderConfigurationError("unknown engine"),
+        ):
+            with pytest.raises(ValueError) as factory_exception_info:
+                AIFactory.get_ai_voice_client(voice_engine="nope")
+            with pytest.raises(ValueError) as voice_factory_exception_info:
+                AIVoiceFactory.create("nope")
+
+        assert str(factory_exception_info.value) == str(
+            voice_factory_exception_info.value
+        )
+        assert "Unsupported AI_VOICE_ENGINE: nope" == str(factory_exception_info.value)
+
+    def test_voice_factory_create_remains_callable_without_arguments(self) -> None:
+        """The pre-existing no-argument AIVoiceFactory.create contract must still hold."""
+        mock_env_settings: Mock = Mock()
+        mock_env_settings.get_setting.return_value = "google"
+
+        with patch(
+            "ai_api_unified.voice.ai_voice_factory.EnvSettings",
+            return_value=mock_env_settings,
+        ):
+            with patch(
+                "ai_api_unified.voice.ai_voice_factory.get_ai_provider_spec",
+                return_value=Mock(),
+            ):
+                with patch(
+                    "ai_api_unified.voice.ai_voice_factory.load_ai_provider_class",
+                    return_value=FakeVoiceClient,
+                ):
+                    voice_client: FakeVoiceClient = AIVoiceFactory.create()
+
+        assert voice_client.engine == "google"

--- a/tests/test_ai_factory_voice_client.py
+++ b/tests/test_ai_factory_voice_client.py
@@ -155,10 +155,27 @@ class TestAiFactoryVoiceClient:
 
         Provider construction raises AiProviderConfigurationError for reasons
         unrelated to engine resolution, and the plaintext-credential rejection
-        is one of them.
+        is one of them. The API key is supplied through patched EnvSettings so
+        construction reaches base-URL validation on a clean clone with no .env.
         """
-        with pytest.raises(AiProviderConfigurationError) as exception_info:
-            AIVoiceFactory.create("openai", base_url="http://insecure.invalid/v1")
+        import ai_api_unified.ai_openai_base as ai_openai_base_module
+        import ai_api_unified.voice.ai_voice_openai as ai_voice_openai_module
+
+        mock_env_settings: Mock = Mock()
+        mock_env_settings.get_setting.side_effect = lambda key, default=None: {
+            "OPENAI_API_KEY": "test-openai-api-key",
+        }.get(key, default)
+
+        with (
+            patch.object(
+                ai_voice_openai_module, "EnvSettings", return_value=mock_env_settings
+            ),
+            patch.object(
+                ai_openai_base_module, "EnvSettings", return_value=mock_env_settings
+            ),
+        ):
+            with pytest.raises(AiProviderConfigurationError) as exception_info:
+                AIVoiceFactory.create("openai", base_url="http://insecure.invalid/v1")
 
         assert "https://" in str(exception_info.value)
         assert "Unsupported AI_VOICE_ENGINE" not in str(exception_info.value)

--- a/tests/test_completions_conversation_api.py
+++ b/tests/test_completions_conversation_api.py
@@ -705,6 +705,24 @@ class TestRetryPolicyAndErrors:
 
         assert openai_base.retry_policy == "default"
 
+    @pytest.mark.parametrize("str_blank_user", ["", "   "])
+    def test_blank_env_openai_user_falls_back_to_sentinel(self, str_blank_user):
+        """A blank OPENAI_USER must not silently drop caller attribution.
+
+        get_setting returns "" rather than the sentinel for a blank key, which
+        normalizes to None downstream and loses finops attribution.
+        """
+        from ai_api_unified.ai_openai_base import AIOpenAIBase
+
+        with patch.dict(
+            os.environ,
+            {"OPENAI_API_KEY": "test-key", "OPENAI_USER": str_blank_user},
+        ):
+            with patch("ai_api_unified.ai_openai_base.OpenAI"):
+                openai_base = AIOpenAIBase()
+
+        assert openai_base.user == "default_user"
+
     def test_status_error_wrapped_with_status_code(self):
         client = _build_client()
         request = httpx.Request("POST", "https://api.anthropic.com/v1/messages")

--- a/tests/test_completions_conversation_api.py
+++ b/tests/test_completions_conversation_api.py
@@ -684,6 +684,27 @@ class TestRetryPolicyAndErrors:
             with pytest.raises(ValueError, match="Unsupported retry policy"):
                 AiAnthropicCompletions(model="claude-opus-4-8", retry_policy="maybe")
 
+    @pytest.mark.parametrize("str_blank_policy", ["", "   "])
+    def test_blank_env_retry_policy_falls_back_to_default(self, str_blank_policy):
+        """A present-but-blank setting must not break OpenAI client construction.
+
+        EnvSettings returns "" rather than the default for a blank key, and ""
+        is not a valid policy, so every OpenAI-backed capability would raise.
+        """
+        from ai_api_unified.ai_openai_base import AIOpenAIBase
+
+        with patch.dict(
+            os.environ,
+            {
+                "OPENAI_API_KEY": "test-key",
+                "COMPLETIONS_RETRY_POLICY": str_blank_policy,
+            },
+        ):
+            with patch("ai_api_unified.ai_openai_base.OpenAI"):
+                openai_base = AIOpenAIBase()
+
+        assert openai_base.retry_policy == "default"
+
     def test_status_error_wrapped_with_status_code(self):
         client = _build_client()
         request = httpx.Request("POST", "https://api.anthropic.com/v1/messages")

--- a/tests/test_completions_conversation_api.py
+++ b/tests/test_completions_conversation_api.py
@@ -686,10 +686,10 @@ class TestRetryPolicyAndErrors:
 
     @pytest.mark.parametrize("str_blank_policy", ["", "   "])
     def test_blank_env_retry_policy_falls_back_to_default(self, str_blank_policy):
-        """A present-but-blank setting must not break OpenAI client construction.
+        """A present-but-blank setting must not break client construction.
 
         EnvSettings returns "" rather than the default for a blank key, and ""
-        is not a valid policy, so every OpenAI-backed capability would raise.
+        is not a valid policy, so every capability reading it would raise.
         """
         from ai_api_unified.ai_openai_base import AIOpenAIBase
 
@@ -704,6 +704,50 @@ class TestRetryPolicyAndErrors:
                 openai_base = AIOpenAIBase()
 
         assert openai_base.retry_policy == "default"
+
+    @pytest.mark.parametrize("str_blank_policy", ["", "   "])
+    def test_blank_env_retry_policy_is_uniform_across_engines(self, str_blank_policy):
+        """Every engine reads COMPLETIONS_RETRY_POLICY, so all must agree on blank.
+
+        Divergence from one shared key is harder to diagnose than a uniform
+        failure: an operator sees one engine build and another raise.
+        """
+        from ai_api_unified.ai_anthropic_base import AIAnthropicBase
+        from ai_api_unified.ai_openai_base import AIOpenAIBase
+
+        with patch.dict(
+            os.environ,
+            {
+                "OPENAI_API_KEY": "test-key",
+                "ANTHROPIC_API_KEY": "test-key",
+                "COMPLETIONS_RETRY_POLICY": str_blank_policy,
+            },
+        ):
+            with patch("ai_api_unified.ai_openai_base.OpenAI"):
+                str_openai_policy = AIOpenAIBase().retry_policy
+            with patch("ai_api_unified.ai_anthropic_base.Anthropic"):
+                str_anthropic_policy = AIAnthropicBase().retry_policy
+
+        assert str_openai_policy == str_anthropic_policy == "default"
+
+    @pytest.mark.parametrize("str_blank_policy", ["", "   "])
+    def test_explicit_blank_retry_policy_is_rejected_not_defaulted(
+        self, str_blank_policy
+    ):
+        """The blank-is-unconfigured rule covers config, never a caller argument."""
+        from ai_api_unified.ai_base import resolve_retry_policy
+
+        with pytest.raises(ValueError, match="Unsupported retry policy"):
+            resolve_retry_policy(
+                str_explicit=str_blank_policy, object_configured="default"
+            )
+
+    def test_resolver_rejects_an_invalid_configured_value(self):
+        """A non-blank invalid configured value must still raise."""
+        from ai_api_unified.ai_base import resolve_retry_policy
+
+        with pytest.raises(ValueError, match="Unsupported retry policy"):
+            resolve_retry_policy(str_explicit=None, object_configured="bogus")
 
     @pytest.mark.parametrize("str_blank_user", ["", "   "])
     def test_blank_env_openai_user_falls_back_to_sentinel(self, str_blank_user):

--- a/tests/test_observability_tts_phase_f.py
+++ b/tests/test_observability_tts_phase_f.py
@@ -17,6 +17,7 @@ pytest.importorskip("google.genai")
 pytest.importorskip("google.cloud.texttospeech")
 pytest.importorskip("google.cloud.speech_v1p1beta1")
 
+import ai_api_unified.ai_openai_base as ai_openai_base_module
 import ai_api_unified.voice.ai_voice_elevenlabs as ai_voice_elevenlabs_module
 import ai_api_unified.voice.ai_voice_openai as ai_voice_openai_module
 from ai_api_unified.middleware.observability import (
@@ -212,9 +213,14 @@ def _build_openai_voice_client(
         OPENAI_USER_SETTING_KEY: TEST_LEGACY_CALLER_ID,
     }.get(key, default)
 
+    # AIOpenAIBase.get_api_base_url builds its own EnvSettings from its own module,
+    # so patching only the voice module would let this read the ambient env and .env.
     with (
         patch.object(
             ai_voice_openai_module, "EnvSettings", return_value=mock_env_settings
+        ),
+        patch.object(
+            ai_openai_base_module, "EnvSettings", return_value=mock_env_settings
         ),
         patch.object(ai_voice_openai_module, "OpenAI", return_value=SimpleNamespace()),
     ):

--- a/tests/test_observability_tts_phase_f.py
+++ b/tests/test_observability_tts_phase_f.py
@@ -222,7 +222,7 @@ def _build_openai_voice_client(
         patch.object(
             ai_openai_base_module, "EnvSettings", return_value=mock_env_settings
         ),
-        patch.object(ai_voice_openai_module, "OpenAI", return_value=SimpleNamespace()),
+        patch.object(ai_openai_base_module, "OpenAI", return_value=SimpleNamespace()),
     ):
         ai_voice_openai: AIVoiceOpenAI = AIVoiceOpenAI(engine="openai")
 

--- a/tests/test_observability_tts_phase_f.py
+++ b/tests/test_observability_tts_phase_f.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 from collections.abc import Callable
+from contextlib import contextmanager
 from types import SimpleNamespace
 from typing import Any
+from unittest.mock import Mock, patch
 
 import pytest
 
@@ -37,6 +39,7 @@ from ai_api_unified.voice.ai_voice_google import (
     AIVoiceGoogle,
     AIVoiceSelectionGoogle,
 )
+from ai_api_unified.ai_openai_base import OPENAI_USER_SETTING_KEY
 from ai_api_unified.voice.ai_voice_openai import (
     AIVoiceOpenAI,
     AIVoiceSelectionOpenAI,
@@ -186,40 +189,49 @@ def _build_openai_voice_client(
     *,
     middleware: RecordingObservabilityMiddleware,
     callable_create: Callable[..., Any],
+    callable_streaming_create: Callable[..., Any] | None = None,
 ) -> AIVoiceOpenAI:
     """
-    Builds a partially initialized OpenAI voice client for observability tests.
+    Builds an OpenAI voice client through its real constructor for observability tests.
+
+    Construction must run the provider's own `__init__`: attribution state such as
+    the OPENAI_USER caller id is resolved there, and a `model_construct` shortcut
+    that injects that state by hand cannot fail when the constructor stops setting it.
 
     Args:
         middleware: Recording observability middleware used to capture lifecycle events.
         callable_create: Fake OpenAI speech creation callable used by the provider code.
+        callable_streaming_create: Optional fake streaming-response creation callable.
 
     Returns:
         AIVoiceOpenAI instance with fake SDK dependencies injected.
     """
-    selected_voice: AIVoiceSelectionOpenAI = AIVoiceSelectionOpenAI(
-        voice_id="alloy",
-        voice_name="Alloy",
-        locale="en-US",
-    )
-    default_audio_format: AudioFormat = _build_audio_format(
-        key="flac_24000",
-        file_extension=".flac",
-        sample_rate_hz=24_000,
-    )
-    ai_voice_openai: AIVoiceOpenAI = AIVoiceOpenAI.model_construct(
-        engine="openai",
-        default_model_id=TEST_OPENAI_MODEL,
-        selected_model=SimpleNamespace(name=TEST_OPENAI_MODEL),
-        default_audio_format=default_audio_format,
-        selected_voice=selected_voice,
-    )
-    object.__setattr__(ai_voice_openai, "user", TEST_LEGACY_CALLER_ID)
+    mock_env_settings: Mock = Mock()
+    mock_env_settings.get_setting.side_effect = lambda key, default=None: {
+        "OPENAI_API_KEY": "test-openai-api-key",
+        OPENAI_USER_SETTING_KEY: TEST_LEGACY_CALLER_ID,
+    }.get(key, default)
+
+    with (
+        patch.object(
+            ai_voice_openai_module, "EnvSettings", return_value=mock_env_settings
+        ),
+        patch.object(ai_voice_openai_module, "OpenAI", return_value=SimpleNamespace()),
+    ):
+        ai_voice_openai: AIVoiceOpenAI = AIVoiceOpenAI(engine="openai")
+
     object.__setattr__(
         ai_voice_openai,
         "client",
         SimpleNamespace(
-            audio=SimpleNamespace(speech=SimpleNamespace(create=callable_create))
+            audio=SimpleNamespace(
+                speech=SimpleNamespace(
+                    create=callable_create,
+                    with_streaming_response=SimpleNamespace(
+                        create=callable_streaming_create
+                    ),
+                )
+            )
         ),
     )
     object.__setattr__(ai_voice_openai, "_observability_middleware", middleware)
@@ -448,7 +460,8 @@ def test_openai_stream_audio_emits_streaming_metadata(
     middleware = RecordingObservabilityMiddleware()
     dict_captured_params: dict[str, Any] = {}
 
-    def _fake_create(**params: Any) -> Any:
+    @contextmanager
+    def _fake_streaming_create(**params: Any) -> Any:
         """
         Capture OpenAI streaming request parameters and return deterministic byte chunks.
 
@@ -456,27 +469,49 @@ def test_openai_stream_audio_emits_streaming_metadata(
             **params: Provider request parameters supplied by the client under test.
 
         Returns:
-            Fake streaming response object exposing an `iter_bytes` iterator.
+            Context-managed fake streaming response exposing an `iter_bytes` iterator.
         """
         dict_captured_params.update(params)
-        # Normal return with a deterministic fake streaming response object.
-        return SimpleNamespace(
+        # Normal yield of a deterministic fake streaming response object.
+        yield SimpleNamespace(
             iter_bytes=lambda: iter([b"openai-", b"stream-", b"audio"])
+        )
+
+    def _unexpected_create(**_: Any) -> Any:
+        """
+        Fail the test when streaming synthesis calls the non-streaming endpoint.
+
+        Args:
+            **_: Ignored provider request parameters.
+
+        Returns:
+            Never returns; always raises AssertionError.
+        """
+        raise AssertionError(
+            "stream_audio must use audio.speech.with_streaming_response.create"
         )
 
     monkeypatch.setattr(ai_voice_openai_module, "is_hex_enabled", lambda: True)
     ai_voice_client: AIVoiceOpenAI = _build_openai_voice_client(
         middleware=middleware,
-        callable_create=_fake_create,
+        callable_create=_unexpected_create,
+        callable_streaming_create=_fake_streaming_create,
     )
 
     audio_bytes: bytes = ai_voice_client.stream_audio(TEST_TEXT_TO_CONVERT)
 
     assert audio_bytes == TEST_OPENAI_STREAM_BYTES
-    assert dict_captured_params["stream"] is True
+    # `stream` is not a parameter of the OpenAI speech endpoint in any 2.x release;
+    # passing it raises TypeError against the real SDK.
+    assert "stream" not in dict_captured_params
+    assert dict_captured_params["model"] == TEST_OPENAI_MODEL
     assert len(middleware.list_before_contexts) == 1
     assert len(middleware.list_after_events) == 1
     assert middleware.list_before_contexts[0].dict_metadata["streaming_mode"] is True
+    assert (
+        middleware.list_before_contexts[0].originating_caller_id
+        == TEST_LEGACY_CALLER_ID
+    )
 
 
 def test_google_emotion_prompt_emits_metadata_only_once() -> None:

--- a/tests/test_voice_caller_id_attribution.py
+++ b/tests/test_voice_caller_id_attribution.py
@@ -21,8 +21,10 @@ pytest.importorskip("google.genai")
 pytest.importorskip("google.cloud.texttospeech")
 pytest.importorskip("google.cloud.speech_v1p1beta1")
 
+import ai_api_unified.ai_openai_base as ai_openai_base_module
 import ai_api_unified.voice.ai_voice_openai as ai_voice_openai_module
-from ai_api_unified.ai_openai_base import OPENAI_USER_SETTING_KEY
+from ai_api_unified.ai_base import RETRY_POLICY_DEFAULT
+from ai_api_unified.ai_openai_base import OPENAI_USER_SETTING_KEY, RETRY_POLICY_KEY
 from ai_api_unified.voice.ai_voice_azure import AIVoiceAzure
 from ai_api_unified.voice.ai_voice_base import AIVoiceBase
 from ai_api_unified.voice.ai_voice_elevenlabs import AIVoiceElevenLabs
@@ -91,9 +93,14 @@ def _build_openai_voice_client() -> AIVoiceOpenAI:
         OPENAI_USER_SETTING_KEY: TEST_OPENAI_USER,
     }.get(key, default)
 
+    # AIOpenAIBase.get_api_base_url builds its own EnvSettings from its own module,
+    # so patching only the voice module would let this read the ambient env and .env.
     with (
         patch.object(
             ai_voice_openai_module, "EnvSettings", return_value=mock_env_settings
+        ),
+        patch.object(
+            ai_openai_base_module, "EnvSettings", return_value=mock_env_settings
         ),
         patch.object(ai_voice_openai_module, "OpenAI", return_value=SimpleNamespace()),
     ):
@@ -213,6 +220,75 @@ def test_base_resolver_defaults_to_no_legacy_caller_id() -> None:
             return ""
 
     assert ConcreteVoiceClient.model_construct()._resolve_legacy_caller_id() is None
+
+
+@pytest.mark.parametrize(
+    "object_configured_retry_policy",
+    ["", "   ", None],
+    ids=["blank", "whitespace", "unset"],
+)
+def test_blank_retry_policy_setting_falls_back_to_default(
+    object_configured_retry_policy: object,
+) -> None:
+    """
+    Verify a present-but-blank COMPLETIONS_RETRY_POLICY does not break construction.
+
+    `EnvSettings.get_setting` returns the empty string rather than the default
+    when a key is present and blank, and the empty string is not a valid policy.
+
+    Args:
+        object_configured_retry_policy: Blank-ish configured retry policy value.
+
+    Returns:
+        None after asserting the client builds and reports the default policy.
+    """
+    mock_env_settings: Mock = Mock()
+    mock_env_settings.get_setting.side_effect = lambda key, default=None: {
+        "OPENAI_API_KEY": "test-openai-api-key",
+        OPENAI_USER_SETTING_KEY: TEST_OPENAI_USER,
+        RETRY_POLICY_KEY: object_configured_retry_policy,
+    }.get(key, default)
+
+    with (
+        patch.object(
+            ai_voice_openai_module, "EnvSettings", return_value=mock_env_settings
+        ),
+        patch.object(
+            ai_openai_base_module, "EnvSettings", return_value=mock_env_settings
+        ),
+        patch.object(ai_voice_openai_module, "OpenAI", return_value=SimpleNamespace()),
+    ):
+        ai_voice_client: AIVoiceOpenAI = AIVoiceOpenAI(engine="openai")
+
+    assert ai_voice_client.retry_policy == RETRY_POLICY_DEFAULT
+
+
+def test_vendor_attributes_stay_writable_like_sibling_capabilities() -> None:
+    """
+    Verify the mirrored AIOpenAIBase attributes accept assignment.
+
+    Existing suites reassign these on completions, embeddings, and images
+    clients, so voice keeps the same writable surface.
+
+    Args:
+        None
+
+    Returns:
+        None after asserting each mirrored attribute round-trips a new value.
+    """
+    ai_voice_client: AIVoiceOpenAI = _build_openai_voice_client()
+
+    ai_voice_client.backoff_delays = [0]
+    ai_voice_client.api_key = "rotated-key"
+    ai_voice_client.user = "rotated-user"
+    ai_voice_client.retry_policy = RETRY_POLICY_DEFAULT
+    ai_voice_client.base_url = "https://example.invalid/v1"
+
+    assert ai_voice_client.backoff_delays == [0]
+    assert ai_voice_client.api_key == "rotated-key"
+    assert ai_voice_client.user == "rotated-user"
+    assert ai_voice_client._resolve_legacy_caller_id() == "rotated-user"
+    assert ai_voice_client.base_url == "https://example.invalid/v1"
 
 
 def test_openai_provider_resolves_configured_user_as_caller_id() -> None:

--- a/tests/test_voice_caller_id_attribution.py
+++ b/tests/test_voice_caller_id_attribution.py
@@ -23,8 +23,12 @@ pytest.importorskip("google.cloud.speech_v1p1beta1")
 
 import ai_api_unified.ai_openai_base as ai_openai_base_module
 import ai_api_unified.voice.ai_voice_openai as ai_voice_openai_module
-from ai_api_unified.ai_base import RETRY_POLICY_DEFAULT
-from ai_api_unified.ai_openai_base import OPENAI_USER_SETTING_KEY, RETRY_POLICY_KEY
+from ai_api_unified.ai_base import RETRY_POLICY_DEFAULT, RETRY_POLICY_NONE
+from ai_api_unified.ai_openai_base import (
+    OPENAI_BASE_URL_OVERRIDE_SETTING,
+    OPENAI_USER_SETTING_KEY,
+    RETRY_POLICY_KEY,
+)
 from ai_api_unified.voice.ai_voice_azure import AIVoiceAzure
 from ai_api_unified.voice.ai_voice_base import AIVoiceBase
 from ai_api_unified.voice.ai_voice_elevenlabs import AIVoiceElevenLabs
@@ -32,6 +36,24 @@ from ai_api_unified.voice.ai_voice_google import AIVoiceGoogle
 from ai_api_unified.voice.ai_voice_openai import AIVoiceOpenAI
 
 TEST_OPENAI_USER: str = "voice-attribution-user"
+TEST_OPENAI_API_KEY: str = "sk-voice-attribution-test-key"
+TEST_OPENAI_BASE_URL: str = "https://voice-attribution.invalid/v1"
+
+# Every attribute AIOpenAIBase.__init__ assigns, split by how the guard below
+# proves the provider re-established it. Presence alone proves nothing now that
+# each name is backed by a class-level property with a PrivateAttr default, so
+# config-derived attributes are checked by value against distinctive inputs.
+DICT_EXPECTED_CONSTRUCTED_VALUES: dict[str, object] = {
+    "api_key": TEST_OPENAI_API_KEY,
+    "user": TEST_OPENAI_USER,
+    "base_url": TEST_OPENAI_BASE_URL,
+    "retry_policy": RETRY_POLICY_DEFAULT,
+}
+# Attributes whose constructed value legitimately equals the unconstructed
+# default, so a value assertion would prove nothing.
+FROZENSET_PRESENCE_ONLY_ATTRIBUTES: frozenset[str] = frozenset(
+    {"env", "client", "backoff_delays", "_async_client"}
+)
 
 LIST_VOICE_PROVIDER_CLASSES: list[type[AIVoiceBase]] = [
     AIVoiceOpenAI,
@@ -89,8 +111,9 @@ def _build_openai_voice_client() -> AIVoiceOpenAI:
     """
     mock_env_settings: Mock = Mock()
     mock_env_settings.get_setting.side_effect = lambda key, default=None: {
-        "OPENAI_API_KEY": "test-openai-api-key",
+        "OPENAI_API_KEY": TEST_OPENAI_API_KEY,
         OPENAI_USER_SETTING_KEY: TEST_OPENAI_USER,
+        OPENAI_BASE_URL_OVERRIDE_SETTING: TEST_OPENAI_BASE_URL,
     }.get(key, default)
 
     # AIOpenAIBase.get_api_base_url builds its own EnvSettings from its own module,
@@ -102,7 +125,7 @@ def _build_openai_voice_client() -> AIVoiceOpenAI:
         patch.object(
             ai_openai_base_module, "EnvSettings", return_value=mock_env_settings
         ),
-        patch.object(ai_voice_openai_module, "OpenAI", return_value=SimpleNamespace()),
+        patch.object(ai_openai_base_module, "OpenAI", return_value=SimpleNamespace()),
     ):
         # Normal return with a constructor-initialized OpenAI voice client.
         return AIVoiceOpenAI(engine="openai")
@@ -163,6 +186,27 @@ def test_skipped_vendor_initializer_state_is_reestablished(
                 "and never runs. Re-establish that attribute in "
                 f"{class_voice_provider.__name__}.__init__ or the first inherited "
                 "method that reads it raises AttributeError."
+            )
+            if str_attribute_name in FROZENSET_PRESENCE_ONLY_ATTRIBUTES:
+                continue
+            assert str_attribute_name in DICT_EXPECTED_CONSTRUCTED_VALUES, (
+                f"{str_base_name}.__init__ assigns '{str_attribute_name}', which this "
+                "guard does not yet classify. Add it to "
+                "DICT_EXPECTED_CONSTRUCTED_VALUES with the value the provider should "
+                "resolve, or to FROZENSET_PRESENCE_ONLY_ATTRIBUTES when its "
+                "constructed value equals the default."
+            )
+            # Presence is satisfied by the class-level property alone, so compare
+            # against a distinctive input: this is what fails when the provider
+            # constructor stops assigning the attribute.
+            assert (
+                getattr(ai_voice_client, str_attribute_name)
+                == DICT_EXPECTED_CONSTRUCTED_VALUES[str_attribute_name]
+            ), (
+                f"{class_voice_provider.__name__}.__init__ left '{str_attribute_name}' "
+                f"at its default instead of the value {str_base_name}.__init__ would "
+                "have resolved. The attribute reads as present because a property "
+                "backs it, so only the value proves the constructor set it."
             )
 
 
@@ -256,11 +300,49 @@ def test_blank_retry_policy_setting_falls_back_to_default(
         patch.object(
             ai_openai_base_module, "EnvSettings", return_value=mock_env_settings
         ),
-        patch.object(ai_voice_openai_module, "OpenAI", return_value=SimpleNamespace()),
+        patch.object(ai_openai_base_module, "OpenAI", return_value=SimpleNamespace()),
     ):
         ai_voice_client: AIVoiceOpenAI = AIVoiceOpenAI(engine="openai")
 
     assert ai_voice_client.retry_policy == RETRY_POLICY_DEFAULT
+
+
+def test_constructor_kwargs_reach_the_shared_initializer() -> None:
+    """
+    Verify base_url and retry_policy kwargs are honored rather than swallowed.
+
+    `AIVoiceBase` ignores unknown model kwargs, so these were silently dropped
+    while every other AIOpenAIBase consumer honored them.
+
+    Args:
+        None
+
+    Returns:
+        None after asserting both kwargs reach the constructed client.
+    """
+    mock_env_settings: Mock = Mock()
+    mock_env_settings.get_setting.side_effect = lambda key, default=None: {
+        "OPENAI_API_KEY": TEST_OPENAI_API_KEY,
+        OPENAI_USER_SETTING_KEY: TEST_OPENAI_USER,
+    }.get(key, default)
+
+    with (
+        patch.object(
+            ai_voice_openai_module, "EnvSettings", return_value=mock_env_settings
+        ),
+        patch.object(
+            ai_openai_base_module, "EnvSettings", return_value=mock_env_settings
+        ),
+        patch.object(ai_openai_base_module, "OpenAI", return_value=SimpleNamespace()),
+    ):
+        ai_voice_client: AIVoiceOpenAI = AIVoiceOpenAI(
+            engine="openai",
+            base_url="https://gateway.invalid/v1",
+            retry_policy=RETRY_POLICY_NONE,
+        )
+
+    assert ai_voice_client.base_url == "https://gateway.invalid/v1"
+    assert ai_voice_client.retry_policy == RETRY_POLICY_NONE
 
 
 def test_vendor_attributes_stay_writable_like_sibling_capabilities() -> None:

--- a/tests/test_voice_caller_id_attribution.py
+++ b/tests/test_voice_caller_id_attribution.py
@@ -360,6 +360,37 @@ def test_constructor_kwargs_reach_the_shared_initializer() -> None:
     assert ai_voice_client.retry_policy == RETRY_POLICY_NONE
 
 
+def test_explicit_blank_retry_policy_is_still_rejected() -> None:
+    """
+    Verify the blank-is-unconfigured rule applies to config, not to a caller argument.
+
+    A caller passing an empty retry policy made a mistake; silently defaulting
+    would leave SDK retries enabled when they meant to configure them.
+
+    Args:
+        None
+
+    Returns:
+        None after asserting an explicit blank policy raises.
+    """
+    mock_env_settings: Mock = Mock()
+    mock_env_settings.get_setting.side_effect = lambda key, default=None: {
+        "OPENAI_API_KEY": TEST_OPENAI_API_KEY,
+    }.get(key, default)
+
+    with (
+        patch.object(
+            ai_voice_openai_module, "EnvSettings", return_value=mock_env_settings
+        ),
+        patch.object(
+            ai_openai_base_module, "EnvSettings", return_value=mock_env_settings
+        ),
+        patch.object(ai_openai_base_module, "OpenAI", return_value=SimpleNamespace()),
+    ):
+        with pytest.raises(ValueError, match="Unsupported retry policy"):
+            AIVoiceOpenAI(engine="openai", retry_policy="")
+
+
 def test_vendor_attributes_stay_writable_like_sibling_capabilities() -> None:
     """
     Verify the mirrored AIOpenAIBase attributes accept assignment.

--- a/tests/test_voice_caller_id_attribution.py
+++ b/tests/test_voice_caller_id_attribution.py
@@ -1,0 +1,251 @@
+# ruff: noqa: E402
+"""Cross-provider guards for voice observability caller-id attribution."""
+
+from __future__ import annotations
+
+import ast
+import inspect
+import textwrap
+from abc import ABC
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import Mock, patch
+
+import pytest
+from pydantic import BaseModel
+
+pytest.importorskip("elevenlabs")
+pytest.importorskip("openai")
+pytest.importorskip("azure.cognitiveservices.speech")
+pytest.importorskip("google.genai")
+pytest.importorskip("google.cloud.texttospeech")
+pytest.importorskip("google.cloud.speech_v1p1beta1")
+
+import ai_api_unified.voice.ai_voice_openai as ai_voice_openai_module
+from ai_api_unified.ai_openai_base import OPENAI_USER_SETTING_KEY
+from ai_api_unified.voice.ai_voice_azure import AIVoiceAzure
+from ai_api_unified.voice.ai_voice_base import AIVoiceBase
+from ai_api_unified.voice.ai_voice_elevenlabs import AIVoiceElevenLabs
+from ai_api_unified.voice.ai_voice_google import AIVoiceGoogle
+from ai_api_unified.voice.ai_voice_openai import AIVoiceOpenAI
+
+TEST_OPENAI_USER: str = "voice-attribution-user"
+
+LIST_VOICE_PROVIDER_CLASSES: list[type[AIVoiceBase]] = [
+    AIVoiceOpenAI,
+    AIVoiceGoogle,
+    AIVoiceAzure,
+    AIVoiceElevenLabs,
+]
+FROZENSET_MRO_BASES_EXEMPT_FROM_INIT_CHECK: frozenset[type] = frozenset(
+    {AIVoiceBase, BaseModel, ABC, object}
+)
+
+
+def _collect_self_assigned_attribute_names(callable_initializer: Any) -> set[str]:
+    """
+    Collects every `self.<name> = ...` target assigned inside one initializer.
+
+    Args:
+        callable_initializer: Initializer function to inspect.
+
+    Returns:
+        Set of attribute names the initializer assigns onto `self`.
+    """
+    module_tree: ast.Module = ast.parse(
+        textwrap.dedent(inspect.getsource(callable_initializer))
+    )
+    set_attribute_names: set[str] = set()
+    for node in ast.walk(module_tree):
+        list_targets: list[ast.expr]
+        if isinstance(node, ast.Assign):
+            list_targets = list(node.targets)
+        elif isinstance(node, ast.AnnAssign):
+            list_targets = [node.target]
+        else:
+            continue
+        for node_target in list_targets:
+            if (
+                isinstance(node_target, ast.Attribute)
+                and isinstance(node_target.value, ast.Name)
+                and node_target.value.id == "self"
+            ):
+                set_attribute_names.add(node_target.attr)
+    # Normal return with every attribute name the initializer assigns onto self.
+    return set_attribute_names
+
+
+def _build_openai_voice_client() -> AIVoiceOpenAI:
+    """
+    Builds an AIVoiceOpenAI through its real constructor with the SDK stubbed out.
+
+    Args:
+        None
+
+    Returns:
+        Fully constructed AIVoiceOpenAI backed by fake environment and SDK objects.
+    """
+    mock_env_settings: Mock = Mock()
+    mock_env_settings.get_setting.side_effect = lambda key, default=None: {
+        "OPENAI_API_KEY": "test-openai-api-key",
+        OPENAI_USER_SETTING_KEY: TEST_OPENAI_USER,
+    }.get(key, default)
+
+    with (
+        patch.object(
+            ai_voice_openai_module, "EnvSettings", return_value=mock_env_settings
+        ),
+        patch.object(ai_voice_openai_module, "OpenAI", return_value=SimpleNamespace()),
+    ):
+        # Normal return with a constructor-initialized OpenAI voice client.
+        return AIVoiceOpenAI(engine="openai")
+
+
+@pytest.mark.parametrize(
+    "class_voice_provider",
+    LIST_VOICE_PROVIDER_CLASSES,
+    ids=lambda class_voice_provider: class_voice_provider.__name__,
+)
+def test_skipped_vendor_initializer_state_is_reestablished(
+    class_voice_provider: type[AIVoiceBase],
+) -> None:
+    """
+    Verify state from a skipped vendor initializer is re-established by the provider.
+
+    Voice providers are pydantic models. `BaseModel.__init__` does not chain to
+    `super().__init__()`, so a vendor base listed after `AIVoiceBase` has its
+    `__init__` skipped and every attribute it would assign stays unset. Reading
+    such an attribute raises AttributeError on the first provider call, which is
+    exactly how `legacy_caller_id=self.user` broke every OpenAI TTS call.
+
+    Args:
+        class_voice_provider: Concrete voice provider class under inspection.
+
+    Returns:
+        None after asserting no skipped initializer leaves an attribute unset.
+    """
+    dict_skipped_initializer_attributes: dict[str, set[str]] = {}
+    for class_base in class_voice_provider.__mro__[1:]:
+        if class_base in FROZENSET_MRO_BASES_EXEMPT_FROM_INIT_CHECK:
+            continue
+        if "__init__" not in vars(class_base):
+            continue
+        dict_skipped_initializer_attributes[class_base.__name__] = (
+            _collect_self_assigned_attribute_names(class_base.__init__)
+        )
+
+    if not dict_skipped_initializer_attributes:
+        pytest.skip(
+            f"{class_voice_provider.__name__} has no skipped vendor initializer"
+        )
+
+    assert class_voice_provider is AIVoiceOpenAI, (
+        f"{class_voice_provider.__name__} gained a vendor base with a skipped "
+        "__init__. Add a constructor-based builder for it here so this guard can "
+        "check the attributes that initializer would have assigned."
+    )
+    ai_voice_client: AIVoiceBase = _build_openai_voice_client()
+    for (
+        str_base_name,
+        set_attribute_names,
+    ) in dict_skipped_initializer_attributes.items():
+        for str_attribute_name in sorted(set_attribute_names):
+            assert hasattr(ai_voice_client, str_attribute_name), (
+                f"{str_base_name}.__init__ assigns '{str_attribute_name}', but it sits "
+                f"behind pydantic's BaseModel in {class_voice_provider.__name__}'s MRO "
+                "and never runs. Re-establish that attribute in "
+                f"{class_voice_provider.__name__}.__init__ or the first inherited "
+                "method that reads it raises AttributeError."
+            )
+
+
+@pytest.mark.parametrize(
+    "class_voice_provider",
+    LIST_VOICE_PROVIDER_CLASSES,
+    ids=lambda class_voice_provider: class_voice_provider.__name__,
+)
+def test_provider_resolves_legacy_caller_id_without_constructed_state(
+    class_voice_provider: type[AIVoiceBase],
+) -> None:
+    """
+    Verify every provider resolves a legacy caller id without touching unset attributes.
+
+    A provider that reads vendor state directly at the observability call site
+    raises AttributeError here, before any network call is attempted.
+
+    Args:
+        class_voice_provider: Concrete voice provider class under inspection.
+
+    Returns:
+        None after asserting the hook returns a string or None on an unconstructed instance.
+    """
+    ai_voice_client: AIVoiceBase = class_voice_provider.model_construct()
+
+    legacy_caller_id: str | None = ai_voice_client._resolve_legacy_caller_id()
+
+    assert legacy_caller_id is None or isinstance(legacy_caller_id, str)
+
+
+def test_base_resolver_defaults_to_no_legacy_caller_id() -> None:
+    """
+    Verify AIVoiceBase attributes nothing by default so vendors without the concept opt out.
+
+    Args:
+        None
+
+    Returns:
+        None after asserting the base resolver returns None.
+    """
+
+    class ConcreteVoiceClient(AIVoiceBase):
+        """Minimal concrete AIVoiceBase used to exercise the default resolver."""
+
+        def text_to_voice(self, **_: Any) -> bytes:
+            """Unused abstract override."""
+            return b""
+
+        def stream_audio(self, *_: Any, **__: Any) -> bytes:
+            """Unused abstract override."""
+            return b""
+
+        def speech_to_text(self, *_: Any, **__: Any) -> str:
+            """Unused abstract override."""
+            return ""
+
+    assert ConcreteVoiceClient.model_construct()._resolve_legacy_caller_id() is None
+
+
+def test_openai_provider_resolves_configured_user_as_caller_id() -> None:
+    """
+    Verify the OpenAI provider attributes calls to the configured OPENAI_USER value.
+
+    Args:
+        None
+
+    Returns:
+        None after asserting the constructed client reports the configured user.
+    """
+    ai_voice_client: AIVoiceOpenAI = _build_openai_voice_client()
+
+    assert ai_voice_client.user == TEST_OPENAI_USER
+    assert ai_voice_client._resolve_legacy_caller_id() == TEST_OPENAI_USER
+
+
+@pytest.mark.parametrize(
+    "class_voice_provider",
+    [AIVoiceGoogle, AIVoiceAzure, AIVoiceElevenLabs],
+    ids=lambda class_voice_provider: class_voice_provider.__name__,
+)
+def test_providers_without_vendor_user_setting_inherit_base_resolver(
+    class_voice_provider: type[AIVoiceBase],
+) -> None:
+    """
+    Verify providers whose vendor exposes no user setting do not override the resolver.
+
+    Args:
+        class_voice_provider: Concrete voice provider class under inspection.
+
+    Returns:
+        None after asserting the provider inherits the base resolver unchanged.
+    """
+    assert "_resolve_legacy_caller_id" not in vars(class_voice_provider)

--- a/tests/test_voice_caller_id_attribution.py
+++ b/tests/test_voice_caller_id_attribution.py
@@ -49,10 +49,14 @@ DICT_EXPECTED_CONSTRUCTED_VALUES: dict[str, object] = {
     "base_url": TEST_OPENAI_BASE_URL,
     "retry_policy": RETRY_POLICY_DEFAULT,
 }
+# Attributes with no distinctive configured value to compare, but which the
+# constructor must still populate: each defaults to None and is non-None after
+# construction, so the guard asserts that rather than mere presence.
+FROZENSET_MUST_BE_POPULATED_ATTRIBUTES: frozenset[str] = frozenset({"env", "client"})
 # Attributes whose constructed value legitimately equals the unconstructed
-# default, so a value assertion would prove nothing.
+# default, so neither a value nor a non-None assertion would prove anything.
 FROZENSET_PRESENCE_ONLY_ATTRIBUTES: frozenset[str] = frozenset(
-    {"env", "client", "backoff_delays", "_async_client"}
+    {"backoff_delays", "_async_client"}
 )
 
 LIST_VOICE_PROVIDER_CLASSES: list[type[AIVoiceBase]] = [
@@ -188,6 +192,17 @@ def test_skipped_vendor_initializer_state_is_reestablished(
                 "method that reads it raises AttributeError."
             )
             if str_attribute_name in FROZENSET_PRESENCE_ONLY_ATTRIBUTES:
+                continue
+            if str_attribute_name in FROZENSET_MUST_BE_POPULATED_ATTRIBUTES:
+                # These default to None, so presence alone would still pass with
+                # the attribute never populated: the SDK client is the case that
+                # would fail at the first provider call, not at construction.
+                assert getattr(ai_voice_client, str_attribute_name) is not None, (
+                    f"{class_voice_provider.__name__}.__init__ left "
+                    f"'{str_attribute_name}' as None. {str_base_name}.__init__ "
+                    "populates it, and the first inherited method that uses it "
+                    "fails on None rather than at construction."
+                )
                 continue
             assert str_attribute_name in DICT_EXPECTED_CONSTRUCTED_VALUES, (
                 f"{str_base_name}.__init__ assigns '{str_attribute_name}', which this "


### PR DESCRIPTION
## What this fixes

Three defects in the voice capability, plus the test fixture that hid the first one.

### 1. Every OpenAI TTS call raised AttributeError

`AIVoiceOpenAI` passed `legacy_caller_id=self.user` at both observability call sites, but `self.user` was never set. Pydantic's `BaseModel` sits ahead of `AIOpenAIBase` in the MRO and does not chain to `super().__init__()`, so that vendor initializer never ran. Seven of the eight attributes it assigns stayed unset, which also broke the inherited `async_client` property and the organization-identity lookup.

Reproduced against the unfixed code with nothing but a factory call:

```
['AIVoiceOpenAI', 'AIVoiceBase', 'BaseModel', 'ABC', 'AIOpenAIBase', 'object']
hasattr user: False
text_to_voice -> AttributeError 'AIVoiceOpenAI' object has no attribute 'user'
stream_audio  -> AttributeError 'AIVoiceOpenAI' object has no attribute 'user'
```

### 2. `stream_audio` raised TypeError once the AttributeError cleared

It passed `stream=True` to `audio.speech.create`, which accepts no such parameter in any `openai` 2.x release (the pin is `>=2.0.0,<3.0.0`). Streaming now goes through `audio.speech.with_streaming_response.create`.

### 3. Voice had no `AIFactory` constructor

Four capabilities were reachable through `AIFactory.get_ai_*_client()`; voice was reachable only through `AIVoiceFactory.create()`.

## Cross-provider audit

This change audits all four registered voice providers.

| Provider | Bases | Vendor init skipped | Before | After |
|---|---|---|---|---|
| openai | `AIVoiceBase, AIOpenAIBase` | yes — `AIOpenAIBase.__init__` | crashed on every TTS call | works; attributed to `OPENAI_USER` |
| google | `AIVoiceBase, AIGoogleBase` | no `__init__` to skip | worked, unattributed | works, unattributed |
| azure | `AIVoiceBase` | n/a | worked, unattributed | works, unattributed |
| elevenlabs | `AIVoiceBase` | n/a | worked, unattributed | works, unattributed |

Attribution was opt-in per call site, and OpenAI was the only provider that opted in — incorrectly. `AIVoiceBase._resolve_legacy_caller_id()` now supplies it for all nine call sites across the four providers. It returns `None` by default, so the three engines with no vendor user setting stay unattributed by design, matching Google images and videos. `AIVoiceOpenAI` overrides it to return `OPENAI_USER`.

`AIVoiceGoogle` carried the same MRO trap in latent form: `AIGoogleBase` has no `__init__` today, so nothing breaks, and the day it gains one pydantic would skip it silently.

## Why the mocked suite stayed green

`tests/test_observability_tts_phase_f.py` built its client with `AIVoiceOpenAI.model_construct(...)` and then `object.__setattr__(client, "user", TEST_LEGACY_CALLER_ID)` — it hand-installed the attribute production never set. Its streaming test also asserted `dict_captured_params["stream"] is True`, pinning defect 2.

The fixture now constructs through the real `__init__` with the SDK stubbed, and the streaming test fails if the non-streaming endpoint is called.

## Guarding the class of bug

`tests/test_voice_caller_id_attribution.py` reads the AST of any vendor initializer that pydantic skips, collects every `self.<name> = ...` it assigns, and asserts a constructed provider exposes each one. It fails when a skipped initializer leaves an attribute unset, and tells the author which attribute and why. Against the unfixed code, seven of the eight names resolve to `False`.

## API surface

`AIFactory.get_ai_voice_client(voice_engine=None)` resolves the engine the same way its four siblings do and delegates to `AIVoiceFactory.create()`, which gains an optional engine override and stays callable with no arguments. Both entry points raise identical errors for an unset or unsupported engine.

`_translate_config_exception` gains no voice branch: delegation means `AIVoiceFactory` raises the `ValueError` itself, so a branch there would be unreachable.

## Scope note

`AIVoiceOpenAI` keeps `AIOpenAIBase` as a base, and `isinstance` is unchanged. The seven missing attributes are backed by `PrivateAttr` plus read-only properties, so `async_client` and the organization lookup work. That keeps this a minor release.

## Verification

- Full mocked suite: 596 passed, 4 skipped, 10 deselected
- `ruff` and `black` clean; the 7 remaining `E402` errors reproduce on `main` and are inherited
- Version synced across `pyproject.toml`, `__version__.py`, and the README title (2.23.0)

<!-- pr-review-prep:start -->
## PR Composition Summary

| Change Type | Lines Changed | Percentage |
|---|---:|---:|
| Core logic changes | 446 | 31% |
| Documentation | 80 | 5% |
| Tests | 835 | 57% |
| Other | 103 | 7% |
| Total | 1464 | 100% |

Percentages are based on changed lines (added + deleted) against the base branch `main`.
<!-- pr-review-prep:end -->

<!-- pr-content-attribution:start -->
## Content Attribution Summary

Based on changed lines across counted PR commits in this PR. Pure data files are excluded — their content is deterministic process output, not authored work.

| Attribution Type | Commits | Lines Changed | Percentage |
|---|---:|---:|---:|
| AI-attributed | 7 | 1464 | 100% |
| Human-attributed | 0 | 0 | 0% |
| Bot-attributed | 0 | 0 | 0% |
| Total | 7 | 1464 | 100% |

Excluded from attribution:
- 0 merge/sync commits
- 0 data-only commits and 0 data-file lines
<!-- pr-content-attribution:end -->

